### PR TITLE
Fix ECS IAM role assumption errors

### DIFF
--- a/.changeset/fix-ecs-role-errors.md
+++ b/.changeset/fix-ecs-role-errors.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Improved error messages for ECS IAM role assumption failures. When an agent fails to start because its task role doesn't exist or can't be assumed, Action Llama now provides clear instructions to run 'al doctor -c' to create the missing per-agent IAM roles. Closes #34.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@action-llama/action-llama",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@action-llama/action-llama",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "^3.1003.0",

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -3,7 +3,7 @@ import { existsSync } from "fs";
 import { confirm } from "@inquirer/prompts";
 import { execFileSync } from "child_process";
 import { STSClient, GetCallerIdentityCommand } from "@aws-sdk/client-sts";
-import { IAMClient, CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { IAMClient, CreateRoleCommand, PutRolePolicyCommand, GetRoleCommand } from "@aws-sdk/client-iam";
 import { discoverAgents, loadAgentConfig, loadGlobalConfig } from "../../shared/config.js";
 import type { CloudConfig } from "../../shared/config.js";
 import { resolveCredential } from "../../credentials/registry.js";
@@ -188,6 +188,12 @@ export async function execute(opts: { project: string; cloud?: boolean; checkOnl
     // Reconcile IAM
     console.log(`\nReconciling cloud IAM...`);
     await reconcileCloudIam(projectPath, cloudConfig);
+    
+    // Validate IAM roles exist for ECS mode
+    if (cloudConfig.provider === "ecs") {
+      console.log(`\nValidating ECS IAM roles...`);
+      await validateEcsRoles(projectPath, cloudConfig);
+    }
   }
 }
 
@@ -531,5 +537,54 @@ function listGsmFields(
     return fields;
   } catch {
     return [];
+  }
+}
+
+async function validateEcsRoles(projectPath: string, cloud: CloudConfig): Promise<void> {
+  const { awsRegion } = cloud;
+  if (!awsRegion) {
+    throw new Error("cloud.awsRegion is required for ECS validation");
+  }
+
+  const agents = discoverAgents(projectPath);
+  if (agents.length === 0) return;
+
+  const iamClient = new IAMClient({ region: awsRegion });
+  const missing: string[] = [];
+
+  for (const name of agents) {
+    const roleName = AWS_CONSTANTS.taskRoleName(name);
+    
+    try {
+      await iamClient.send(new GetRoleCommand({ RoleName: roleName }));
+      console.log(`  [ok] ${roleName}`);
+    } catch (err: any) {
+      if (err.name === "NoSuchEntityException") {
+        missing.push(roleName);
+        console.log(`  [MISSING] ${roleName}`);
+      } else {
+        console.log(`  [ERROR] ${roleName}: ${err.message}`);
+      }
+    }
+  }
+
+  if (missing.length > 0) {
+    console.log(`\n${missing.length} IAM task role(s) are missing.`);
+    console.log("These roles are automatically created when you run 'al doctor -c'.");
+    console.log("If they're still missing, you may need to create them manually:");
+    for (const role of missing) {
+      console.log(`  aws iam create-role --role-name ${role} --assume-role-policy-document file://ecs-trust.json`);
+    }
+    console.log("\nECS task trust policy (save as ecs-trust.json):");
+    console.log(JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [{
+        Effect: "Allow",
+        Principal: { Service: "ecs-tasks.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      }],
+    }, null, 2));
+  } else {
+    console.log(`All ${agents.length} IAM task role(s) exist.`);
   }
 }

--- a/src/docker/ecs-runtime.ts
+++ b/src/docker/ecs-runtime.ts
@@ -484,8 +484,25 @@ export class ECSFargateRuntime implements ContainerRuntime {
       streamPrefix: family,
     });
 
-    const taskArn = await this.runTask(taskDefArn);
-    return taskArn;
+    try {
+      const taskArn = await this.runTask(taskDefArn);
+      return taskArn;
+    } catch (err: any) {
+      // Improve error message for common IAM role issues
+      if (err.message?.includes("Unable to assume the service linked role") || 
+          err.message?.includes("Unable to assume the role")) {
+        const roleName = AWS_CONSTANTS.taskRoleName(opts.agentName);
+        const betterMessage = `Failed to start ECS task for agent "${opts.agentName}". ` +
+          `The IAM task role "${roleName}" either doesn't exist or can't be assumed by ECS.\n\n` +
+          `To fix this issue:\n` +
+          `1. Run 'al doctor -c' to create per-agent IAM roles\n` +
+          `2. Or manually create the role with ECS task trust policy:\n` +
+          `   aws iam create-role --role-name ${roleName} --assume-role-policy-document file://ecs-trust.json\n\n` +
+          `Original error: ${err.message}`;
+        throw new Error(betterMessage);
+      }
+      throw err;
+    }
   }
 
   streamLogs(
@@ -686,6 +703,24 @@ export class ECSFargateRuntime implements ContainerRuntime {
     if (tasks.length === 0) {
       const failures = res.failures || [];
       const reason = failures[0]?.reason || "unknown";
+      
+      // Extract agent name from task definition ARN for better error messages
+      const family = taskDefinitionArn.split("/").pop()?.split(":")[0] ?? "";
+      const agentName = AWS_CONSTANTS.agentNameFromFamily(family);
+      
+      // Provide specific guidance for role assumption failures
+      if (reason.includes("Unable to assume the role") || 
+          reason.includes("arn:aws:iam::") && reason.includes("role/al-")) {
+        throw new Error(
+          `ECS failed to start task for agent "${agentName}": ${reason}\n\n` +
+          `This usually means the IAM task role doesn't exist or has incorrect permissions.\n` +
+          `To fix:\n` +
+          `1. Run 'al doctor -c' to create/update per-agent IAM roles\n` +
+          `2. Verify the role ${AWS_CONSTANTS.taskRoleName(agentName)} exists in your AWS account\n` +
+          `3. Check that the role has the correct ECS task trust policy`
+        );
+      }
+      
       throw new Error(`Failed to start ECS task: ${reason}`);
     }
 


### PR DESCRIPTION
Closes #34

This PR fixes the issue where ECS agents fail to start with confusing error messages when their IAM task roles don't exist or can't be assumed.

## Changes Made

1. **Improved error handling in ECS runtime**: Added specific error messages for IAM role assumption failures that direct users to run `al doctor -c` to create missing roles.

2. **Enhanced runTask error messages**: When ECS fails to start a task due to role issues, the error now includes:
   - The agent name affected
   - Clear instructions to run `al doctor -c`
   - Example commands for manual role creation
   - Explanation of ECS task trust policy requirements

3. **Added IAM role validation**: The `al doctor -c` command now validates that all per-agent IAM roles exist and provides detailed instructions if any are missing.

## Root Cause

The issue occurs when users:
1. Run `al cloud setup` to configure ECS 
2. But forget to run `al doctor -c` to create per-agent IAM roles
3. The ECS runtime tries to use role `al-{agentName}-task-role` but it doesn't exist

## Testing

- All existing tests pass
- Error messages are more actionable and user-friendly
- Added changeset for patch release