### PR TITLE
Add AWS credentials for managing AWS resources

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -12,6 +12,7 @@ Credentials are stored in `~/.action-llama-credentials/<type>/<instance>/<field>
 | `git_ssh` | `id_rsa`, `username`, `email` | SSH private key + git author identity | SSH key mounted as file; `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL`/`GIT_COMMITTER_NAME`/`GIT_COMMITTER_EMAIL` set from `username`/`email` |
 | `github_webhook_secret` | `secret` | Shared secret for GitHub webhook verification | _(used by gateway)_ |
 | `sentry_client_secret` | `secret` | Client secret for Sentry webhook verification | _(used by gateway)_ |
+| `aws` | `access_key_id`, `secret_access_key`, `default_region` | AWS credentials for managing AWS resources | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` env vars |
 
 ## How Credentials Work
 

--- a/src/credentials/builtins/aws.ts
+++ b/src/credentials/builtins/aws.ts
@@ -1,0 +1,35 @@
+import type { CredentialDefinition } from "../schema.js";
+
+const aws: CredentialDefinition = {
+  id: "aws",
+  label: "AWS Credentials",
+  description: "AWS access key, secret key, and optional region for managing AWS resources",
+  helpUrl: "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html",
+  fields: [
+    { name: "access_key_id", label: "Access Key ID", description: "AWS access key ID (AKIA...)", secret: false },
+    { name: "secret_access_key", label: "Secret Access Key", description: "AWS secret access key", secret: true },
+    { name: "default_region", label: "Default Region", description: "AWS region (e.g., us-east-1, us-west-2)", secret: false },
+  ],
+  envVars: { 
+    access_key_id: "AWS_ACCESS_KEY_ID",
+    secret_access_key: "AWS_SECRET_ACCESS_KEY",
+    default_region: "AWS_DEFAULT_REGION"
+  },
+  agentContext: "`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` — use AWS CLI and SDK directly",
+
+  async validate(values) {
+    // Basic validation - check that required fields are present
+    if (!values.access_key_id) {
+      throw new Error("Access Key ID is required");
+    }
+    if (!values.secret_access_key) {
+      throw new Error("Secret Access Key is required");
+    }
+    if (values.access_key_id && !values.access_key_id.startsWith("AKIA")) {
+      throw new Error("Access Key ID should start with AKIA");
+    }
+    return true;
+  },
+};
+
+export default aws;

--- a/src/credentials/builtins/index.ts
+++ b/src/credentials/builtins/index.ts
@@ -5,6 +5,7 @@ import sentryToken from "./sentry-token.js";
 import gitSsh from "./id-rsa.js";
 import githubWebhookSecret from "./github-webhook-secret.js";
 import sentryClientSecret from "./sentry-client-secret.js";
+import aws from "./aws.js";
 
 export const builtinCredentials: Record<string, CredentialDefinition> = {
   "github_token": githubToken,
@@ -13,4 +14,5 @@ export const builtinCredentials: Record<string, CredentialDefinition> = {
   "git_ssh": gitSsh,
   "github_webhook_secret": githubWebhookSecret,
   "sentry_client_secret": sentryClientSecret,
+  "aws": aws,
 };


### PR DESCRIPTION
Closes #5\n\nAdds AWS credential support with the following features:\n- AWS access key ID, secret access key, and default region fields\n- Runtime injection as AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_DEFAULT_REGION environment variables\n- Basic validation for required fields and access key format\n- Documentation update in credentials.md