### PR TITLE
Add AWS credentials support

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -12,6 +12,7 @@ Credentials are stored in `~/.action-llama-credentials/<type>/<instance>/<field>
 | `git_ssh` | `id_rsa`, `username`, `email` | SSH private key + git author identity | SSH key mounted as file; `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL`/`GIT_COMMITTER_NAME`/`GIT_COMMITTER_EMAIL` set from `username`/`email` |
 | `github_webhook_secret` | `secret` | Shared secret for GitHub webhook verification | _(used by gateway)_ |
 | `sentry_client_secret` | `secret` | Client secret for Sentry webhook verification | _(used by gateway)_ |
+| `aws_credentials` | `access_key_id`, `secret_access_key`, `region` | AWS credentials for managing AWS resources | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` env vars |
 
 ## How Credentials Work
 

--- a/src/credentials/builtins/aws-credentials.ts
+++ b/src/credentials/builtins/aws-credentials.ts
@@ -1,0 +1,21 @@
+import type { CredentialDefinition } from "../schema.js";
+
+const awsCredentials: CredentialDefinition = {
+  id: "aws_credentials",
+  label: "AWS Credentials",
+  description: "AWS access key and secret key for managing AWS resources",
+  helpUrl: "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html",
+  fields: [
+    { name: "access_key_id", label: "Access Key ID", description: "AWS Access Key ID (AKIA...)", secret: false },
+    { name: "secret_access_key", label: "Secret Access Key", description: "AWS Secret Access Key", secret: true },
+    { name: "region", label: "Default Region", description: "AWS region (e.g. us-east-1, us-west-2)", secret: false },
+  ],
+  envVars: { 
+    access_key_id: "AWS_ACCESS_KEY_ID",
+    secret_access_key: "AWS_SECRET_ACCESS_KEY",
+    region: "AWS_DEFAULT_REGION"
+  },
+  agentContext: "`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` — use `aws` CLI and AWS SDKs directly",
+};
+
+export default awsCredentials;

--- a/src/credentials/builtins/index.ts
+++ b/src/credentials/builtins/index.ts
@@ -5,6 +5,7 @@ import sentryToken from "./sentry-token.js";
 import gitSsh from "./id-rsa.js";
 import githubWebhookSecret from "./github-webhook-secret.js";
 import sentryClientSecret from "./sentry-client-secret.js";
+import awsCredentials from "./aws-credentials.js";
 
 export const builtinCredentials: Record<string, CredentialDefinition> = {
   "github_token": githubToken,
@@ -13,4 +14,5 @@ export const builtinCredentials: Record<string, CredentialDefinition> = {
   "git_ssh": gitSsh,
   "github_webhook_secret": githubWebhookSecret,
   "sentry_client_secret": sentryClientSecret,
+  "aws_credentials": awsCredentials,
 };


### PR DESCRIPTION
Closes #5

This PR adds support for AWS credentials to allow agents to manage AWS resources.

## Changes
- Added `aws_credentials` builtin credential type with fields:
  - `access_key_id` → `AWS_ACCESS_KEY_ID` env var
  - `secret_access_key` → `AWS_SECRET_ACCESS_KEY` env var  
  - `region` → `AWS_DEFAULT_REGION` env var
- Updated documentation to include AWS credentials

## Usage
Agents can now reference AWS credentials in their `agent-config.toml`:
```toml
credentials = ["aws_credentials:default"]
```

This will inject standard AWS SDK environment variables so agents can use the `aws` CLI or AWS SDKs directly.