### PR TITLE
feat: add organization-level webhook filtering support

### DIFF
--- a/src/webhooks/definitions/github.ts
+++ b/src/webhooks/definitions/github.ts
@@ -32,6 +32,8 @@ export const github: WebhookDefinition = {
         { value: "created", label: "Created" },
       ],
     },
+    { field: "repos", label: "Repositories", type: "text[]" },
+    { field: "orgs", label: "Organizations", type: "text[]" },
     { field: "labels", label: "Labels", type: "text[]" },
     { field: "assignee", label: "Assignee", type: "text" },
     { field: "branches", label: "Branches", type: "text[]" },

--- a/src/webhooks/providers/github.ts
+++ b/src/webhooks/providers/github.ts
@@ -175,6 +175,14 @@ export class GitHubWebhookProvider implements WebhookProvider {
       return false;
     }
 
+    // Check organization matching - extract org from repo name (e.g., "acme/app" -> "acme")
+    if (f.orgs?.length) {
+      const org = context.repo.split('/')[0];
+      if (!f.orgs.includes(org)) {
+        return false;
+      }
+    }
+
     if (f.labels?.length) {
       const contextLabels = context.labels || [];
       const hasMatchingLabel = f.labels.some((l) => contextLabels.includes(l));

--- a/src/webhooks/types.ts
+++ b/src/webhooks/types.ts
@@ -24,6 +24,7 @@ export interface WebhookContext {
 
 export interface GitHubWebhookFilter {
   repos?: string[];
+  orgs?: string[];
   events?: string[];
   actions?: string[];
   labels?: string[];
@@ -46,6 +47,7 @@ export interface WebhookTrigger {
   events?: string[];
   actions?: string[];
   repos?: string[];
+  orgs?: string[];
   labels?: string[];
   assignee?: string;
   author?: string;

--- a/test/webhooks/providers/github.test.ts
+++ b/test/webhooks/providers/github.test.ts
@@ -285,6 +285,12 @@ describe("GitHubWebhookProvider", () => {
       expect(provider.matchesFilter(baseContext, { repos: ["other/repo"] })).toBe(false);
     });
 
+    it("matches on orgs", () => {
+      expect(provider.matchesFilter(baseContext, { orgs: ["acme"] })).toBe(true);
+      expect(provider.matchesFilter(baseContext, { orgs: ["other"] })).toBe(false);
+      expect(provider.matchesFilter(baseContext, { orgs: ["acme", "other"] })).toBe(true);
+    });
+
     it("matches on labels (any match)", () => {
       expect(provider.matchesFilter(baseContext, { labels: ["agent"] })).toBe(true);
       expect(provider.matchesFilter(baseContext, { labels: ["nonexistent"] })).toBe(false);
@@ -319,6 +325,23 @@ describe("GitHubWebhookProvider", () => {
       // Fail one criterion
       const filter2: GitHubWebhookFilter = { ...filter, assignee: "wrong" };
       expect(provider.matchesFilter(baseContext, filter2)).toBe(false);
+    });
+
+    it("matches with both repos and orgs criteria", () => {
+      const filter: GitHubWebhookFilter = {
+        repos: ["acme/app"],
+        orgs: ["acme"],
+      };
+      expect(provider.matchesFilter(baseContext, filter)).toBe(true);
+
+      // Test with different repos in same org
+      const otherRepoContext = { ...baseContext, repo: "acme/other" };
+      expect(provider.matchesFilter(otherRepoContext, { orgs: ["acme"] })).toBe(true);
+      expect(provider.matchesFilter(otherRepoContext, { repos: ["acme/app"] })).toBe(false);
+
+      // Test with different org
+      const differentOrgContext = { ...baseContext, repo: "other-org/app" };
+      expect(provider.matchesFilter(differentOrgContext, { orgs: ["acme"] })).toBe(false);
     });
 
     it("skips action filter when context has no action", () => {


### PR DESCRIPTION
Closes #28

This PR adds support for organization-level webhook filtering in addition to the existing repository-level filtering.

## Changes Made

- Added  field to  and  interfaces
- Implemented organization matching logic in 
- Organization is extracted from repository name (e.g., 'acme/app' → 'acme')
- Added both  and  fields to GitHub webhook UI definition for better configuration
- Added comprehensive test coverage for the new organization filtering functionality

## Usage

Users can now configure webhooks to match against entire organizations instead of listing individual repositories:



This allows the webhook to listen for org-wide events, not just repo events, as requested in the issue.

## Testing

All existing tests pass, and new tests verify:
- Organization matching works correctly
- Multiple organizations can be specified
- Organization and repository filters can be used together
- Different repositories within the same organization are matched