### PR TITLE
Add AWS credentials support

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -9,6 +9,7 @@ Credentials are stored in `~/.action-llama-credentials/<type>/<instance>/<field>
 | `github_token` | `token` | GitHub PAT with repo and workflow scopes | `GITHUB_TOKEN` and `GH_TOKEN` env vars |
 | `anthropic_key` | `token` | Anthropic API key, OAuth token, or pi auth | _(read by SDK)_ |
 | `sentry_token` | `token` | Sentry auth token for error monitoring | `SENTRY_AUTH_TOKEN` env var |
+| `aws_credentials` | `access_key_id`, `secret_access_key`, `default_region` | AWS access credentials and default region | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` env vars |
 | `git_ssh` | `id_rsa`, `username`, `email` | SSH private key + git author identity | SSH key mounted as file; `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL`/`GIT_COMMITTER_NAME`/`GIT_COMMITTER_EMAIL` set from `username`/`email` |
 | `github_webhook_secret` | `secret` | Shared secret for GitHub webhook verification | _(used by gateway)_ |
 | `sentry_client_secret` | `secret` | Client secret for Sentry webhook verification | _(used by gateway)_ |

--- a/src/credentials/builtins/aws-credentials.ts
+++ b/src/credentials/builtins/aws-credentials.ts
@@ -1,0 +1,36 @@
+import type { CredentialDefinition } from "../schema.js";
+
+const awsCredentials: CredentialDefinition = {
+  id: "aws_credentials",
+  label: "AWS Credentials",
+  description: "Access credentials for AWS services",
+  helpUrl: "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html",
+  fields: [
+    { 
+      name: "access_key_id", 
+      label: "Access Key ID", 
+      description: "AWS access key ID (AKIA...)", 
+      secret: false 
+    },
+    { 
+      name: "secret_access_key", 
+      label: "Secret Access Key", 
+      description: "AWS secret access key", 
+      secret: true 
+    },
+    { 
+      name: "default_region", 
+      label: "Default Region", 
+      description: "Default AWS region (e.g., us-east-1)", 
+      secret: false 
+    },
+  ],
+  envVars: {
+    access_key_id: "AWS_ACCESS_KEY_ID",
+    secret_access_key: "AWS_SECRET_ACCESS_KEY",
+    default_region: "AWS_DEFAULT_REGION",
+  },
+  agentContext: "`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` — use AWS CLI and SDKs",
+};
+
+export default awsCredentials;

--- a/src/credentials/builtins/index.ts
+++ b/src/credentials/builtins/index.ts
@@ -5,6 +5,7 @@ import sentryToken from "./sentry-token.js";
 import gitSsh from "./id-rsa.js";
 import githubWebhookSecret from "./github-webhook-secret.js";
 import sentryClientSecret from "./sentry-client-secret.js";
