### PR TITLE
Add AWS credentials support

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -12,6 +12,7 @@ Credentials are stored in `~/.action-llama-credentials/<type>/<instance>/<field>
 | `git_ssh` | `id_rsa`, `username`, `email` | SSH private key + git author identity | SSH key mounted as file; `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL`/`GIT_COMMITTER_NAME`/`GIT_COMMITTER_EMAIL` set from `username`/`email` |
 | `github_webhook_secret` | `secret` | Shared secret for GitHub webhook verification | _(used by gateway)_ |
 | `sentry_client_secret` | `secret` | Client secret for Sentry webhook verification | _(used by gateway)_ |
+| `aws` | `access_key_id`, `secret_access_key`, `session_token` | AWS credentials for programmatic access | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` env vars |
 
 ## How Credentials Work
 
@@ -46,6 +47,17 @@ Or multiple SSH keys:
 
 Reference them as `"git_ssh:default"` or `"git_ssh:botty"` in your agent config. If you omit the instance, it defaults to `"default"`.
 
+You can also have multiple AWS credential instances for different accounts or roles:
+
+```
+~/.action-llama-credentials/aws/default/access_key_id
+~/.action-llama-credentials/aws/default/secret_access_key
+~/.action-llama-credentials/aws/production/access_key_id
+~/.action-llama-credentials/aws/production/secret_access_key
+```
+
+Reference them as `"aws:default"` or `"aws:production"` in your agent config.
+
 ## Setting Up Credentials
 
 ### During `al new`
@@ -66,6 +78,11 @@ echo "ghp_your_token_here" > ~/.action-llama-credentials/github_token/default/to
 
 mkdir -p ~/.action-llama-credentials/anthropic_key/default
 echo "sk-ant-api-your_key_here" > ~/.action-llama-credentials/anthropic_key/default/token
