### PR TITLE
feat: Add AWS credentials support

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -12,6 +12,7 @@ Credentials are stored in `~/.action-llama-credentials/<type>/<instance>/<field>
 | `git_ssh` | `id_rsa`, `username`, `email` | SSH private key + git author identity | SSH key mounted as file; `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL`/`GIT_COMMITTER_NAME`/`GIT_COMMITTER_EMAIL` set from `username`/`email` |
 | `github_webhook_secret` | `secret` | Shared secret for GitHub webhook verification | _(used by gateway)_ |
 | `sentry_client_secret` | `secret` | Client secret for Sentry webhook verification | _(used by gateway)_ |
+| `aws` | `access_key_id`, `secret_access_key`, `default_region` | AWS credentials for managing AWS resources | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` env vars |
 
 ## How Credentials Work
 

--- a/src/credentials/builtins/aws.ts
+++ b/src/credentials/builtins/aws.ts
@@ -1,0 +1,39 @@
+import type { CredentialDefinition } from "../schema.js";
+
+const aws: CredentialDefinition = {
+  id: "aws",
+  label: "AWS Credentials",
+  description: "AWS Access Key for managing AWS resources",
+  helpUrl: "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html",
+  fields: [
+    { name: "access_key_id", label: "Access Key ID", description: "AWS Access Key ID", secret: false },
+    { name: "secret_access_key", label: "Secret Access Key", description: "AWS Secret Access Key", secret: true },
+    { name: "default_region", label: "Default Region", description: "AWS default region (optional)", secret: false },
+  ],
+  envVars: { 
+    access_key_id: "AWS_ACCESS_KEY_ID",
+    secret_access_key: "AWS_SECRET_ACCESS_KEY",
+    default_region: "AWS_DEFAULT_REGION"
+  },
+  agentContext: "`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` — use `aws` CLI and AWS SDKs directly",
+
+  async validate(values) {
+    // Basic validation that required fields are present
+    if (!values.access_key_id || !values.secret_access_key) {
+      throw new Error("Access Key ID and Secret Access Key are required");
+    }
+    
+    if (values.access_key_id.length < 16 || values.access_key_id.length > 128) {
+      throw new Error("AWS Access Key ID should be between 16 and 128 characters");
+    }
+    
+    if (values.secret_access_key.length < 40) {
+      throw new Error("AWS Secret Access Key should be at least 40 characters");
+    }
+    
+    // We could add a real AWS API validation here, but for now basic validation is sufficient
+    return true;
+  },
+};
+
+export default aws;

--- a/src/credentials/builtins/index.ts
+++ b/src/credentials/builtins/index.ts
@@ -5,6 +5,7 @@ import sentryToken from "./sentry-token.js";
 import gitSsh from "./id-rsa.js";
 import githubWebhookSecret from "./github-webhook-secret.js";
 import sentryClientSecret from "./sentry-client-secret.js";
+import aws from "./aws.js";
 
 export const builtinCredentials: Record<string, CredentialDefinition> = {
   "github_token": githubToken,
@@ -13,4 +14,5 @@ export const builtinCredentials: Record<string, CredentialDefinition> = {
   "git_ssh": gitSsh,
   "github_webhook_secret": githubWebhookSecret,
   "sentry_client_secret": sentryClientSecret,
+  "aws": aws,
 };


### PR DESCRIPTION
Closes #5\n\nAdds support for AWS credentials in the Action Llama credential system.\n\n**Changes:**\n- Added `aws` credential type with `access_key_id`, `secret_access_key`, and `default_region` fields\n- Credentials are injected as standard AWS environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`\n- Includes basic validation for credential format\n- Updated documentation to include the new AWS credential type\n\n**Usage:**\nAgents can now reference AWS credentials in their `agent-config.toml`:\n```toml\ncredentials = ["aws:default"]\n```\n\nThis enables agents to manage AWS resources using the AWS CLI or AWS SDKs.