### PR TITLE
Logging updates

### DIFF
--- a/src/agents/container-runner.ts
+++ b/src/agents/container-runner.ts
@@ -121,7 +121,7 @@ export class ContainerAgentRunner {
     }
   }
 
-  async run(prompt: string): Promise<RunOutcome> {
+  async run(prompt: string, triggerInfo?: { type: 'schedule' | 'webhook' | 'agent'; source?: string }): Promise<RunOutcome> {
     if (this._running) {
       this.logger.warn(`${this.agentConfig.name} is already running, skipping`);
       return { result: "error", triggers: [] };
@@ -142,7 +142,15 @@ export class ContainerAgentRunner {
     this._triggers = [];
     this._triggerAccum = null;
     this.statusTracker?.setAgentState(this.agentConfig.name, "running");
-    this.logger.info(`Starting ${this.agentConfig.name} container run`);
+    
+    if (triggerInfo) {
+      const triggerDetails = triggerInfo.type === 'agent' && triggerInfo.source 
+        ? `${triggerInfo.type} (${triggerInfo.source})` 
+        : triggerInfo.type;
+      this.logger.info(`Starting ${this.agentConfig.name} container run (triggered by ${triggerDetails})`);
+    } else {
+      this.logger.info(`Starting ${this.agentConfig.name} container run`);
+    }
     const runStartTime = Date.now();
     let runError: string | undefined;
     let runResult: RunResult = "error";

--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -73,7 +73,7 @@ export class AgentRunner {
     return this.running;
   }
 
-  async run(prompt: string): Promise<RunOutcome> {
+  async run(prompt: string, triggerInfo?: { type: 'schedule' | 'webhook' | 'agent'; source?: string }): Promise<RunOutcome> {
     if (this.running) {
       this.logger.warn(`${this.agentConfig.name} is already running, skipping`);
       return { result: "error", triggers: [] };
@@ -81,7 +81,15 @@ export class AgentRunner {
 
     this.running = true;
     this.statusTracker?.setAgentState(this.agentConfig.name, "running");
-    this.logger.info(`Starting ${this.agentConfig.name} run`);
+    
+    if (triggerInfo) {
+      const triggerDetails = triggerInfo.type === 'agent' && triggerInfo.source 
+        ? `${triggerInfo.type} (${triggerInfo.source})` 
+        : triggerInfo.type;
+      this.logger.info(`Starting ${this.agentConfig.name} run (triggered by ${triggerDetails})`);
+    } else {
+      this.logger.info(`Starting ${this.agentConfig.name} run`);
+    }
     const runStartTime = Date.now();
     let runError: string | undefined;
 

--- a/src/scheduler/index.ts
+++ b/src/scheduler/index.ts
@@ -18,7 +18,7 @@ import type { WebhookContext, WebhookFilter, WebhookTrigger, GitHubWebhookFilter
 
 interface RunnerLike {
   isRunning: boolean;
-  run(prompt: string): Promise<RunOutcome>;
+  run(prompt: string, triggerInfo?: { type: 'schedule' | 'webhook' | 'agent'; source?: string }): Promise<RunOutcome>;
 }
 
 // Provider type → credential type for loading secrets
@@ -100,7 +100,7 @@ async function runTriggered(
   depth: number,
   ctx: SchedulerContext
 ): Promise<void> {
-  const { result, triggers } = await runner.run(prompt);
+  const { result, triggers } = await runner.run(prompt, { type: 'agent', source: sourceAgent });
   if (triggers.length > 0) {
     dispatchTriggers(triggers, agentConfig.name, depth, ctx);
   }
@@ -116,7 +116,7 @@ async function runWithReruns(
   depth: number,
   ctx: SchedulerContext
 ): Promise<void> {
-  let { result, triggers } = await runner.run(buildScheduledPrompt(agentConfig));
+  let { result, triggers } = await runner.run(buildScheduledPrompt(agentConfig), { type: 'schedule' });
   if (triggers.length > 0) {
     dispatchTriggers(triggers, agentConfig.name, depth, ctx);
   }
@@ -124,7 +124,7 @@ async function runWithReruns(
   while (result === "completed" && reruns < ctx.maxReruns) {
     reruns++;
     ctx.logger.info({ rerun: reruns, maxReruns: ctx.maxReruns }, `${agentConfig.name} did work, re-running immediately`);
-    ({ result, triggers } = await runner.run(buildScheduledPrompt(agentConfig)));
+    ({ result, triggers } = await runner.run(buildScheduledPrompt(agentConfig), { type: 'schedule' }));
     if (triggers.length > 0) {
       dispatchTriggers(triggers, agentConfig.name, depth, ctx);
     }
@@ -322,37 +322,54 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
 
     // 3. Build per-agent images for agents with a custom Dockerfile
     const { existsSync } = await import("fs");
-    for (const agentConfig of agentConfigs) {
+    const agentsWithCustomImages = agentConfigs.filter(ac => 
+      existsSync(resolvePath(projectPath, ac.name, "Dockerfile"))
+    );
+    const totalCustomImages = agentsWithCustomImages.length;
+    
+    for (const [index, agentConfig] of agentConfigs.entries()) {
       const agentDockerfile = resolvePath(projectPath, agentConfig.name, "Dockerfile");
       if (!existsSync(agentDockerfile)) {
         agentImages[agentConfig.name] = baseImage;
         continue;
       }
 
+      const customImageIndex = agentsWithCustomImages.findIndex(ac => ac.name === agentConfig.name) + 1;
+      const progressIndicator = totalCustomImages > 1 ? ` (${customImageIndex}/${totalCustomImages})` : "";
+      
       statusTracker?.setAgentState(agentConfig.name, "building");
-      statusTracker?.setAgentStatusText(agentConfig.name, "Building custom image");
+      statusTracker?.setAgentStatusText(agentConfig.name, `Building custom image${progressIndicator}`);
       const agentImageTag = AWS_CONSTANTS.agentImage(agentConfig.name);
       const image = await runtime.buildImage({
         tag: agentImageTag,
         dockerfile: agentDockerfile,
         contextDir: packageRoot,
         baseImage,
-        onProgress: (msg) => statusTracker?.setAgentStatusText(agentConfig.name, msg),
+        onProgress: (msg) => statusTracker?.setAgentStatusText(agentConfig.name, `${msg}${progressIndicator}`),
       });
       agentImages[agentConfig.name] = image;
-      logger.info({ agent: agentConfig.name, image }, "Built custom agent image");
+      logger.info({ agent: agentConfig.name, image, progress: `${customImageIndex}/${totalCustomImages}` }, "Built custom agent image");
     }
 
     // 4. Push images to remote registry if needed (no-op for local, tags+pushes for cloud)
     if (runtimeType !== "local") {
+      const imagesToPush = agentConfigs.filter(ac => {
+        const currentImage = agentImages[ac.name] || baseImage;
+        return !currentImage.includes("/");
+      });
+      const totalImagesToPush = imagesToPush.length;
+      
+      let pushIndex = 0;
       for (const agentConfig of agentConfigs) {
         const currentImage = agentImages[agentConfig.name] || baseImage;
         if (!currentImage.includes("/")) {
           // Looks like a local tag — needs pushing
-          statusTracker?.setAgentStatusText(agentConfig.name, "Pushing image to registry");
+          pushIndex++;
+          const progressIndicator = totalImagesToPush > 1 ? ` (${pushIndex}/${totalImagesToPush})` : "";
+          statusTracker?.setAgentStatusText(agentConfig.name, `Pushing image to registry${progressIndicator}`);
           const remoteImage = await runtime.pushImage(currentImage);
           agentImages[agentConfig.name] = remoteImage;
-          logger.info({ agent: agentConfig.name, image: remoteImage }, "Pushed image to registry");
+          logger.info({ agent: agentConfig.name, image: remoteImage, progress: `${pushIndex}/${totalImagesToPush}` }, "Pushed image to registry");
         }
       }
     }
@@ -459,7 +476,7 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
               "webhook triggering agent"
             );
             const prompt = buildWebhookPrompt(agentConfig, context);
-            runner.run(prompt).then(({ triggers }) => {
+            runner.run(prompt, { type: 'webhook', source: context.event }).then(({ triggers }) => {
               if (triggers.length > 0) {
                 dispatchTriggers(triggers, agentConfig.name, 0, schedulerCtx);
               }


### PR DESCRIPTION
Closes #23

## Summary

This PR implements the logging improvements requested in issue #23:

### 1. Progress indicators for image building
- When building multiple agent images, the scheduler now shows progress indicators like "Building custom image (1/3)", "Building custom image (2/3)", etc.
- Same for pushing images to registry: "Pushing image to registry (1/2)", "Pushing image to registry (2/2)", etc.
- Progress indicators only show when there are multiple images to process

### 2. Container startup trigger information  
- Added trigger information to runner interfaces to track what triggered each run
- Container and agent runners now log what triggered them: "Starting container run (triggered by schedule)", "Starting container run (triggered by webhook)", "Starting container run (triggered by agent)", etc.
- Trigger information includes the source for agent triggers and webhook events

## Changes Made

- **scheduler/index.ts**: Added progress indicators for image building and pushing, updated runner calls to include trigger information
- **agents/runner.ts**: Added optional triggerInfo parameter and logging
- **agents/container-runner.ts**: Added optional triggerInfo parameter and logging  

## Testing

- All existing tests pass (286/286)
- Changes are backward compatible - triggerInfo parameter is optional
- TypeScript compilation successful