### PR TITLE
Rename parallelism to scale

### DIFF
--- a/src/scheduler/index.ts
+++ b/src/scheduler/index.ts
@@ -489,7 +489,7 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
     logger.info("Docker infrastructure ready");
   }
 
-  // Create runner pools for each agent with configurable parallelism
+  // Create runner pools for each agent with configurable scale
   const runnerPools: Record<string, AgentRunnerPool> = {};
 
   // Import necessary classes once if docker is enabled


### PR DESCRIPTION
Closes #45\n\nRenames the remaining 'parallelism' reference to 'scale' in the scheduler comment. This completes the transition from 'parallelism' to 'scale' configuration field for controlling concurrent agent instances.\n\nChanges:\n- Updated comment in scheduler/index.ts from 'configurable parallelism' to 'configurable scale'\n- Changeset already exists for this change\n- All tests pass