### PR TITLE
Add AWS credentials support

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -12,6 +12,7 @@ Credentials are stored in `~/.action-llama-credentials/<type>/<instance>/<field>
 | `git_ssh` | `id_rsa`, `username`, `email` | SSH private key + git author identity | SSH key mounted as file; `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL`/`GIT_COMMITTER_NAME`/`GIT_COMMITTER_EMAIL` set from `username`/`email` |
 | `github_webhook_secret` | `secret` | Shared secret for GitHub webhook verification | _(used by gateway)_ |
 | `sentry_client_secret` | `secret` | Client secret for Sentry webhook verification | _(used by gateway)_ |
+| `aws` | `access_key_id`, `secret_access_key`, `session_token`, `region` | AWS access credentials for managing AWS resources | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_DEFAULT_REGION` env vars |
 
 ## How Credentials Work
 
@@ -66,6 +67,11 @@ echo "ghp_your_token_here" > ~/.action-llama-credentials/github_token/default/to
 
 mkdir -p ~/.action-llama-credentials/anthropic_key/default
 echo "sk-ant-api-your_key_here" > ~/.action-llama-credentials/anthropic_key/default/token
+
+mkdir -p ~/.action-llama-credentials/aws/default
+echo "AKIAIOSFODNN7EXAMPLE" > ~/.action-llama-credentials/aws/default/access_key_id
+echo "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" > ~/.action-llama-credentials/aws/default/secret_access_key
+echo "us-east-1" > ~/.action-llama-credentials/aws/default/region
 ```
 
 ### Anthropic Auth Methods

--- a/src/credentials/builtins/aws.ts
+++ b/src/credentials/builtins/aws.ts
@@ -1,0 +1,37 @@
+import type { CredentialDefinition } from "../schema.js";
+
+const aws: CredentialDefinition = {
+  id: "aws",
+  label: "AWS Credentials",
+  description: "AWS access credentials for managing AWS resources",
+  helpUrl: "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html",
+  fields: [
+    { name: "access_key_id", label: "Access Key ID", description: "AWS access key ID (AKIA...)", secret: false },
+    { name: "secret_access_key", label: "Secret Access Key", description: "AWS secret access key", secret: true },
+    { name: "session_token", label: "Session Token", description: "AWS session token (optional, for temporary credentials)", secret: true },
+    { name: "region", label: "Default Region", description: "AWS region (optional, e.g. us-east-1)", secret: false },
+  ],
+  envVars: { 
+    access_key_id: "AWS_ACCESS_KEY_ID", 
+    secret_access_key: "AWS_SECRET_ACCESS_KEY",
+    session_token: "AWS_SESSION_TOKEN",
+    region: "AWS_DEFAULT_REGION"
+  },
+  agentContext: "`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_DEFAULT_REGION` — use `aws` CLI and AWS SDKs directly",
+
+  async validate(values) {
+    // Basic validation - ensure required fields are present
+    if (!values.access_key_id || !values.secret_access_key) {
+      throw new Error("Access Key ID and Secret Access Key are required");
+    }
+    
+    // Basic format validation for access key ID
+    if (!values.access_key_id.match(/^AKIA[0-9A-Z]{16}$/)) {
+      throw new Error("Access Key ID should start with 'AKIA' followed by 16 alphanumeric characters");
+    }
+
+    return true;
+  },
+};
+
+export default aws;

--- a/src/credentials/builtins/index.ts
+++ b/src/credentials/builtins/index.ts
@@ -5,6 +5,7 @@ import sentryToken from "./sentry-token.js";
 import gitSsh from "./id-rsa.js";
 import githubWebhookSecret from "./github-webhook-secret.js";
 import sentryClientSecret from "./sentry-client-secret.js";
+import aws from "./aws.js";
 
 export const builtinCredentials: Record<string, CredentialDefinition> = {
   "github_token": githubToken,
@@ -13,4 +14,5 @@ export const builtinCredentials: Record<string, CredentialDefinition> = {
   "git_ssh": gitSsh,
   "github_webhook_secret": githubWebhookSecret,
   "sentry_client_secret": sentryClientSecret,
+  "aws": aws,
 };


### PR DESCRIPTION
Closes #5

Implements AWS credential support to allow agents to manage AWS resources.

## Changes

- Added  credential type with fields:
  -  → 
  -  →  
  -  →  (optional)
  -  →  (optional)
- Includes validation for required fields and access key ID format
- Updated documentation with AWS credential type and manual setup examples
- All existing tests pass (192/192)

## Usage

Agents can now use AWS credentials by adding `"aws:default"` to their credentials array in `agent-config.toml`:

```toml
credentials = ["aws:default", "github_token:default"]
```

The AWS environment variables will be automatically injected, enabling use of AWS CLI and SDKs.