### PR TITLE
Add -w flag to enable webview in scheduler runtime ENTRYPOINT

### DIFF
--- a/src/cloud/scheduler-image.ts
+++ b/src/cloud/scheduler-image.ts
@@ -103,7 +103,7 @@ function generateDockerfile(): string {
     "EXPOSE 8080",
     "",
     'ENTRYPOINT ["node", "dist/cli/main.js", "start", \\',
-    '  "-p", "/app/static/project", "-c", "--headless", "--gateway"]',
+    '  "-p", "/app/static/project", "-c", "--headless", "--gateway", "-w"]',
     "",
   ].join("\n");
 }


### PR DESCRIPTION
Closes #78

Adds the  flag to the scheduler runtime ENTRYPOINT to enable the web dashboard in cloud deployments.

**Changes:**
- Modified  to include the  flag in the Docker ENTRYPOINT
- This enables the web dashboard at  for scheduler containers

**Testing:**
- Build passes ✅
- All 677 tests pass ✅