### PR TITLE
Add support for custom LLMs

### DIFF
--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -105,22 +105,18 @@ export class AgentRunner {
 
       const authStorage = AuthStorage.create();
       if (model.authType !== "pi_auth") {
-        if (model.provider === "anthropic") {
-          const credential = await backendLoadField("anthropic_key", "default", "token");
+        // Try to load API key using provider-specific credential type
+        const credentialType = `${model.provider}_key`;
+        try {
+          const credential = await backendLoadField(credentialType, "default", "token");
           if (credential) {
-            authStorage.setRuntimeApiKey("anthropic", credential);
+            authStorage.setRuntimeApiKey(model.provider, credential);
+            this.logger.debug(`Loaded ${credentialType} credential for ${model.provider}`);
           } else {
-            this.logger.warn("anthropic_key credential not found — agent may fail to authenticate. Run 'al doctor' to configure it.");
+            this.logger.warn(`${credentialType} credential not found — agent may fail to authenticate. Run 'al doctor' to configure it.`);
           }
-        } else if (model.provider === "openai") {
-          const credential = await backendLoadField("openai_key", "default", "token");
-          if (credential) {
-            authStorage.setRuntimeApiKey("openai", credential);
-          } else {
-            this.logger.warn("openai_key credential not found — agent may fail to authenticate. Run 'al doctor' to configure it.");
-          }
-        } else {
-          this.logger.warn(`Unsupported model provider: ${model.provider}. Supported providers: anthropic, openai`);
+        } catch (err) {
+          this.logger.warn(`Failed to load credential for provider ${model.provider}: ${credentialType} credential type may not be configured.`);
         }
       }
 

--- a/src/credentials/builtins/custom-key.ts
+++ b/src/credentials/builtins/custom-key.ts
@@ -1,0 +1,39 @@
+import type { CredentialDefinition } from "../schema.js";
+import { input, confirm } from "@inquirer/prompts";
+import { CREDENTIALS_DIR } from "../../shared/paths.js";
+
+const customKey: CredentialDefinition = {
+  id: "custom_key",
+  label: "Custom LLM Provider API Credential",
+  description: "API key for custom LLM providers",
+  fields: [
+    { name: "token", label: "API Key", description: "API key for your custom LLM provider", secret: true },
+  ],
+
+  async prompt(existing) {
+    if (existing?.token) {
+      const reuse = await confirm({
+        message: `Found existing custom credential in ${CREDENTIALS_DIR}/custom_key/. Use it?`,
+        default: true,
+      });
+      if (reuse) {
+        console.log(`Using existing custom API key.\n`);
+        return { values: existing, params: { authType: "api_key" } };
+      }
+    }
+
+    const token = (await input({
+      message: "Custom LLM provider API key:",
+      validate: (v) => {
+        v = v.trim();
+        if (v.length === 0) return "API key is required";
+        return true;
+      },
+    })).trim();
+
+    console.log("Custom API key saved. It will be verified on first agent run.\n");
+    return { values: { token }, params: { authType: "api_key" } };
+  },
+};
+
+export default customKey;

--- a/src/credentials/builtins/google-key.ts
+++ b/src/credentials/builtins/google-key.ts
@@ -1,0 +1,39 @@
+import type { CredentialDefinition } from "../schema.js";
+import { input, confirm } from "@inquirer/prompts";
+import { CREDENTIALS_DIR } from "../../shared/paths.js";
+
+const googleKey: CredentialDefinition = {
+  id: "google_key",
+  label: "Google AI API Credential",
+  description: "API key for Google Gemini models",
+  fields: [
+    { name: "token", label: "API Key", description: "Google AI Studio API key", secret: true },
+  ],
+
+  async prompt(existing) {
+    if (existing?.token) {
+      const reuse = await confirm({
+        message: `Found existing Google credential in ${CREDENTIALS_DIR}/google_key/. Use it?`,
+        default: true,
+      });
+      if (reuse) {
+        console.log(`Using existing Google API key.\n`);
+        return { values: existing, params: { authType: "api_key" } };
+      }
+    }
+
+    const token = (await input({
+      message: "Google AI Studio API key:",
+      validate: (v) => {
+        v = v.trim();
+        if (v.length === 0) return "API key is required";
+        return true;
+      },
+    })).trim();
+
+    console.log("Google API key saved. It will be verified on first agent run.\n");
+    return { values: { token }, params: { authType: "api_key" } };
+  },
+};
+
+export default googleKey;

--- a/src/credentials/builtins/groq-key.ts
+++ b/src/credentials/builtins/groq-key.ts
@@ -1,0 +1,40 @@
+import type { CredentialDefinition } from "../schema.js";
+import { input, confirm } from "@inquirer/prompts";
+import { CREDENTIALS_DIR } from "../../shared/paths.js";
+
+const groqKey: CredentialDefinition = {
+  id: "groq_key",
+  label: "Groq API Credential",
+  description: "API key for Groq models (fast inference)",
+  fields: [
+    { name: "token", label: "API Key", description: "Groq API key (gsk_...)", secret: true },
+  ],
+
+  async prompt(existing) {
+    if (existing?.token) {
+      const reuse = await confirm({
+        message: `Found existing Groq credential in ${CREDENTIALS_DIR}/groq_key/. Use it?`,
+        default: true,
+      });
+      if (reuse) {
+        console.log(`Using existing Groq API key.\n`);
+        return { values: existing, params: { authType: "api_key" } };
+      }
+    }
+
+    const token = (await input({
+      message: "Groq API key:",
+      validate: (v) => {
+        v = v.trim();
+        if (v.length === 0) return "API key is required";
+        if (!v.startsWith("gsk_")) return "API key should start with 'gsk_'";
+        return true;
+      },
+    })).trim();
+
+    console.log("Groq API key saved. It will be verified on first agent run.\n");
+    return { values: { token }, params: { authType: "api_key" } };
+  },
+};
+
+export default groqKey;

--- a/src/credentials/builtins/index.ts
+++ b/src/credentials/builtins/index.ts
@@ -2,6 +2,12 @@ import type { CredentialDefinition } from "../schema.js";
 import githubToken from "./github-token.js";
 import anthropicKey from "./anthropic-key.js";
 import openaiKey from "./openai-key.js";
+import groqKey from "./groq-key.js";
+import googleKey from "./google-key.js";
+import xaiKey from "./xai-key.js";
+import mistralKey from "./mistral-key.js";
+import openrouterKey from "./openrouter-key.js";
+import customKey from "./custom-key.js";
 import sentryToken from "./sentry-token.js";
 import gitSsh from "./id-rsa.js";
 import githubWebhookSecret from "./github-webhook-secret.js";
@@ -15,6 +21,12 @@ export const builtinCredentials: Record<string, CredentialDefinition> = {
   "github_token": githubToken,
   "anthropic_key": anthropicKey,
   "openai_key": openaiKey,
+  "groq_key": groqKey,
+  "google_key": googleKey,
+  "xai_key": xaiKey,
+  "mistral_key": mistralKey,
+  "openrouter_key": openrouterKey,
+  "custom_key": customKey,
   "sentry_token": sentryToken,
   "git_ssh": gitSsh,
   "github_webhook_secret": githubWebhookSecret,

--- a/src/credentials/builtins/mistral-key.ts
+++ b/src/credentials/builtins/mistral-key.ts
@@ -1,0 +1,39 @@
+import type { CredentialDefinition } from "../schema.js";
+import { input, confirm } from "@inquirer/prompts";
+import { CREDENTIALS_DIR } from "../../shared/paths.js";
+
+const mistralKey: CredentialDefinition = {
+  id: "mistral_key",
+  label: "Mistral AI API Credential", 
+  description: "API key for Mistral AI models",
+  fields: [
+    { name: "token", label: "API Key", description: "Mistral AI API key", secret: true },
+  ],
+
+  async prompt(existing) {
+    if (existing?.token) {
+      const reuse = await confirm({
+        message: `Found existing Mistral credential in ${CREDENTIALS_DIR}/mistral_key/. Use it?`,
+        default: true,
+      });
+      if (reuse) {
+        console.log(`Using existing Mistral API key.\n`);
+        return { values: existing, params: { authType: "api_key" } };
+      }
+    }
+
+    const token = (await input({
+      message: "Mistral AI API key:",
+      validate: (v) => {
+        v = v.trim();
+        if (v.length === 0) return "API key is required";
+        return true;
+      },
+    })).trim();
+
+    console.log("Mistral API key saved. It will be verified on first agent run.\n");
+    return { values: { token }, params: { authType: "api_key" } };
+  },
+};
+
+export default mistralKey;

--- a/src/credentials/builtins/openrouter-key.ts
+++ b/src/credentials/builtins/openrouter-key.ts
@@ -1,0 +1,40 @@
+import type { CredentialDefinition } from "../schema.js";
+import { input, confirm } from "@inquirer/prompts";
+import { CREDENTIALS_DIR } from "../../shared/paths.js";
+
+const openrouterKey: CredentialDefinition = {
+  id: "openrouter_key",
+  label: "OpenRouter API Credential",
+  description: "API key for OpenRouter (multi-provider access)",
+  fields: [
+    { name: "token", label: "API Key", description: "OpenRouter API key (sk-or-...)", secret: true },
+  ],
+
+  async prompt(existing) {
+    if (existing?.token) {
+      const reuse = await confirm({
+        message: `Found existing OpenRouter credential in ${CREDENTIALS_DIR}/openrouter_key/. Use it?`,
+        default: true,
+      });
+      if (reuse) {
+        console.log(`Using existing OpenRouter API key.\n`);
+        return { values: existing, params: { authType: "api_key" } };
+      }
+    }
+
+    const token = (await input({
+      message: "OpenRouter API key:",
+      validate: (v) => {
+        v = v.trim();
+        if (v.length === 0) return "API key is required";
+        if (!v.startsWith("sk-or-")) return "API key should start with 'sk-or-'";
+        return true;
+      },
+    })).trim();
+
+    console.log("OpenRouter API key saved. It will be verified on first agent run.\n");
+    return { values: { token }, params: { authType: "api_key" } };
+  },
+};
+
+export default openrouterKey;

--- a/src/credentials/builtins/xai-key.ts
+++ b/src/credentials/builtins/xai-key.ts
@@ -1,0 +1,40 @@
+import type { CredentialDefinition } from "../schema.js";
+import { input, confirm } from "@inquirer/prompts";
+import { CREDENTIALS_DIR } from "../../shared/paths.js";
+
+const xaiKey: CredentialDefinition = {
+  id: "xai_key",
+  label: "xAI API Credential",
+  description: "API key for xAI Grok models",
+  fields: [
+    { name: "token", label: "API Key", description: "xAI API key", secret: true },
+  ],
+
+  async prompt(existing) {
+    if (existing?.token) {
+      const reuse = await confirm({
+        message: `Found existing xAI credential in ${CREDENTIALS_DIR}/xai_key/. Use it?`,
+        default: true,
+      });
+      if (reuse) {
+        console.log(`Using existing xAI API key.\n`);
+        return { values: existing, params: { authType: "api_key" } };
+      }
+    }
+
+    const token = (await input({
+      message: "xAI API key:",
+      validate: (v) => {
+        v = v.trim();
+        if (v.length === 0) return "API key is required";
+        if (!v.startsWith("xai-")) return "API key should start with 'xai-'";
+        return true;
+      },
+    })).trim();
+
+    console.log("xAI API key saved. It will be verified on first agent run.\n");
+    return { values: { token }, params: { authType: "api_key" } };
+  },
+};
+
+export default xaiKey;

--- a/src/setup/prompts.ts
+++ b/src/setup/prompts.ts
@@ -1,4 +1,4 @@
-import { input, select, confirm } from "@inquirer/prompts";
+import { input, select, confirm, password } from "@inquirer/prompts";
 import { validateGitHubToken } from "./validators.js";
 import { writeCredentialFields } from "../shared/credentials.js";
 import type { GlobalConfig, ModelConfig } from "../shared/config.js";
@@ -73,17 +73,57 @@ export async function runSetup(): Promise<{
   // Step 2: LLM defaults
   console.log("\n--- Step 2: LLM Defaults ---\n");
 
-  const modelName = await select({
-    message: "Select model:",
+  const provider = await select({
+    message: "Select LLM provider:",
     choices: [
-      { name: "claude-sonnet-4-20250514 (recommended)", value: "claude-sonnet-4-20250514" },
-      { name: "claude-opus-4-20250514", value: "claude-opus-4-20250514" },
-      { name: "claude-haiku-3-5-20241022", value: "claude-haiku-3-5-20241022" },
+      { name: "Anthropic Claude (recommended)", value: "anthropic" },
+      { name: "OpenAI GPT", value: "openai" },
+      { name: "Groq", value: "groq" },
+      { name: "Google Gemini", value: "google" },
+      { name: "xAI Grok", value: "xai" },
+      { name: "Mistral", value: "mistral" },
+      { name: "OpenRouter (multi-provider)", value: "openrouter" },
+      { name: "Other (custom provider)", value: "custom" },
     ],
-    default: "claude-sonnet-4-20250514",
+    default: "anthropic",
   });
 
-  await select({
+  let modelName: string;
+  if (provider === "anthropic") {
+    modelName = await select({
+      message: "Select Anthropic model:",
+      choices: [
+        { name: "claude-sonnet-4-20250514 (recommended)", value: "claude-sonnet-4-20250514" },
+        { name: "claude-opus-4-20250514", value: "claude-opus-4-20250514" },
+        { name: "claude-haiku-3-5-20241022", value: "claude-haiku-3-5-20241022" },
+      ],
+      default: "claude-sonnet-4-20250514",
+    });
+  } else if (provider === "openai") {
+    modelName = await select({
+      message: "Select OpenAI model:",
+      choices: [
+        { name: "gpt-4o (recommended)", value: "gpt-4o" },
+        { name: "gpt-4o-mini", value: "gpt-4o-mini" },
+        { name: "gpt-4-turbo", value: "gpt-4-turbo" },
+        { name: "o1-preview", value: "o1-preview" },
+        { name: "o1-mini", value: "o1-mini" },
+      ],
+      default: "gpt-4o",
+    });
+  } else {
+    modelName = await input({
+      message: `Enter ${provider} model name:`,
+      default: provider === "groq" ? "llama-3.3-70b-versatile" :
+                provider === "google" ? "gemini-2.0-flash-exp" :
+                provider === "xai" ? "grok-beta" :
+                provider === "mistral" ? "mistral-large-2411" :
+                provider === "openrouter" ? "anthropic/claude-3.5-sonnet" :
+                "model-name",
+    });
+  }
+
+  const thinkingLevel = await select({
     message: "Thinking level:",
     choices: [
       { name: "off", value: "off" as const },
@@ -95,8 +135,32 @@ export async function runSetup(): Promise<{
     default: "medium" as const,
   });
 
+  // Prompt for provider-specific credentials
+  if (provider !== "anthropic" && provider !== "openai") {
+    const credentialType = `${provider}_key`;
+    try {
+      const existingCred = resolveCredential(credentialType);
+      await promptAndStoreCredential(existingCred);
+    } catch {
+      // If credential type doesn't exist in registry, prompt manually
+      const apiKey = await password({
+        message: `Enter ${provider} API key:`,
+      });
+      if (apiKey) {
+        writeCredentialFields(credentialType, "default", { token: apiKey });
+      }
+    }
+  }
+
   // Build global config
-  const globalConfig: GlobalConfig = {};
+  const globalConfig: GlobalConfig = {
+    model: {
+      provider,
+      model: modelName,
+      thinkingLevel,
+      authType: "api_key",
+    },
+  };
 
   return {
     globalConfig,

--- a/test/agents/runner.test.ts
+++ b/test/agents/runner.test.ts
@@ -375,13 +375,14 @@ describe("AgentRunner", () => {
     expect(mockPrompt).toHaveBeenCalled();
   });
 
-  it("warns on unsupported provider", async () => {
+  it("supports arbitrary LLM providers", async () => {
     const logger = makeLogger();
-    const warnSpy = vi.spyOn(logger, "warn");
+    const debugSpy = vi.spyOn(logger, "debug");
+    
     const agentConfig = makeAgentConfig({
       model: {
-        provider: "unsupported",
-        model: "some-model",
+        provider: "groq",
+        model: "llama-3.3-70b-versatile",
         thinkingLevel: "medium",
         authType: "api_key",
       },
@@ -391,6 +392,8 @@ describe("AgentRunner", () => {
     mockSubscribe.mockImplementation(() => {});
 
     await runner.run("Test");
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Unsupported model provider"));
+    // Should successfully load groq_key credential and run without warnings
+    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining("Loaded groq_key credential for groq"));
+    expect(mockPrompt).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #27

This PR adds support for arbitrary LLM providers by extending Action Llama beyond just Anthropic Claude and OpenAI.

## Changes Made

### 1. Generic Provider Support in AgentRunner
- Removed hard-coded provider checks for 'anthropic' and 'openai' only
- Implemented generic credential loading using `{provider}_key` pattern
- Any provider can now be used as long as the appropriate credential is configured

### 2. Expanded Setup Options
- Added provider selection during project setup with options for:
  - Anthropic Claude (default)
  - OpenAI GPT
  - Groq
  - Google Gemini
  - xAI Grok
  - Mistral
  - OpenRouter (multi-provider)
  - Custom provider option
- Provider-specific model selection with sensible defaults
- Automatic credential prompting for non-builtin providers

### 3. New Credential Definitions
Added builtin credential support for popular LLM providers:
- `groq_key` - Groq API credentials
- `google_key` - Google AI Studio API credentials  
- `xai_key` - xAI API credentials
- `mistral_key` - Mistral AI API credentials
- `openrouter_key` - OpenRouter API credentials
- `custom_key` - Generic credential for any custom provider

### 4. Test Updates
- Updated tests to verify arbitrary provider support
- Added test for generic credential loading behavior

## Usage

After this change, users can:

1. **Use any provider** supported by the underlying pi-ai library (which supports 20+ providers)
2. **Configure during setup** by selecting from popular providers or entering custom ones
3. **Add new providers later** by manually configuring credentials using `al doctor`

Example config for Groq:
```toml
[model]
provider = "groq"
model = "llama-3.3-70b-versatile"
thinkingLevel = "medium"
authType = "api_key"
```

The system will automatically look for a `groq_key` credential or prompt to create one.

## Backward Compatibility

Fully backward compatible - existing Anthropic and OpenAI configurations continue to work unchanged.