### PR TITLE
Add AWS credentials support

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -12,6 +12,7 @@ Credentials are stored in `~/.action-llama-credentials/<type>/<instance>/<field>
 | `git_ssh` | `id_rsa`, `username`, `email` | SSH private key + git author identity | SSH key mounted as file; `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL`/`GIT_COMMITTER_NAME`/`GIT_COMMITTER_EMAIL` set from `username`/`email` |
 | `github_webhook_secret` | `secret` | Shared secret for GitHub webhook verification | _(used by gateway)_ |
 | `sentry_client_secret` | `secret` | Client secret for Sentry webhook verification | _(used by gateway)_ |
+| `aws` | `access_key_id`, `secret_access_key`, `session_token`, `default_region` | AWS credentials for managing AWS resources | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_DEFAULT_REGION` env vars |
 
 ## How Credentials Work
 

--- a/src/credentials/builtins/aws.ts
+++ b/src/credentials/builtins/aws.ts
@@ -1,0 +1,23 @@
+import type { CredentialDefinition } from "../schema.js";
+
+const aws: CredentialDefinition = {
+  id: "aws",
+  label: "AWS Credentials",
+  description: "AWS access key, secret key, and optional region for managing AWS resources",
+  helpUrl: "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html",
+  fields: [
+    { name: "access_key_id", label: "Access Key ID", description: "AWS access key ID (AKIA...)", secret: false },
+    { name: "secret_access_key", label: "Secret Access Key", description: "AWS secret access key", secret: true },
+    { name: "session_token", label: "Session Token", description: "AWS session token (optional, for temporary credentials)", secret: true },
+    { name: "default_region", label: "Default Region", description: "AWS default region (e.g., us-east-1)", secret: false },
+  ],
+  envVars: {
+    access_key_id: "AWS_ACCESS_KEY_ID",
+    secret_access_key: "AWS_SECRET_ACCESS_KEY",
+    session_token: "AWS_SESSION_TOKEN",
+    default_region: "AWS_DEFAULT_REGION",
+  },
+  agentContext: "`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_DEFAULT_REGION` — use AWS CLI and SDKs directly",
+};
+
+export default aws;

--- a/src/credentials/builtins/index.ts
+++ b/src/credentials/builtins/index.ts
@@ -5,6 +5,7 @@ import sentryToken from "./sentry-token.js";
 import gitSsh from "./id-rsa.js";
 import githubWebhookSecret from "./github-webhook-secret.js";
 import sentryClientSecret from "./sentry-client-secret.js";
+import aws from "./aws.js";
 
 export const builtinCredentials: Record<string, CredentialDefinition> = {
   "github_token": githubToken,
@@ -13,4 +14,5 @@ export const builtinCredentials: Record<string, CredentialDefinition> = {
   "git_ssh": gitSsh,
   "github_webhook_secret": githubWebhookSecret,
   "sentry_client_secret": sentryClientSecret,
+  "aws": aws,
 };


### PR DESCRIPTION
Closes #5

This PR adds AWS credentials support to Action Llama, enabling agents to manage AWS resources.

## Changes

- **New AWS credential type**: Added `aws` credential type with standard AWS fields:
  - `access_key_id`: AWS Access Key ID  
  - `secret_access_key`: AWS Secret Access Key
  - `session_token`: AWS Session Token (optional, for temporary credentials)
  - `default_region`: AWS Default Region
  
- **Environment variable injection**: Maps credential fields to standard AWS environment variables:
  - `AWS_ACCESS_KEY_ID`
  - `AWS_SECRET_ACCESS_KEY` 
  - `AWS_SESSION_TOKEN`
  - `AWS_DEFAULT_REGION`

- **Documentation updated**: Added AWS credentials to the built-in credentials table in `docs/credentials.md`

## Usage

Agents can now include `"aws:default"` in their `credentials` array and use AWS CLI, SDKs, or tools directly. The credentials will be automatically injected as environment variables at runtime.

Example agent-config.toml:
```toml
credentials = ["aws:default", "github_token:default"]
```

All existing tests pass and the implementation follows the established credential pattern.