### PR TITLE
Add ability to stop and start agents in TUI

### DIFF
--- a/.changeset/agent-tui-controls.md
+++ b/.changeset/agent-tui-controls.md
@@ -1,0 +1,7 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Added ability to stop and start agents in the TUI. Use ↑/↓ arrow keys to select agents and 
+Space to enable/disable them. Disabled agents skip scheduled runs and ignore webhook events. 
+The TUI shows enabled/disabled state and tracks counts in the header. Closes #43.

--- a/src/scheduler/index.ts
+++ b/src/scheduler/index.ts
@@ -575,6 +575,12 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
           type: providerType,
           filter,
           trigger: (context: WebhookContext) => {
+            // Skip if agent is disabled
+            if (statusTracker && !statusTracker.isAgentEnabled(agentConfig.name)) {
+              logger.info({ agent: agentConfig.name, event: context.event }, "agent is disabled, ignoring webhook event");
+              return;
+            }
+            
             const availableRunner = pool.getAvailableRunner();
             if (!availableRunner) {
               const { accepted, dropped } = webhookQueue.enqueue(agentConfig.name, context);
@@ -601,7 +607,7 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
               if (triggers.length > 0) {
                 dispatchTriggers(triggers, agentConfig.name, 0, schedulerCtx);
               }
-              // Drain any events that queued while this webhook run was executing
+              // Drain any events that queued while this webhook run was executed
               return drainWebhookQueue(agentConfig, schedulerCtx);
             }).catch((err) => {
               logger.error({ err }, `${agentConfig.name} webhook run failed`);
@@ -621,6 +627,12 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
     const pool = runnerPools[agentConfig.name];
 
     const job = new Cron(agentConfig.schedule, { timezone }, async () => {
+      // Skip if agent is disabled
+      if (statusTracker && !statusTracker.isAgentEnabled(agentConfig.name)) {
+        logger.info({ agent: agentConfig.name }, "agent is disabled, skipping scheduled run");
+        return;
+      }
+      
       const availableRunner = pool.getAvailableRunner();
       if (!availableRunner) {
         logger.warn({ agent: agentConfig.name, running: pool.countRunning(), parallelism: pool.parallelism }, "all agent runners busy, skipping scheduled run");
@@ -655,6 +667,39 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
     logger.info({ url }, "Webhook endpoint registered");
   }
   logger.info(`Scheduler running with ${cronJobs.length} scheduled jobs`);
+
+  // Handle agent enable/disable events
+  if (statusTracker) {
+    // Create a map of agent name to cron job for easy lookup
+    const agentCronJobs = new Map<string, Cron>();
+    for (let i = 0; i < agentConfigs.length; i++) {
+      const config = agentConfigs[i];
+      if (config.schedule && cronJobs[i]) {
+        agentCronJobs.set(config.name, cronJobs[i]);
+      }
+    }
+
+    statusTracker.on("agent-enabled", (agentName: string) => {
+      const job = agentCronJobs.get(agentName);
+      if (job) {
+        job.resume();
+        const nextRun = job.nextRun();
+        if (nextRun) {
+          statusTracker.setNextRunAt(agentName, nextRun);
+        }
+        logger.info({ agent: agentName }, "agent enabled, cron job resumed");
+      }
+    });
+
+    statusTracker.on("agent-disabled", (agentName: string) => {
+      const job = agentCronJobs.get(agentName);
+      if (job) {
+        job.pause();
+        statusTracker.setNextRunAt(agentName, null);
+        logger.info({ agent: agentName }, "agent disabled, cron job paused");
+      }
+    });
+  }
 
   // Fire initial run for scheduled agents
   for (const agentConfig of agentConfigs) {

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Box, Text } from "ink";
+import { Box, Text, useInput } from "ink";
 import type { StatusTracker, AgentStatus, SchedulerInfo, LogLine } from "./status-tracker.js";
 
 function formatRelativeTime(date: Date | null): string {
@@ -36,7 +36,7 @@ function formatTime(date: Date): string {
   return date.toLocaleTimeString("en-US", { hour12: false });
 }
 
-function Header({ info, agentCount }: { info: SchedulerInfo | null; agentCount: number }) {
+function Header({ info, agentCount, agents }: { info: SchedulerInfo | null; agentCount: number; agents: AgentStatus[] }) {
   if (!info) return null;
   const isCloud = info.mode === "docker" && info.runtime && info.runtime !== "local";
   const runtimeLabels: Record<string, string> = {
@@ -48,10 +48,15 @@ function Header({ info, agentCount }: { info: SchedulerInfo | null; agentCount: 
     : isCloud
       ? runtimeLabels[info.runtime!] || "Cloud mode"
       : "Docker mode";
+  
+  const enabledCount = agents.filter(a => a.enabled).length;
+  const disabledCount = agentCount - enabledCount;
+  
   return (
     <Box flexDirection="column">
       <Text bold>
-        Action Llama ({modeLabel}) — {agentCount} agent{agentCount !== 1 ? "s" : ""}, {info.cronJobCount} cron job{info.cronJobCount !== 1 ? "s" : ""}
+        Action Llama ({modeLabel}) — {agentCount} agent{agentCount !== 1 ? "s" : ""} 
+        ({enabledCount} enabled{disabledCount > 0 ? `, ${disabledCount} disabled` : ""}), {info.cronJobCount} cron job{info.cronJobCount !== 1 ? "s" : ""}
       </Text>
       <Text dimColor>
         {info.gatewayPort ? `Gateway: :${info.gatewayPort}` : ""}
@@ -72,7 +77,7 @@ function Header({ info, agentCount }: { info: SchedulerInfo | null; agentCount: 
   );
 }
 
-function AgentRow({ agent }: { agent: AgentStatus }) {
+function AgentRow({ agent, isSelected }: { agent: AgentStatus; isSelected: boolean }) {
   const stateColor = agent.state === "running" ? "green" : agent.state === "building" ? "yellow" : agent.state === "error" ? "red" : "white";
   const stateLabel = agent.state === "running" ? "Running" : agent.state === "building" ? "Building" : agent.state === "error" ? "Error" : "Idle";
 
@@ -83,31 +88,39 @@ function AgentRow({ agent }: { agent: AgentStatus }) {
       ? agent.lastError
       : "";
 
+  const enabledLabel = agent.enabled ? "Enabled" : "Disabled";
+  const enabledColor = agent.enabled ? "green" : "yellow";
+
   return (
     <Box flexDirection="column">
-      <Box>
+      <Box backgroundColor={isSelected ? "blue" : undefined}>
         <Box width={12}>
-          <Text bold>{agent.name}</Text>
+          <Text bold color={isSelected ? "white" : undefined}>
+            {isSelected ? "▶ " : "  "}{agent.name}
+          </Text>
         </Box>
         <Box width={10}>
-          <Text color={stateColor}>{stateLabel}</Text>
+          <Text color={isSelected ? "white" : stateColor}>{stateLabel}</Text>
+        </Box>
+        <Box width={10}>
+          <Text color={isSelected ? "white" : enabledColor}>{enabledLabel}</Text>
         </Box>
         <Box width={30}>
-          <Text dimColor>
+          <Text dimColor={!isSelected}>
             {agent.lastRunAt
               ? `Last: ${formatRelativeTime(agent.lastRunAt)}${agent.lastRunDuration !== null ? ` (${formatDuration(agent.lastRunDuration)})` : ""}`
               : ""}
           </Text>
         </Box>
         <Box>
-          <Text dimColor>
+          <Text dimColor={!isSelected}>
             {agent.nextRunAt ? `Next: ${formatTimeUntil(agent.nextRunAt)}` : ""}
           </Text>
         </Box>
       </Box>
       {detail ? (
         <Box paddingLeft={2}>
-          <Text color={agent.state === "error" ? "red" : undefined} dimColor={agent.state !== "error"} wrap="truncate-end">
+          <Text color={agent.state === "error" ? "red" : undefined} dimColor={agent.state !== "error" || isSelected} wrap="truncate-end">
             {detail.slice(0, 120)}
           </Text>
         </Box>
@@ -135,7 +148,7 @@ function Footer() {
   return (
     <Box flexDirection="column">
       <Text dimColor>{"─".repeat(50)}</Text>
-      <Text dimColor>Ctrl+C to stop</Text>
+      <Text dimColor>↑/↓: Select agent • Space: Enable/Disable • Ctrl+C: Stop</Text>
     </Box>
   );
 }
@@ -144,13 +157,38 @@ export default function App({ statusTracker }: { statusTracker: StatusTracker })
   const [agents, setAgents] = useState<AgentStatus[]>(() => statusTracker.getAllAgents());
   const [info, setInfo] = useState<SchedulerInfo | null>(() => statusTracker.getSchedulerInfo());
   const [logs, setLogs] = useState<LogLine[]>(() => statusTracker.getRecentLogs(5));
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const [, setTick] = useState(0);
+
+  useInput((input, key) => {
+    if (key.upArrow) {
+      setSelectedIndex((prev) => Math.max(0, prev - 1));
+    } else if (key.downArrow) {
+      setSelectedIndex((prev) => Math.min(agents.length - 1, prev + 1));
+    } else if (input === " " && agents.length > 0) {
+      // Toggle agent enabled/disabled state
+      const selectedAgent = agents[selectedIndex];
+      if (selectedAgent) {
+        if (selectedAgent.enabled) {
+          statusTracker.disableAgent(selectedAgent.name);
+        } else {
+          statusTracker.enableAgent(selectedAgent.name);
+        }
+      }
+    }
+  });
 
   useEffect(() => {
     const update = () => {
-      setAgents(statusTracker.getAllAgents());
+      const newAgents = statusTracker.getAllAgents();
+      setAgents(newAgents);
       setInfo(statusTracker.getSchedulerInfo());
       setLogs(statusTracker.getRecentLogs(5));
+      
+      // Adjust selection if agents list changed
+      if (selectedIndex >= newAgents.length) {
+        setSelectedIndex(Math.max(0, newAgents.length - 1));
+      }
     };
 
     statusTracker.on("update", update);
@@ -163,14 +201,14 @@ export default function App({ statusTracker }: { statusTracker: StatusTracker })
       statusTracker.off("update", update);
       clearInterval(timer);
     };
-  }, [statusTracker]);
+  }, [statusTracker, selectedIndex]);
 
   return (
     <Box flexDirection="column" paddingTop={1}>
-      <Header info={info} agentCount={agents.length} />
+      <Header info={info} agentCount={agents.length} agents={agents} />
       <Box flexDirection="column" paddingTop={1} paddingBottom={1}>
-        {agents.map((agent) => (
-          <AgentRow key={agent.name} agent={agent} />
+        {agents.map((agent, index) => (
+          <AgentRow key={agent.name} agent={agent} isSelected={index === selectedIndex} />
         ))}
       </Box>
       <RecentActivity logs={logs} />

--- a/src/tui/status-tracker.ts
+++ b/src/tui/status-tracker.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "events";
 export interface AgentStatus {
   name: string;
   state: "idle" | "running" | "building" | "error";
+  enabled: boolean;
   statusText: string | null;
   lastError: string | null;
   lastRunAt: Date | null;
@@ -38,6 +39,7 @@ export class StatusTracker extends EventEmitter {
     this.agents.set(name, {
       name,
       state: "idle",
+      enabled: true,
       statusText: null,
       lastError: null,
       lastRunAt: null,
@@ -98,6 +100,28 @@ export class StatusTracker extends EventEmitter {
     if (!agent) return;
     agent.nextRunAt = nextRunAt;
     this.emit("update");
+  }
+
+  enableAgent(name: string): void {
+    const agent = this.agents.get(name);
+    if (!agent) return;
+    agent.enabled = true;
+    this.emit("update");
+    this.emit("agent-enabled", name);
+  }
+
+  disableAgent(name: string): void {
+    const agent = this.agents.get(name);
+    if (!agent) return;
+    agent.enabled = false;
+    agent.nextRunAt = null; // Clear next run time when disabled
+    this.emit("update");
+    this.emit("agent-disabled", name);
+  }
+
+  isAgentEnabled(name: string): boolean {
+    const agent = this.agents.get(name);
+    return agent ? agent.enabled : false;
   }
 
   setSchedulerInfo(info: SchedulerInfo): void {

--- a/test/tui/App.test.tsx
+++ b/test/tui/App.test.tsx
@@ -97,7 +97,7 @@ describe("App TUI", () => {
     instance = render(<App statusTracker={tracker} />);
     const output = instance.lastFrame()!;
 
-    expect(output).toContain("Ctrl+C to stop");
+    expect(output).toContain("Ctrl+C: Stop");
   });
 
   it("renders error state with detail", () => {


### PR DESCRIPTION
Closes #43

This PR adds interactive controls to the TUI that allow users to stop and start agents.

## Changes Made

- **StatusTracker**: Added  field to  and methods to enable/disable agents
- **Scheduler**: Modified cron job and webhook handling to respect agent enabled/disabled state
- **TUI**: Made the interface interactive with:
  - Arrow key navigation (↑/↓) to select agents
  - Space bar to toggle agent enabled/disabled state
  - Visual selection indicators and enabled/disabled status display
- **Tests**: Updated existing test to match new footer text

## How it works

- Use ↑/↓ arrow keys to navigate between agents
- Press Space to enable/disable the selected agent
- Disabled agents:
  - Skip scheduled cron runs
  - Ignore incoming webhook events
  - Show as "Disabled" in the status column
  - Have their next run time cleared
- The TUI header shows counts of enabled vs disabled agents
- All changes are logged appropriately

This provides a clean, intuitive way to control agent execution without stopping the entire scheduler.