+
+mkdir -p ~/.action-llama-credentials/aws/default
+echo "AKIAIOSFODNN7EXAMPLE" > ~/.action-llama-credentials/aws/default/access_key_id
+echo "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" > ~/.action-llama-credentials/aws/default/secret_access_key
+# Optional: echo "temporary-session-token" > ~/.action-llama-credentials/aws/default/session_token
 ```
 
 ### Anthropic Auth Methods

--- a/src/credentials/builtins/aws.ts
+++ b/src/credentials/builtins/aws.ts
@@ -1,0 +1,27 @@
+import type { CredentialDefinition } from "../schema.js";
+import { validateAWSCredentials } from "../../setup/validators.js";
+
+const aws: CredentialDefinition = {
+  id: "aws",
+  label: "AWS Credentials",
+  description: "AWS Access Key ID and Secret Access Key for programmatic access",
+  helpUrl: "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html",
+  fields: [
+    { name: "access_key_id", label: "Access Key ID", description: "AWS Access Key ID (AKIA...)", secret: false },
+    { name: "secret_access_key", label: "Secret Access Key", description: "AWS Secret Access Key", secret: true },
+    { name: "session_token", label: "Session Token (optional)", description: "AWS Session Token for temporary credentials", secret: true },
+  ],
+  envVars: { 
+    access_key_id: "AWS_ACCESS_KEY_ID",
+    secret_access_key: "AWS_SECRET_ACCESS_KEY",
+    session_token: "AWS_SESSION_TOKEN"
+  },
+  agentContext: "`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` — use AWS CLI and SDKs directly",
+
+  async validate(values) {
+    await validateAWSCredentials(values.access_key_id, values.secret_access_key, values.session_token);
+    return true;
+  },
+};
+
+export default aws;

--- a/src/credentials/builtins/index.ts
+++ b/src/credentials/builtins/index.ts
@@ -5,6 +5,7 @@ import sentryToken from "./sentry-token.js";
 import gitSsh from "./id-rsa.js";
 import githubWebhookSecret from "./github-webhook-secret.js";
 import sentryClientSecret from "./sentry-client-secret.js";
+import aws from "./aws.js";
 
 export const builtinCredentials: Record<string, CredentialDefinition> = {
   "github_token": githubToken,
@@ -13,4 +14,5 @@ export const builtinCredentials: Record<string, CredentialDefinition> = {
   "git_ssh": gitSsh,
   "github_webhook_secret": githubWebhookSecret,
   "sentry_client_secret": sentryClientSecret,
+  "aws": aws,
 };

--- a/src/setup/validators.ts
+++ b/src/setup/validators.ts
@@ -63,3 +63,106 @@ export function validateOAuthTokenFormat(token: string) {
   }
   return true;
 }
+
+export async function validateAWSCredentials(accessKeyId: string, secretAccessKey: string, sessionToken?: string) {
+  // Use AWS STS GetCallerIdentity to validate credentials
+  const region = "us-east-1"; // STS is available in all regions, use us-east-1 as default
+  const service = "sts";
+  const action = "GetCallerIdentity";
+  const host = `${service}.${region}.amazonaws.com`;
+  const endpoint = `https://${host}/`;
+  
+  // Create AWS Signature Version 4
+  const now = new Date();
+  const dateStamp = now.toISOString().slice(0, 10).replace(/-/g, "");
+  const timestamp = now.toISOString().slice(0, 19).replace(/[-:]/g, "") + "Z";
+  
+  const params = "Action=GetCallerIdentity&Version=2011-06-15";
+  const headers: Record<string, string> = {
+    "Host": host,
+    "X-Amz-Date": timestamp,
+  };
+  
+  if (sessionToken) {
+    headers["X-Amz-Security-Token"] = sessionToken;
+  }
+  
+  // Create canonical request
+  const headerNames = Object.keys(headers).map(h => h.toLowerCase()).sort().join(";");
+  const canonicalHeaders = Object.keys(headers).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
+    .map(key => `${key.toLowerCase()}:${headers[key]}\n`).join("");
+  
+  const canonicalRequest = `POST\n/\n${params}\n${canonicalHeaders}\n${headerNames}\npayload`;
+  
+  // Create string to sign
+  const algorithm = "AWS4-HMAC-SHA256";
+  const credentialScope = `${dateStamp}/${region}/${service}/aws4_request`;
+  const stringToSign = `${algorithm}\n${timestamp}\n${credentialScope}\n${await sha256(canonicalRequest)}`;
+  
+  // Create signing key
+  const signingKey = await hmacSha256(
+    await hmacSha256(
+      await hmacSha256(
+        await hmacSha256(`AWS4${secretAccessKey}`, dateStamp),
+        region
+      ),
+      service
+    ),
+    "aws4_request"
+  );
+  
+  // Create signature
+  const signature = await hmacSha256(signingKey, stringToSign);
+  const signatureHex = Array.from(new Uint8Array(signature))
+    .map(b => b.toString(16).padStart(2, '0')).join('');
+  
+  // Create authorization header
+  const authHeader = `${algorithm} Credential=${accessKeyId}/${credentialScope}, SignedHeaders=${headerNames}, Signature=${signatureHex}`;
+  headers["Authorization"] = authHeader;
+  
+  // Make the request
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      ...headers,
+      "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+    },
+    body: params + "&X-Amz-Content-Sha256=payload",
+  });
+  
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`AWS credentials validation failed (${res.status}): ${body}`);
+  }
+  
+  const responseText = await res.text();
+  if (!responseText.includes("<GetCallerIdentityResponse")) {
+    throw new Error("AWS credentials validation failed: Invalid response format");
+  }
+  
+  return true;
+}
+
+async function sha256(message: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(message);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+async function hmacSha256(key: string | ArrayBuffer, message: string): Promise<ArrayBuffer> {
+  const encoder = new TextEncoder();
+  const keyData = typeof key === 'string' ? encoder.encode(key) : key;
+  const messageData = encoder.encode(message);
+  
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    keyData,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  
+  return crypto.subtle.sign('HMAC', cryptoKey, messageData);
+}


### PR DESCRIPTION
Closes #5

Added support for AWS credentials to enable agents to manage AWS resources.

## Changes
- Added `aws` credential type with fields:
  - `access_key_id` - AWS Access Key ID
  - `secret_access_key` - AWS Secret Access Key (secret)  
  - `session_token` - AWS Session Token for temporary credentials (secret, optional)
- Environment variables injected at runtime:
  - `AWS_ACCESS_KEY_ID`
  - `AWS_SECRET_ACCESS_KEY`
  - `AWS_SESSION_TOKEN`
- Added credential validation using AWS STS GetCallerIdentity API
- Updated documentation with AWS credential examples and setup instructions

## Usage
Agents can now reference AWS credentials in their `agent-config.toml`:
```toml
credentials = ["aws:default"]
```

And use AWS CLI or SDKs directly with the injected environment variables.