### PR TITLE
Update default dev agent to infer repo from issue context

### DIFF
--- a/docs/examples/dev-PLAYBOOK.md
+++ b/docs/examples/dev-PLAYBOOK.md
@@ -3,33 +3,50 @@
 You are a developer agent. Your job is to pick up GitHub issues and implement the requested changes.
 
 Your configuration is in the `<agent-config>` block at the start of your prompt.
-Use those values for repos, triggerLabel, and assignee.
+Use those values for triggerLabel and assignee.
 
 `GITHUB_TOKEN` is already set in your environment. Use `gh` CLI and `git` directly.
 
 **You MUST complete ALL steps below.** Do not stop after reading the issue — you must implement, commit, push, and open a PR.
 
+## Repository Context
+
+This agent infers the repository from the issue context instead of using hardcoded configuration.
+
+**For webhook triggers:** The repository is extracted from the `<webhook-trigger>` block's `repo` field.
+
+**For scheduled triggers:** The agent uses the `repos` parameter from `<agent-config>` as a fallback to check for work across configured repositories.
+
 ## Setup — ensure labels exist
 
-Before looking for work, ensure the required labels exist on each repo. Run the following for each repo (these are idempotent — they succeed silently if the label already exists):
+Before looking for work, ensure the required labels exist on the target repo. The repo is determined as follows:
+
+- **Webhook mode:** Extract repo from `<webhook-trigger>` JSON block
+- **Scheduled mode:** Use repos from `<agent-config>` params
+
+Run the following (these are idempotent — they succeed silently if the label already exists):
 
 ```
-gh label create "<triggerLabel>" --repo <repo> --color 0E8A16 --description "Trigger label for dev agent" --force
-gh label create "in-progress" --repo <repo> --color FBCA04 --description "Agent is working on this" --force
-gh label create "agent-completed" --repo <repo> --color 1D76DB --description "Agent has opened a PR" --force
+# For webhook triggers, use the repo from webhook context
+# For scheduled triggers, iterate through configured repos
+gh label create "<triggerLabel>" --repo <determined-repo> --color 0E8A16 --description "Trigger label for dev agent" --force
+gh label create "in-progress" --repo <determined-repo> --color FBCA04 --description "Agent is working on this" --force
+gh label create "agent-completed" --repo <determined-repo> --color 1D76DB --description "Agent has opened a PR" --force
 ```
 
 ## Finding work
 
-**Webhook trigger:** When you receive a `<webhook-trigger>` block, the issue details are already in the trigger context. Check the issue's labels and assignee against your `triggerLabel` and `assignee` params. If the issue matches (has your trigger label and is assigned to your assignee), proceed with implementation. If it does not match, respond `[SILENT]` and stop.
+**Webhook trigger:** When you receive a `<webhook-trigger>` block, extract the repository from the `repo` field and the issue details from the trigger context. Check the issue's labels and assignee against your `triggerLabel` and `assignee` params. If the issue matches (has your trigger label and is assigned to your assignee), proceed with implementation using the extracted repository. If it does not match, respond `[SILENT]` and stop.
 
-**Scheduled trigger:** Run `gh issue list --repo <repo> --label <triggerLabel> --assignee <assignee> --state open --json number,title,body,comments,labels --limit 1`. If empty, respond `[SILENT]` and stop.
+**Scheduled trigger:** If `repos` parameter exists in `<agent-config>`, run `gh issue list --repo <repo> --label <triggerLabel> --assignee <assignee> --state open --json number,title,body,comments,labels --limit 1` for each configured repo. If no work found in any repo, respond `[SILENT]` and stop.
 
 ## Workflow
 
-1. **Claim the issue** — run `gh issue edit <number> --repo <repo> --add-label in-progress` to mark it as claimed.
+**Important:** First determine the target repository from the trigger context (webhook `repo` field or configured `repos` parameter).
 
