### PR TITLE
Add Bugsnag credential support

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -9,6 +9,7 @@ Credentials are stored in `~/.action-llama-credentials/<type>/<instance>/<field>
 | `github_token` | `token` | GitHub PAT with repo and workflow scopes | `GITHUB_TOKEN` and `GH_TOKEN` env vars |
 | `anthropic_key` | `token` | Anthropic API key, OAuth token, or pi auth | _(read by SDK)_ |
 | `sentry_token` | `token` | Sentry auth token for error monitoring | `SENTRY_AUTH_TOKEN` env var |
+| `bugsnag_token` | `token` | Bugsnag auth token for error monitoring and release management | `BUGSNAG_AUTH_TOKEN` env var |
 | `netlify_token` | `token` | Netlify Personal Access Token for site management | `NETLIFY_AUTH_TOKEN` env var |
 | `git_ssh` | `id_rsa`, `username`, `email` | SSH private key + git author identity | SSH key mounted as file; `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL`/`GIT_COMMITTER_NAME`/`GIT_COMMITTER_EMAIL` set from `username`/`email` |
 | `github_webhook_secret` | `secret` | Shared secret for GitHub webhook verification | _(used by gateway)_ |
@@ -69,6 +70,9 @@ echo "ghp_your_token_here" > ~/.action-llama-credentials/github_token/default/to
 
 mkdir -p ~/.action-llama-credentials/anthropic_key/default
 echo "sk-ant-api-your_key_here" > ~/.action-llama-credentials/anthropic_key/default/token
+
+mkdir -p ~/.action-llama-credentials/bugsnag_token/default
+echo "your_bugsnag_token_here" > ~/.action-llama-credentials/bugsnag_token/default/token
 
 mkdir -p ~/.action-llama-credentials/netlify_token/default
 echo "your_netlify_token_here" > ~/.action-llama-credentials/netlify_token/default/token

--- a/src/credentials/builtins/bugsnag-token.ts
+++ b/src/credentials/builtins/bugsnag-token.ts
@@ -1,0 +1,21 @@
+import type { CredentialDefinition } from "../schema.js";
+import { validateBugsnagToken } from "../../setup/validators.js";
+
+const bugsnagToken: CredentialDefinition = {
+  id: "bugsnag_token",
+  label: "Bugsnag Auth Token",
+  description: "For error monitoring and release management",
+  helpUrl: "https://app.bugsnag.com/settings/my-account/auth-tokens",
+  fields: [
+    { name: "token", label: "Auth Token", description: "Bugsnag auth token", secret: true },
+  ],
+  envVars: { token: "BUGSNAG_AUTH_TOKEN" },
+  agentContext: "`BUGSNAG_AUTH_TOKEN` — use for Bugsnag API requests",
+
+  async validate(values) {
+    await validateBugsnagToken(values.token);
+    return true;
+  },
+};
+
+export default bugsnagToken;

--- a/src/credentials/builtins/index.ts
+++ b/src/credentials/builtins/index.ts
@@ -9,6 +9,7 @@ import sentryClientSecret from "./sentry-client-secret.js";
 import netlifyToken from "./netlify-token.js";
 import xTwitterApi from "./x-twitter-api.js";
 import aws from "./aws.js";
+import bugsnagToken from "./bugsnag-token.js";
 
 export const builtinCredentials: Record<string, CredentialDefinition> = {
   "github_token": githubToken,
@@ -21,4 +22,5 @@ export const builtinCredentials: Record<string, CredentialDefinition> = {
   "netlify_token": netlifyToken,
   "x_twitter_api": xTwitterApi,
   "aws": aws,
+  "bugsnag_token": bugsnagToken,
 };

--- a/src/setup/validators.ts
+++ b/src/setup/validators.ts
@@ -103,3 +103,25 @@ export async function validateXTwitterToken(bearerToken: string) {
     id: user.data.id,
   };
 }
+
+export async function validateBugsnagToken(token: string) {
+  const res = await fetch("https://api.bugsnag.com/user", {
+    headers: { 
+      Authorization: `token ${token}`,
+      "Content-Type": "application/json"
+    },
+  });
+  
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Bugsnag auth failed (${res.status}): ${body}`);
+  }
+  
+  const user = (await res.json()) as { id: string; name: string; email: string };
+  
+  return {
+    user: user.email,
+    name: user.name,
+    id: user.id,
+  };
+}


### PR DESCRIPTION
Closes #16\n\nAdds support for Bugsnag auth tokens as a built-in credential type. This enables agents to authenticate with the Bugsnag API for error monitoring and release management.\n\nChanges:\n- Added \ credential definition\n- Added Bugsnag token validation\n- Updated credentials documentation\n- All tests pass