### PR TITLE
Auto-enable gateway when using -w flag

### DIFF
--- a/.changeset/auto-enable-gateway-for-web-ui.md
+++ b/.changeset/auto-enable-gateway-for-web-ui.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+The `-w` flag now automatically enables the gateway, eliminating the need to specify both `-g` and `-w` flags. Users can now simply use `al start -w` to enable the web dashboard. Closes #76.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@action-llama/action-llama",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@action-llama/action-llama",
-      "version": "0.10.2",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-apprunner": "^3.1006.0",

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -16,9 +16,9 @@ export async function execute(opts: { project: string; cloud?: boolean; headless
     );
   }
 
-  // Validate: --web-ui requires --gateway
+  // Auto-enable gateway when web UI is requested
   if (opts.webUi && !opts.gateway) {
-    throw new Error("--web-ui requires --gateway (-g). The web dashboard is served by the gateway.");
+    opts.gateway = true;
   }
 
   // Ensure all credentials are present before starting

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -76,7 +76,7 @@ program
   .option("-c, --cloud", "run on cloud infrastructure")
   .option("-H, --headless", "non-interactive mode (no TUI, no credential prompts, for CI/deploy environments)")
   .option("-g, --gateway", "enable the HTTP gateway server (required for webhooks, locks, and web UI)")
-  .option("-w, --web-ui", "enable web dashboard at http://localhost:<port>/dashboard (requires -g)")
+  .option("-w, --web-ui", "enable web dashboard at http://localhost:<port>/dashboard (auto-enables gateway)")
   .action(withCommand(async (opts) => {
     initializeTelemetryForProject(opts.project);
     const { execute } = await import("./commands/start.js");


### PR DESCRIPTION
Closes #76

This change improves the user experience by automatically enabling the gateway when the  flag is used. Users no longer need to specify both  and  flags.

## Changes
- Modified  to automatically set  when  is true
- Updated CLI help text to reflect that the gateway is auto-enabled
- Added changeset documenting the improvement

## Benefits  
- Simpler command:  instead of 
- More intuitive UX - web UI obviously needs the gateway to function
- Backward compatible - existing  usage still works