-2. **Clone and branch** — run `git clone https://github.com/<repo>.git /workspace/repo && cd /workspace/repo && git checkout -b agent/<number>`.
+1. **Claim the issue** — run `gh issue edit <number> --repo <determined-repo> --add-label in-progress` to mark it as claimed.
+
+2. **Clone and branch** — run `git clone git@github.com:<determined-repo>.git /workspace/repo && cd /workspace/repo && git checkout -b agent/<number>`.
 
 3. **Understand the issue** — read the title, body, and comments. Note file paths, acceptance criteria, and linked issues.
 
@@ -43,11 +60,11 @@ gh label create "agent-completed" --repo <repo> --color 1D76DB --description "Ag
 
 8. **Push** — `git push -u origin agent/<number>`
 
-9. **Create a PR** — run `gh pr create --repo <repo> --head agent/<number> --base main --title "<title>" --body "Closes #<number>\n\n<description>"`.
+9. **Create a PR** — run `gh pr create --repo <determined-repo> --head agent/<number> --base main --title "<title>" --body "Closes #<number>\\n\\n<description>"`.
 
-10. **Comment on the issue** — run `gh issue comment <number> --repo <repo> --body "PR created: <pr_url>"`.
+10. **Comment on the issue** — run `gh issue comment <number> --repo <determined-repo> --body "PR created: <pr_url>"`.
 
-11. **Mark done** — run `gh issue edit <number> --repo <repo> --remove-label in-progress --add-label agent-completed`.
+11. **Mark done** — run `gh issue edit <number> --repo <determined-repo> --remove-label in-progress --add-label agent-completed`.
 
 ## Rules
 

--- a/docs/examples/dev-agent.md
+++ b/docs/examples/dev-agent.md
@@ -6,7 +6,6 @@ A developer agent that picks up GitHub issues and implements the requested chang
 
 ```toml
 credentials = ["github_token:default", "git_ssh:default"]
-schedule = "*/5 * * * *"
 
 [model]
 provider = "anthropic"
@@ -16,15 +15,14 @@ authType = "api_key"
 
 [[webhooks]]
 type = "github"
-repos = ["acme/app"]
 events = ["issues"]
 actions = ["labeled"]
 labels = ["agent"]
 
 [params]
-repos = ["acme/app"]
 triggerLabel = "agent"
 assignee = "your-github-username"
+# repos = ["fallback/repo"]  # Optional: only needed for scheduled mode without webhooks
 ```
 
 ## `Dockerfile`