+import awsCredentials from "./aws-credentials.js";
 
 export const builtinCredentials: Record<string, CredentialDefinition> = {
   "github_token": githubToken,
@@ -13,4 +14,5 @@ export const builtinCredentials: Record<string, CredentialDefinition> = {
   "git_ssh": gitSsh,
   "github_webhook_secret": githubWebhookSecret,
   "sentry_client_secret": sentryClientSecret,
+  "aws_credentials": awsCredentials,
 };

--- a/src/setup/scaffold.ts
+++ b/src/setup/scaffold.ts
@@ -36,6 +36,7 @@ Credentials are managed by the user via \`al setup\` and stored in \`~/.action-l
 | \`anthropic_key\` | Anthropic API key or OAuth token | \`token\` | Read directly by the agent SDK (not an env var) | LLM access — required for all agents |
 | \`github_token\` | GitHub PAT (repo + workflow scopes) | \`token\` | \`GITHUB_TOKEN\` and \`GH_TOKEN\` env vars | \`gh\` CLI, \`git\` over HTTPS, GitHub API |
 | \`git_ssh\` | SSH private key + git identity | \`id_rsa\`, \`username\`, \`email\` | SSH key mounted as file; \`GIT_SSH_COMMAND\` configured automatically; \`GIT_AUTHOR_NAME\`/\`GIT_AUTHOR_EMAIL\`/\`GIT_COMMITTER_NAME\`/\`GIT_COMMITTER_EMAIL\` set from \`username\`/\`email\` | \`git clone\`/\`push\` over SSH — **required for pushing to repos** |
+| \`aws_credentials\` | AWS access credentials and default region | \`access_key_id\`, \`secret_access_key\`, \`default_region\` | \`AWS_ACCESS_KEY_ID\`, \`AWS_SECRET_ACCESS_KEY\`, \`AWS_DEFAULT_REGION\` env vars | AWS CLI, AWS SDKs via standard env vars |
 | \`sentry_token\` | Sentry auth token | \`token\` | \`SENTRY_AUTH_TOKEN\` env var | Sentry API via \`curl\` |
 | \`github_webhook_secret\` | Shared HMAC secret | \`secret\` | Used by gateway only (not injected into agents) | Validates GitHub webhook payloads |
 | \`sentry_client_secret\` | Sentry client secret | \`secret\` | Used by gateway only (not injected into agents) | Validates Sentry webhook payloads |

--- a/test/credentials/builtins/aws-credentials.test.ts
+++ b/test/credentials/builtins/aws-credentials.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import awsCredentials from "../../../src/credentials/builtins/aws-credentials.js";
+
+describe("aws-credentials", () => {
+  it("should have correct id and labels", () => {
+    expect(awsCredentials.id).toBe("aws_credentials");
+    expect(awsCredentials.label).toBe("AWS Credentials");
+    expect(awsCredentials.description).toBe("Access credentials for AWS services");
+  });
+
+  it("should have correct fields", () => {
+    expect(awsCredentials.fields).toHaveLength(3);
+    
+    const accessKeyField = awsCredentials.fields.find(f => f.name === "access_key_id");
+    expect(accessKeyField).toBeDefined();
+    expect(accessKeyField?.label).toBe("Access Key ID");
+    expect(accessKeyField?.secret).toBe(false);
+    
+    const secretKeyField = awsCredentials.fields.find(f => f.name === "secret_access_key");
+    expect(secretKeyField).toBeDefined();
+    expect(secretKeyField?.label).toBe("Secret Access Key");
+    expect(secretKeyField?.secret).toBe(true);
+    
+    const regionField = awsCredentials.fields.find(f => f.name === "default_region");
+    expect(regionField).toBeDefined();
+    expect(regionField?.label).toBe("Default Region");
+    expect(regionField?.secret).toBe(false);
+  });
+
+  it("should have correct env var mappings", () => {
+    expect(awsCredentials.envVars).toEqual({
+      access_key_id: "AWS_ACCESS_KEY_ID",
+      secret_access_key: "AWS_SECRET_ACCESS_KEY",
+      default_region: "AWS_DEFAULT_REGION",
+    });
+  });
+
+  it("should have agent context", () => {
+    expect(awsCredentials.agentContext).toContain("AWS_ACCESS_KEY_ID");
+    expect(awsCredentials.agentContext).toContain("AWS_SECRET_ACCESS_KEY");
+    expect(awsCredentials.agentContext).toContain("AWS_DEFAULT_REGION");
+  });
+
+  it("should have help URL", () => {
+    expect(awsCredentials.helpUrl).toBe("https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html");
+  });
+});

--- a/test/credentials/builtins/index.test.ts
+++ b/test/credentials/builtins/index.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { builtinCredentials } from "../../../src/credentials/builtins/index.js";
+
+describe("builtin credentials", () => {
+  it("should include all expected credential types", () => {
+    const expectedTypes = [
+      "github_token",
+      "anthropic_key", 
+      "sentry_token",
+      "git_ssh",
+      "github_webhook_secret",
+      "sentry_client_secret",
+      "aws_credentials",
+    ];
+    
+    for (const type of expectedTypes) {
+      expect(builtinCredentials).toHaveProperty(type);
+      expect(builtinCredentials[type].id).toBe(type);
+    }
+  });
+
+  it("should have aws_credentials with correct structure", () => {
+    const awsCreds = builtinCredentials.aws_credentials;
+    expect(awsCreds).toBeDefined();
+    expect(awsCreds.id).toBe("aws_credentials");
+    expect(awsCreds.fields).toHaveLength(3);
+    expect(awsCreds.envVars).toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes #5\n\nAdds support for AWS credentials so agents can manage AWS resources.\n\nChanges:\n- Added new  credential type with fields for access key ID, secret access key, and default region\n- Maps to standard AWS environment variables: , , \n- Updated documentation in credentials.md and project templates\n- Added comprehensive tests\n\nAgents can now use AWS CLI and AWS SDKs by including  in their credential arrays.