### PR TITLE
Add model provider selection to 'al new' command - make Codex first-class option

### DIFF
--- a/src/cli/commands/new.ts
+++ b/src/cli/commands/new.ts
@@ -1,5 +1,6 @@
 import { resolve } from "path";
 import { execSync } from "child_process";
+import { select } from "@inquirer/prompts";
 import { scaffoldProject } from "../../setup/scaffold.js";
 import { CREDENTIALS_DIR } from "../../shared/paths.js";
 import { resolveCredential } from "../../credentials/registry.js";
@@ -13,33 +14,83 @@ export async function execute(name: string): Promise<void> {
 
   console.log("\n=== Action Llama — New Project ===\n");
 
-  // Only prompt for the Anthropic credential; other credentials are
-  // handled per-agent by `al doctor` (which runs automatically before `al start`).
-  console.log("--- Anthropic Auth ---\n");
-  const anthropicDef = resolveCredential("anthropic_key");
-  const result = await promptCredential(anthropicDef);
+  // Step 1: Choose model provider
+  console.log("--- Model Provider ---\n");
+  const provider = await select({
+    message: "Select model provider:",
+    choices: [
+      { name: "Anthropic Claude (recommended)", value: "anthropic" },
+      { name: "OpenAI GPT/Codex", value: "openai" },
+    ],
+    default: "anthropic",
+  });
+
+  // Step 2: Choose model based on provider
+  let model: string;
+  let thinkingLevel: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+
+  if (provider === "openai") {
+    console.log("\n--- OpenAI Model ---\n");
+    model = await select({
+      message: "Select OpenAI model:",
+      choices: [
+        { name: "gpt-4o (recommended for coding)", value: "gpt-4o" },
+        { name: "gpt-4", value: "gpt-4" },
+        { name: "o1-preview", value: "o1-preview" },
+        { name: "gpt-3.5-turbo", value: "gpt-3.5-turbo" },
+      ],
+      default: "gpt-4o",
+    });
+
+    thinkingLevel = "low"; // OpenAI models work better with lower thinking levels
+  } else {
+    console.log("\n--- Anthropic Model ---\n");
+    model = await select({
+      message: "Select Claude model:",
+      choices: [
+        { name: "claude-sonnet-4-20250514 (recommended)", value: "claude-sonnet-4-20250514" },
+        { name: "claude-opus-4-20250514", value: "claude-opus-4-20250514" },
+        { name: "claude-haiku-3-5-20241022", value: "claude-haiku-3-5-20241022" },
+      ],
+      default: "claude-sonnet-4-20250514",
+    });
+
+    thinkingLevel = "medium";
+  }
+
+  // Step 3: Set up credentials
+  console.log(`\n--- ${provider === "anthropic" ? "Anthropic" : "OpenAI"} Auth ---\n`);
+  
+  const credentialType = provider === "anthropic" ? "anthropic_key" : "openai_key";
+  const credentialDef = resolveCredential(credentialType);
+  const result = await promptCredential(credentialDef);
 
   if (result && Object.keys(result.values).length > 0) {
-    const existing = loadCredentialField("anthropic_key", "default", "token");
+    const existing = loadCredentialField(credentialType, "default", "token");
     const newValue = result.values.token;
     if (newValue && newValue !== existing) {
-      writeCredentialFields("anthropic_key", "default", result.values);
-      console.log(`  Wrote ${CREDENTIALS_DIR}/anthropic_key/default/`);
+      writeCredentialFields(credentialType, "default", result.values);
+      console.log(`  Wrote ${CREDENTIALS_DIR}/${credentialType}/default/`);
     } else {
-      console.log(`  Anthropic key unchanged`);
+      console.log(`  ${provider === "anthropic" ? "Anthropic" : "OpenAI"} key unchanged`);
     }
   } else {
-    console.log("  Using existing pi auth (no key file needed)");
+    if (provider === "anthropic") {
+      console.log("  Using existing pi auth (no key file needed)");
+    } else {
+      console.log("  No API key provided - you'll need to configure it later with 'al doctor'");
+    }
   }
 
   console.log("\n--- Writing configuration ---\n");
 
   const globalConfig: GlobalConfig = {
     model: {
-      provider: "anthropic",
-      model: "claude-sonnet-4-20250514",
-      thinkingLevel: "medium",
-      authType: result ? "api_key" : "pi_auth",
+      provider,
+      model,
+      thinkingLevel,
+      authType: result && Object.keys(result.values).length > 0 ? "api_key" : 
+                (provider === "anthropic" ? "pi_auth" : "api_key"),
     },
   };
 
@@ -55,6 +106,8 @@ export async function execute(name: string): Promise<void> {
   console.log(`
 Setup complete!
 
+  Provider:    ${provider}
+  Model:       ${model}
   Credentials: ${CREDENTIALS_DIR}/
   Project:     ${projectPath}/
 

--- a/test/cli/commands/new.test.ts
+++ b/test/cli/commands/new.test.ts
@@ -6,12 +6,9 @@ vi.mock("../../../src/credentials/prompter.js", () => ({
   promptCredential: (...args: any[]) => mockPromptCredential(...args),
 }));
 
+const mockResolveCredential = vi.fn();
 vi.mock("../../../src/credentials/registry.js", () => ({
-  resolveCredential: () => ({
-    id: "anthropic_key",
-    label: "Anthropic API Credential",
-    fields: [{ name: "token", label: "API Key", secret: true }],
-  }),
+  resolveCredential: (...args: any[]) => mockResolveCredential(...args),
 }));
 
 const mockWriteCredentialFields = vi.fn();
@@ -37,12 +34,19 @@ vi.mock("../../../src/shared/credentials.js", () => ({
   resetDefaultBackend: () => {},
 }));
 
+const mockScaffoldProject = vi.fn();
 vi.mock("../../../src/setup/scaffold.js", () => ({
-  scaffoldProject: vi.fn(),
+  scaffoldProject: (...args: any[]) => mockScaffoldProject(...args),
 }));
 
 vi.mock("child_process", () => ({
   execSync: vi.fn(),
+}));
+
+// Mock inquirer prompts
+const mockSelect = vi.fn();
+vi.mock("@inquirer/prompts", () => ({
+  select: (...args: any[]) => mockSelect(...args),
 }));
 
 import { execute } from "../../../src/cli/commands/new.js";
@@ -51,13 +55,39 @@ describe("new", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockLoadCredentialField.mockReturnValue(undefined);
+    
+    // Default to Anthropic selection
+    mockSelect.mockImplementation(({ choices, default: defaultValue }) => {
+      if (choices.some((c: any) => c.value === "anthropic")) {
+        return Promise.resolve("anthropic");
+      }
+      // For model selection, return the default
+      return Promise.resolve(defaultValue);
+    });
+
+    mockResolveCredential.mockImplementation((id: string) => {
+      if (id === "anthropic_key") {
+        return {
+          id: "anthropic_key",
+          label: "Anthropic API Credential",
+          fields: [{ name: "token", label: "API Key", secret: true }],
+        };
+      } else if (id === "openai_key") {
+        return {
+          id: "openai_key",
+          label: "OpenAI API Credential",
+          fields: [{ name: "token", label: "API Key", secret: true }],
+        };
+      }
+      throw new Error(`Unknown credential: ${id}`);
+    });
   });
 
   it("throws when no project name given", async () => {
     await expect(execute("")).rejects.toThrow();
   });
 
-  it("writes new anthropic credential", async () => {
+  it("writes new anthropic credential when anthropic provider selected", async () => {
     mockPromptCredential.mockResolvedValue({
       values: { token: "sk-ant-api-new" },
       params: { authType: "api_key" },
@@ -66,6 +96,44 @@ describe("new", () => {
     const output = await captureLog(() => execute("my-project"));
     expect(mockWriteCredentialFields).toHaveBeenCalledWith("anthropic_key", "default", { token: "sk-ant-api-new" });
     expect(output).toContain("Setup complete!");
+    expect(output).toContain("Provider:    anthropic");
+  });
+
+  it("writes new openai credential when openai provider selected", async () => {
+    // Mock selecting OpenAI provider and gpt-4o model
+    mockSelect.mockImplementation(({ choices }) => {
+      if (choices.some((c: any) => c.value === "anthropic")) {
+        return Promise.resolve("openai");
+      }
+      return Promise.resolve("gpt-4o");
+    });
+
+    mockPromptCredential.mockResolvedValue({
+      values: { token: "sk-openai-new" },
+      params: { authType: "api_key" },
+    });
+
+    const output = await captureLog(() => execute("my-project"));
+    expect(mockResolveCredential).toHaveBeenCalledWith("openai_key");
+    expect(mockWriteCredentialFields).toHaveBeenCalledWith("openai_key", "default", { token: "sk-openai-new" });
+    expect(output).toContain("Setup complete!");
+    expect(output).toContain("Provider:    openai");
+    expect(output).toContain("Model:       gpt-4o");
+    
+    // Check that the scaffold was called with OpenAI config
+    expect(mockScaffoldProject).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        model: expect.objectContaining({
+          provider: "openai",
+          model: "gpt-4o",
+          thinkingLevel: "low",
+          authType: "api_key",
+        }),
+      }),
+      [],
+      "my-project"
+    );
   });
 
   it("skips unchanged anthropic credential", async () => {
@@ -89,5 +157,37 @@ describe("new", () => {
     const output = await captureLog(() => execute("my-project"));
     expect(mockWriteCredentialFields).not.toHaveBeenCalled();
     expect(output).toContain("Using existing pi auth");
+  });
+
+  it("handles no OpenAI key provided", async () => {
+    // Mock selecting OpenAI provider
+    mockSelect.mockImplementation(({ choices }) => {
+      if (choices.some((c: any) => c.value === "anthropic")) {
+        return Promise.resolve("openai");
+      }
+      return Promise.resolve("gpt-4o");
+    });
+
+    mockPromptCredential.mockResolvedValue({
+      values: {},
+      params: {},
+    });
+
+    const output = await captureLog(() => execute("my-project"));
+    expect(mockWriteCredentialFields).not.toHaveBeenCalled();
+    expect(output).toContain("No API key provided - you'll need to configure it later with 'al doctor'");
+    
+    // Should still create the project with api_key auth type but no credentials
+    expect(mockScaffoldProject).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        model: expect.objectContaining({
+          provider: "openai",
+          authType: "api_key",
+        }),
+      }),
+      [],
+      "my-project"
+    );
   });
 });


### PR DESCRIPTION
Closes #26\n\nThis PR implements model provider selection in the `al new` command, making OpenAI GPT/Codex a first-class option alongside Anthropic Claude.\n\n## Changes\n\n- Modified `src/cli/commands/new.ts` to prompt for model provider selection (Anthropic vs OpenAI)\n- Added model-specific selections with recommended defaults (gpt-4o for OpenAI, claude-sonnet-4-20250514 for Anthropic) \n- Properly handles credentials for both providers\n- Sets appropriate thinking levels (low for OpenAI models, medium for Anthropic)\n- Updated tests to cover both provider paths\n\n## Testing\n\n- All existing tests pass\n- Added new test cases for OpenAI provider selection\n- Tests cover credential handling for both providers\n\n## User Experience\n\nNow when running `npx al new my-project`, users are prompted to:\n1. Select model provider (Anthropic or OpenAI)\n2. Choose specific model based on provider\n3. Configure appropriate credentials\n\nThis addresses the issue where the command previously only looked for Anthropic keys and makes Codex/GPT models easily accessible during project creation.