### PR TITLE
fix: rename parallelism to scale in agent config

### DIFF
--- a/.changeset/rename-parallelism-to-scale.md
+++ b/.changeset/rename-parallelism-to-scale.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Renamed `parallelism` config field to `scale` in agent-config.toml. The field controls how many instances of an agent can run concurrently. Updated all documentation, tests, and log messages to use the new naming. Closes #45.

--- a/docs/agent-config-reference.md
+++ b/docs/agent-config-reference.md
@@ -14,7 +14,7 @@ credentials = ["github_token:default", "git_ssh:default", "sentry_token:default"
 schedule = "*/5 * * * *"
 
 # Optional: number of concurrent runs allowed (default: 1)
-parallelism = 2
+scale = 2
 
 # Required: LLM model configuration
 [model]
@@ -51,7 +51,7 @@ sentryProjects = ["web-app", "api"]
 |-------|------|----------|-------------|
 | `credentials` | string[] | Yes | Credential refs as `"type:instance"` needed at runtime |
 | `schedule` | string | No* | Cron expression for polling |
-| `parallelism` | number | No | Number of concurrent runs allowed (default: 1) |
+| `scale` | number | No | Number of concurrent runs allowed (default: 1) |
 | `model` | table | No | LLM model configuration (falls back to `[model]` in project `config.toml`) |
 | `model.provider` | string | Yes* | LLM provider ("anthropic", "openai", "groq", "google", "xai", "mistral", "openrouter", or "custom") |
 | `model.model` | string | Yes* | Model ID |
@@ -62,9 +62,9 @@ sentryProjects = ["web-app", "api"]
 
 *At least one of `schedule` or `webhooks` is required. *Required within `[model]` if the agent defines its own model block (otherwise inherits from project `config.toml`).
 
-## Parallelism
+## Scale
 
-The `parallelism` field controls how many instances of an agent can run concurrently. This is useful for agents that handle high-volume workloads or when you want to process multiple tasks simultaneously.
+The `scale` field controls how many instances of an agent can run concurrently. This is useful for agents that handle high-volume workloads or when you want to process multiple tasks simultaneously.
 
 - **Default**: 1 (only one instance can run at a time)
 - **Minimum**: 1 
@@ -78,9 +78,9 @@ The `parallelism` field controls how many instances of an agent can run concurre
 
 ### Example use cases
 
-- **Dev agent** with `parallelism = 3`: Handle multiple GitHub issues simultaneously
-- **Review agent** with `parallelism = 2`: Review multiple PRs in parallel
-- **Monitoring agent** with `parallelism = 1`: Ensure only one instance processes alerts at a time
+- **Dev agent** with `scale = 3`: Handle multiple GitHub issues simultaneously
+- **Review agent** with `scale = 2`: Review multiple PRs in parallel
+- **Monitoring agent** with `scale = 1`: Ensure only one instance processes alerts at a time
 
 ### Resource considerations
 

--- a/src/scheduler/index.ts
+++ b/src/scheduler/index.ts
@@ -24,7 +24,7 @@ interface RunnerLike {
 
 interface AgentRunnerPool {
   runners: RunnerLike[];
-  parallelism: number;
+  scale: number;
   getAvailableRunner(): RunnerLike | null;
   isAllRunning(): boolean;
   countRunning(): number;
@@ -108,10 +108,10 @@ function dispatchTriggers(
     const pool = ctx.runnerPools[agent];
     const availableRunner = pool.getAvailableRunner();
     if (!availableRunner) {
-      ctx.logger.warn({ source: sourceAgent, target: agent, running: pool.countRunning(), parallelism: pool.parallelism }, "all agent runners busy, skipping trigger");
+      ctx.logger.warn({ source: sourceAgent, target: agent, running: pool.countRunning(), scale: pool.scale }, "all agent runners busy, skipping trigger");
       continue;
     }
-    ctx.logger.info({ source: sourceAgent, target: agent, depth, running: pool.countRunning(), parallelism: pool.parallelism }, "agent trigger firing");
+    ctx.logger.info({ source: sourceAgent, target: agent, depth, running: pool.countRunning(), scale: pool.scale }, "agent trigger firing");
     const prompt = buildTriggeredPrompt(targetConfig, sourceAgent, context);
     runTriggered(availableRunner, targetConfig, prompt, sourceAgent, depth + 1, ctx).catch((err) => {
       ctx.logger.error({ err, target: agent }, "triggered run failed");
@@ -153,7 +153,7 @@ async function drainWebhookQueue(
     
     const ageMs = Date.now() - event.receivedAt.getTime();
     ctx.logger.info(
-      { agent: agentConfig.name, event: event.context.event, ageMs, remaining: ctx.webhookQueue.size(agentConfig.name), running: pool.countRunning(), parallelism: pool.parallelism },
+      { agent: agentConfig.name, event: event.context.event, ageMs, remaining: ctx.webhookQueue.size(agentConfig.name), running: pool.countRunning(), scale: pool.scale },
       "processing queued webhook event"
     );
     try {
@@ -506,10 +506,10 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
     : (_secret: string) => {};
 
   function createAgentRunnerPool(agentConfig: AgentConfig): AgentRunnerPool {
-    const parallelism = agentConfig.parallelism || 1;
+    const scale = agentConfig.scale || 1;
     const runners: RunnerLike[] = [];
     
-    for (let i = 0; i < parallelism; i++) {
+    for (let i = 0; i < scale; i++) {
       if (dockerEnabled && runtime && ContainerAgentRunnerClass) {
         runners.push(new ContainerAgentRunnerClass(
           runtime,
@@ -536,7 +536,7 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
 
     return {
       runners,
-      parallelism,
+      scale,
       getAvailableRunner(): RunnerLike | null {
         return runners.find(r => !r.isRunning) || null;
       },
@@ -551,7 +551,7 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
 
   for (const agentConfig of agentConfigs) {
     runnerPools[agentConfig.name] = createAgentRunnerPool(agentConfig);
-    logger.info({ agent: agentConfig.name, parallelism: agentConfig.parallelism || 1 }, "Created agent runner pool");
+    logger.info({ agent: agentConfig.name, scale: agentConfig.scale || 1 }, "Created agent runner pool");
   }
 
   const webhookQueueSize = globalConfig.webhookQueueSize ?? 20;
@@ -586,7 +586,7 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
               const { accepted, dropped } = webhookQueue.enqueue(agentConfig.name, context);
               if (accepted) {
                 logger.info(
-                  { agent: agentConfig.name, event: context.event, queueSize: webhookQueue.size(agentConfig.name), running: pool.countRunning(), parallelism: pool.parallelism },
+                  { agent: agentConfig.name, event: context.event, queueSize: webhookQueue.size(agentConfig.name), running: pool.countRunning(), scale: pool.scale },
                   "all agent runners busy, webhook event queued"
                 );
               }
@@ -599,7 +599,7 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
               return;
             }
             logger.info(
-              { agent: agentConfig.name, event: context.event, action: context.action, running: pool.countRunning(), parallelism: pool.parallelism },
+              { agent: agentConfig.name, event: context.event, action: context.action, running: pool.countRunning(), scale: pool.scale },
               "webhook triggering agent"
             );
             const prompt = buildWebhookPrompt(agentConfig, context);
@@ -635,10 +635,10 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
       
       const availableRunner = pool.getAvailableRunner();
       if (!availableRunner) {
-        logger.warn({ agent: agentConfig.name, running: pool.countRunning(), parallelism: pool.parallelism }, "all agent runners busy, skipping scheduled run");
+        logger.warn({ agent: agentConfig.name, running: pool.countRunning(), scale: pool.scale }, "all agent runners busy, skipping scheduled run");
         return;
       }
-      logger.info({ agent: agentConfig.name, running: pool.countRunning(), parallelism: pool.parallelism }, "triggering scheduled run");
+      logger.info({ agent: agentConfig.name, running: pool.countRunning(), scale: pool.scale }, "triggering scheduled run");
       await runWithReruns(availableRunner, agentConfig, 0, schedulerCtx);
     });
 

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -69,7 +69,7 @@ export interface AgentConfig {
   schedule?: string;
   webhooks?: WebhookTrigger[];
   params?: Record<string, unknown>;
-  parallelism?: number; // Number of concurrent runs allowed (default: 1)
+  scale?: number; // Number of concurrent runs allowed (default: 1)
 }
 
 // --- Loaders ---

--- a/test/scheduler/index.test.ts
+++ b/test/scheduler/index.test.ts
@@ -116,10 +116,10 @@ describe("startScheduler", () => {
     const { runnerPools } = await startScheduler(tmpDir);
     expect(Object.keys(runnerPools).sort()).toEqual(["dev", "devops", "reviewer"]);
     
-    // Each pool should have default parallelism of 1
+    // Each pool should have default scale of 1
     for (const poolName of Object.keys(runnerPools)) {
       const pool = runnerPools[poolName];
-      expect(pool.parallelism).toBe(1);
+      expect(pool.scale).toBe(1);
       expect(pool.runners).toHaveLength(1);
     }
   });
@@ -144,7 +144,7 @@ describe("startScheduler", () => {
       expect.objectContaining({
         agent: "dev",
         running: 1,
-        parallelism: 1,
+        scale: 1,
       }),
       "all agent runners busy, skipping scheduled run"
     );
@@ -262,14 +262,14 @@ describe("startScheduler", () => {
     );
   });
 
-  describe("parallelism", () => {
-    function setupParallelismProject(tmpDir: string) {
+  describe("scale", () => {
+    function setupScaleProject(tmpDir: string) {
       const globalConfig = {};
       writeFileSync(resolve(tmpDir, "config.toml"), stringifyTOML(globalConfig as Record<string, unknown>));
 
       const model = { provider: "anthropic", model: "claude-sonnet-4-20250514", thinkingLevel: "medium", authType: "api_key" };
       const agents = [
-        { name: "parallel-agent", credentials: ["github_token:default"], model, schedule: "*/5 * * * *", parallelism: 3 },
+        { name: "scaled-agent", credentials: ["github_token:default"], model, schedule: "*/5 * * * *", scale: 3 },
         { name: "single-agent", credentials: ["github_token:default"], model, schedule: "*/5 * * * *" }, // defaults to 1
       ];
 
@@ -287,23 +287,23 @@ describe("startScheduler", () => {
       vi.clearAllMocks();
       cronCallbacks.length = 0;
       mockIsRunning = false;
-      tmpDir = mkdtempSync(join(tmpdir(), "al-sched-parallel-"));
-      setupParallelismProject(tmpDir);
+      tmpDir = mkdtempSync(join(tmpdir(), "al-sched-scale-"));
+      setupScaleProject(tmpDir);
     });
 
-    it("creates multiple runners when parallelism > 1", async () => {
+    it("creates multiple runners when scale > 1", async () => {
       const { runnerPools } = await startScheduler(tmpDir);
       
-      // parallel-agent should have 3 runners
-      expect(runnerPools["parallel-agent"].parallelism).toBe(3);
-      expect(runnerPools["parallel-agent"].runners).toHaveLength(3);
+      // scaled-agent should have 3 runners
+      expect(runnerPools["scaled-agent"].scale).toBe(3);
+      expect(runnerPools["scaled-agent"].runners).toHaveLength(3);
       
       // single-agent should have 1 runner (default)
-      expect(runnerPools["single-agent"].parallelism).toBe(1);
+      expect(runnerPools["single-agent"].scale).toBe(1);
       expect(runnerPools["single-agent"].runners).toHaveLength(1);
     });
 
-    it("allows concurrent runs up to parallelism limit", async () => {
+    it("allows concurrent runs up to scale limit", async () => {
       // Mock some runners as running
       const runningStates = new Map<number, boolean>();
       let callIndex = 0;
@@ -336,13 +336,13 @@ describe("startScheduler", () => {
       // Trigger multiple cron runs quickly
       const cronPromises = [];
       for (let i = 0; i < 5; i++) {
-        cronPromises.push(cronCallbacks[0]()); // parallel-agent cron
+        cronPromises.push(cronCallbacks[0]()); // scaled-agent cron
       }
 
       // Wait for all to settle
       await Promise.all(cronPromises);
 
-      // parallel-agent can run up to 3 concurrent instances
+      // scaled-agent can run up to 3 concurrent instances
       // single-agent can run 1 instance
       // The exact number depends on timing, but we should see multiple calls
       expect(mockRun).toHaveBeenCalled();
@@ -361,7 +361,7 @@ describe("startScheduler", () => {
         name: "webhook-agent", 
         credentials: ["github_token:default"], 
         model: { provider: "anthropic", model: "claude-sonnet-4-20250514", thinkingLevel: "medium", authType: "api_key" },
-        parallelism: 2,
+        scale: 2,
         webhooks: [{ source: "github", events: ["issues"], actions: ["opened"] }]
       };
       
@@ -375,8 +375,8 @@ describe("startScheduler", () => {
       
       const { runnerPools } = await startScheduler(tmpDir);
       
-      // Verify webhook agent has parallelism of 2
-      expect(runnerPools["webhook-agent"].parallelism).toBe(2);
+      // Verify webhook agent has scale of 2
+      expect(runnerPools["webhook-agent"].scale).toBe(2);
       expect(runnerPools["webhook-agent"].runners).toHaveLength(2);
     });
   });


### PR DESCRIPTION
Closes #45\n\nRenames the `parallelism` config field to `scale` in agent-config.toml as requested. This change:\n\n- Updates the AgentConfig interface to use `scale` instead of `parallelism`\n- Updates all log messages and internal references\n- Updates documentation in agent-config-reference.md\n- Updates all tests to use the new field name\n- Includes a changeset for the rename\n\nThe field continues to control how many instances of an agent can run concurrently, with a default value of 1.