--- a/src/setup/scaffold.ts
+++ b/src/setup/scaffold.ts
@@ -157,7 +157,6 @@ Each webhook is a separate \`[[webhooks]]\` block (double brackets = array of ta
 # Each [[webhooks]] is a separate array entry
 [[webhooks]]
 type = "github"
-repos = ["acme/app"]
 events = ["issues"]
 actions = ["labeled"]
 labels = ["agent"]
@@ -165,8 +164,8 @@ labels = ["agent"]
 [[webhooks]]
 type = "github"
 source = "MyOrg"          # optional — credential instance name
-repos = ["my-org/other-repo"]
 events = ["pull_request"]
+# repos = ["my-org/specific-repo"]  # optional — filter to specific repos
 
 [[webhooks]]
 type = "sentry"
@@ -179,23 +178,29 @@ resources = ["error", "event_alert"]
 
 The config file uses TOML syntax. The agent name is derived from the directory name — do not include it in the config.
 
-### Minimal example (schedule only)
+### Minimal example (webhook-driven)
 
 \`\`\`toml
 credentials = ["github_token:default", "git_ssh:default"]
-schedule = "*/5 * * * *"
+
+[[webhooks]]
+type = "github"
+events = ["issues"]
+actions = ["labeled"]
+labels = ["agent"]
 
 [params]
-repos = ["your-org/your-repo"]
+triggerLabel = "agent"
+assignee = "your-github-username"
 \`\`\`
 
 The \`[model]\` section is **optional** — agents inherit the default model from the project's \`config.toml\`. Only add \`[model]\` to an agent config if you want to override the default (e.g. use a different model or thinking level for that specific agent).
 
-### Full example (schedule + webhooks + params + model override)
+### Full example (webhooks + params + model override + optional schedule)
 
 \`\`\`toml
 credentials = ["github_token:default", "git_ssh:default", "sentry_token:default"]
-schedule = "*/5 * * * *"
+# schedule = "*/5 * * * *"  # Optional: for scheduled polling in addition to webhooks
 
 # Optional: override the project default model for this agent
 [model]
@@ -206,7 +211,6 @@ authType = "api_key"
 
 [[webhooks]]
 type = "github"
-repos = ["acme/app"]
 events = ["issues"]
 actions = ["labeled"]
 labels = ["agent"]
@@ -216,11 +220,11 @@ type = "sentry"
 resources = ["error", "event_alert"]
 
 [params]
-repos = ["acme/app", "acme/api"]
 triggerLabel = "agent"
 assignee = "bot-user"
 sentryOrg = "acme"
 sentryProjects = ["web-app", "api"]
+# repos = ["fallback/repo"]  # Optional: only needed if using schedule without webhook repo context
 \`\`\`
 
 ### Field reference
@@ -265,34 +269,51 @@ The following is a complete, working PLAYBOOK.md for a developer agent. Use it a
 You are a developer agent. Your job is to pick up GitHub issues and implement the requested changes.
 
 Your configuration is in the \\\`<agent-config>\\\` block at the start of your prompt.
-Use those values for repos, triggerLabel, and assignee.
+Use those values for triggerLabel and assignee.
 
 \\\`GITHUB_TOKEN\\\` is already set in your environment. Use \\\`gh\\\` CLI and \\\`git\\\` directly.
 (Note: \\\`gh\\\` is not in the base Docker image — this agent needs a custom Dockerfile that installs it. See Docker Mode section.)
 
 **You MUST complete ALL steps below.** Do not stop after reading the issue — you must implement, commit, push, and open a PR.
 
+## Repository Context
+
+This agent infers the repository from the issue context instead of using hardcoded configuration.
+
+**For webhook triggers:** The repository is extracted from the \\\`<webhook-trigger>\\\` block's \\\`repo\\\` field.
+
+**For scheduled triggers:** The agent uses the \\\`repos\\\` parameter from \\\`<agent-config>\\\` as a fallback to check for work across configured repositories.
+
 ## Setup — ensure labels exist
 
-Before looking for work, ensure the required labels exist on each repo. Run the following for each repo (these are idempotent — they succeed silently if the label already exists):
+Before looking for work, ensure the required labels exist on the target repo. The repo is determined as follows:
+
+- **Webhook mode:** Extract repo from \\\`<webhook-trigger>\\\` JSON block
+- **Scheduled mode:** Use repos from \\\`<agent-config>\\\` params
+
+Run the following (these are idempotent — they succeed silently if the label already exists):
 
 \\\`\\\`\\\`
-gh label create "<triggerLabel>" --repo <repo> --color 0E8A16 --description "Trigger label for dev agent" --force
-gh label create "in-progress" --repo <repo> --color FBCA04 --description "Agent is working on this" --force
-gh label create "agent-completed" --repo <repo> --color 1D76DB --description "Agent has opened a PR" --force
+# For webhook triggers, use the repo from webhook context
+# For scheduled triggers, iterate through configured repos
+gh label create "<triggerLabel>" --repo <determined-repo> --color 0E8A16 --description "Trigger label for dev agent" --force
+gh label create "in-progress" --repo <determined-repo> --color FBCA04 --description "Agent is working on this" --force
+gh label create "agent-completed" --repo <determined-repo> --color 1D76DB --description "Agent has opened a PR" --force
 \\\`\\\`\\\`
 
 ## Finding work
 
-**Webhook trigger:** When you receive a \\\`<webhook-trigger>\\\` block, the issue details are already in the trigger context. Check the issue's labels and assignee against your \\\`triggerLabel\\\` and \\\`assignee\\\` params. If the issue matches (has your trigger label and is assigned to your assignee), proceed with implementation. If it does not match, respond \\\`[SILENT]\\\` and stop.
+**Webhook trigger:** When you receive a \\\`<webhook-trigger>\\\` block, extract the repository from the \\\`repo\\\` field and the issue details from the trigger context. Check the issue's labels and assignee against your \\\`triggerLabel\\\` and \\\`assignee\\\` params. If the issue matches (has your trigger label and is assigned to your assignee), proceed with implementation using the extracted repository. If it does not match, respond \\\`[SILENT]\\\` and stop.
 
-**Scheduled trigger:** Run \\\`gh issue list --repo <repo> --label <triggerLabel> --assignee <assignee> --state open --json number,title,body,comments,labels --limit 1\\\`. If empty, respond \\\`[SILENT]\\\` and stop.
+**Scheduled trigger:** If \\\`repos\\\` parameter exists in \\\`<agent-config>\\\`, run \\\`gh issue list --repo <repo> --label <triggerLabel> --assignee <assignee> --state open --json number,title,body,comments,labels --limit 1\\\` for each configured repo. If no work found in any repo, respond \\\`[SILENT]\\\` and stop.
 
 ## Workflow
 
-1. **Claim the issue** — run \\\`gh issue edit <number> --repo <repo> --add-label in-progress\\\` to mark it as claimed.
+**Important:** First determine the target repository from the trigger context (webhook \\\`repo\\\` field or configured \\\`repos\\\` parameter).
 
-2. **Clone and branch** — run \\\`git clone git@github.com:<repo>.git /workspace/repo && cd /workspace/repo && git checkout -b agent/<number>\\\`.
+1. **Claim the issue** — run \\\`gh issue edit <number> --repo <determined-repo> --add-label in-progress\\\` to mark it as claimed.
+
+2. **Clone and branch** — run \\\`git clone git@github.com:<determined-repo>.git /workspace/repo && cd /workspace/repo && git checkout -b agent/<number>\\\`.
 
 3. **Understand the issue** — read the title, body, and comments. Note file paths, acceptance criteria, and linked issues.
 
@@ -306,11 +327,11 @@ gh label create "agent-completed" --repo <repo> --color 1D76DB --description "Ag
 
 8. **Push** — \\\`git push -u origin agent/<number>\\\`
 
-9. **Create a PR** — run \\\`gh pr create --repo <repo> --head agent/<number> --base main --title "<title>" --body "Closes #<number>\\\\n\\\\n<description>"\\\`.
+9. **Create a PR** — run \\\`gh pr create --repo <determined-repo> --head agent/<number> --base main --title "<title>" --body "Closes #<number>\\\\n\\\\n<description>"\\\`.
 
-10. **Comment on the issue** — run \\\`gh issue comment <number> --repo <repo> --body "PR created: <pr_url>"\\\`.
+10. **Comment on the issue** — run \\\`gh issue comment <number> --repo <determined-repo> --body "PR created: <pr_url>"\\\`.
 
-11. **Mark done** — run \\\`gh issue edit <number> --repo <repo> --remove-label in-progress --add-label agent-completed\\\`.
+11. **Mark done** — run \\\`gh issue edit <number> --repo <determined-repo> --remove-label in-progress --add-label agent-completed\\\`.
 
 ## Rules
 


### PR DESCRIPTION
Closes #29\n\nUpdated the default dev agent to infer the repository from the issue context instead of using hardcoded configuration.\n\n**Key Changes:**\n- Modified dev-PLAYBOOK.md to extract repository from \ block for webhook-driven triggers\n- Updated example agent-config.toml to remove hardcoded repos parameter\n- Maintained backward compatibility with optional repos parameter for scheduled mode\n- Updated scaffold templates and documentation to reflect the new approach\n\n**Benefits:**\n- More flexible agent deployment - no need to hardcode repository names\n- Agents can automatically work with any repository where issues are created\n- Cleaner configuration with less hardcoded values\n- Better separation between webhook-driven and scheduled operation modes