### PR TITLE
Rename cloud commands: al cloud setup/teardown to al setup/teardown cloud

### DIFF
--- a/.changeset/rename-cloud-commands.md
+++ b/.changeset/rename-cloud-commands.md
@@ -1,0 +1,9 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Renamed CLI commands for better consistency. The cloud setup and teardown commands 
+have been restructured from `al cloud setup`/`al cloud teardown` to 
+`al setup cloud`/`al teardown cloud`. This change provides a more logical command 
+hierarchy and better aligns with potential future setup/teardown operations for 
+other infrastructure types. Closes #80.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Action Llama supports:
 - more by request
 
 ```bash
-al cloud setup    # Interactive wizard: pick provider, configure, push creds, provision IAM
+al setup cloud    # Interactive wizard: pick provider, configure, push creds, provision IAM
 al start -c      # Start on cloud
 ```
 
@@ -111,8 +111,8 @@ Commands generally have two modes: local or cloud.
 | `al new <name>` | Interactive setup — creates project directory and credentials |
 | `al chat [agent]` | Interactive console — or agent-scoped session with credentials loaded |
 | `al doctor` | Check agents, credentials, webhooks, and config — prompt to fix |
-| `al cloud setup` | Interactive wizard for cloud provider setup |
-| `al cloud teardown` | Delete cloud IAM resources and remove cloud config |
+| `al setup cloud` | Interactive wizard for cloud provider setup |
+| `al teardown cloud` | Delete cloud IAM resources and remove cloud config |
 | `al creds ls` | List stored credentials (names only, no secrets) |
 | `al run <agent>` | Manually run a single agent |
 | `al start` | Start the scheduler (cron + webhooks) |

--- a/docs/cloud-run.md
+++ b/docs/cloud-run.md
@@ -45,7 +45,7 @@ Local Docker settings (`[local]`) control resource limits:
 The fastest way to get started:
 
 ```bash
-al cloud setup -p .
+al setup cloud -p .
 ```
 
 This interactive wizard prompts for all required fields, writes the `[cloud]` config, pushes credentials, and provisions IAM in one step.

--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -7,7 +7,7 @@ Action Llama supports two cloud providers. Both use the same project structure a
 ## Quick start
 
 ```bash
-al cloud setup -p .   # Interactive wizard: pick provider, configure, push creds, provision IAM
+al setup cloud -p .   # Interactive wizard: pick provider, configure, push creds, provision IAM
 al start -c -p .     # Start on cloud
 ```
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -104,26 +104,26 @@ al creds rm github_webhook_secret:myapp
 
 Removes all field files for the credential instance. If the type directory becomes empty, it is also removed.
 
-## `al cloud setup`
+## `al setup cloud`
 
 Interactive wizard for configuring cloud infrastructure. Prompts for provider selection and provider-specific fields, writes `[cloud]` to config.toml, pushes credentials, and provisions IAM — all in one shot.
 
 If an existing `[cloud]` config is found, you'll be prompted to tear down the old infrastructure first.
 
 ```bash
-al cloud setup -p .
+al setup cloud -p .
 ```
 
 | Option | Description |
 |--------|-------------|
 | `-p, --project <dir>` | Project directory (default: `.`) |
 
-## `al cloud teardown`
+## `al teardown cloud`
 
 Deletes per-agent IAM resources (service accounts for Cloud Run, task roles for ECS) and removes the `[cloud]` section from config.toml.
 
 ```bash
-al cloud teardown -p .
+al teardown cloud -p .
 ```
 
 | Option | Description |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -76,7 +76,7 @@ Controls local Docker container isolation. These settings also apply as resource
 
 ### `[cloud]` — Cloud Provider
 
-Only needed when running agents on cloud infrastructure with `al start -c`. Configure using `al cloud setup` (interactive wizard) or manually.
+Only needed when running agents on cloud infrastructure with `al start -c`. Configure using `al setup cloud` (interactive wizard) or manually.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -147,7 +147,7 @@ The gateway automatically loads secrets from all credential instances (e.g. `git
 
 ## Cloud Credential Sync
 
-When using cloud runtimes, credentials are automatically pushed to the cloud secret manager by `al doctor -c` or `al cloud setup`. See [Cloud Run docs](cloud-run.md) and [ECS docs](ecs.md) for details.
+When using cloud runtimes, credentials are automatically pushed to the cloud secret manager by `al doctor -c` or `al setup cloud`. See [Cloud Run docs](cloud-run.md) and [ECS docs](ecs.md) for details.
 
 ### Google Secret Manager (GSM)
 

--- a/docs/ecs.md
+++ b/docs/ecs.md
@@ -7,7 +7,7 @@ Run agents as ECS Fargate tasks on AWS instead of local Docker containers. Agent
 - AWS account with ECS, ECR, Secrets Manager, and CloudWatch Logs access
 - AWS CLI configured (`aws configure`) or `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` env vars
 - Docker is **not** required — images are built remotely via AWS CodeBuild and pushed directly to ECR
-- The IAM user running `al cloud setup` needs `iam:CreateServiceLinkedRole` permission (or the service-linked roles for ECS and App Runner must already exist — see [Service-linked roles](#service-linked-roles))
+- The IAM user running `al setup cloud` needs `iam:CreateServiceLinkedRole` permission (or the service-linked roles for ECS and App Runner must already exist — see [Service-linked roles](#service-linked-roles))
 
 ## Configuration
 
@@ -70,7 +70,7 @@ Optional cloud scheduler configuration (for `al cloud deploy`):
 
 AWS requires service-linked roles for ECS and App Runner. These are account-level roles that AWS services use internally — they only need to be created once per AWS account.
 
-`al cloud setup` automatically creates both:
+`al setup cloud` automatically creates both:
 
 - `AWSServiceRoleForECS` (for ECS Fargate task execution)
 - `AWSServiceRoleForAppRunner` (for App Runner service management)
@@ -89,7 +89,7 @@ These commands are safe to re-run — they return an error if the role already e
 The fastest way to get started:
 
 ```bash
-al cloud setup -p .
+al setup cloud -p .
 ```
 
 This interactive wizard prompts for all required fields, writes the `[cloud]` config, pushes credentials, and provisions IAM in one step.
@@ -437,7 +437,7 @@ There are six IAM principals involved:
 
 This is the minimum policy for the IAM user or role running `al` commands. Replace `<REGION>`, `<ACCOUNT_ID>`, and `<REPO_NAME>` with your values.
 
-> **Note:** `al cloud setup` automatically grants the PassRole and Logs statements via the `ActionLlamaOperator` inline policy. You still need to attach the remaining statements (ECS, SecretsManager, ECR, CodeBuild, Lambda, S3, IAM) manually or via your own IaC.
+> **Note:** `al setup cloud` automatically grants the PassRole and Logs statements via the `ActionLlamaOperator` inline policy. You still need to attach the remaining statements (ECS, SecretsManager, ECR, CodeBuild, Lambda, S3, IAM) manually or via your own IaC.
 
 ```json
 {
@@ -613,7 +613,7 @@ This is the minimum policy for the IAM user or role running `al` commands. Repla
 }
 ```
 
-The `SetupWizardReadOnly` statement is only needed for `al cloud setup`. You can remove it after initial setup if you prefer a tighter policy.
+The `SetupWizardReadOnly` statement is only needed for `al setup cloud`. You can remove it after initial setup if you prefer a tighter policy.
 
 The `CodeBuild` and `S3BuildContext` statements are required for image builds via CodeBuild.
 
@@ -621,7 +621,7 @@ The `SecretsManager` statement can be scoped to `arn:aws:secretsmanager:<REGION>
 
 The `IAMAgentRoles` statement is scoped to `al-*` roles, so it cannot modify unrelated IAM resources.
 
-The `AppRunner` statement is only needed for `al cloud deploy` / `al cloud teardown`. You can omit it if you only run the scheduler locally.
+The `AppRunner` statement is only needed for `al cloud deploy` / `al teardown cloud`. You can omit it if you only run the scheduler locally.
 
 ### Execution role (ECS infrastructure)
 
@@ -706,7 +706,7 @@ Attach the same policy statements from the [operator IAM policy](#operator-iam-p
 ```bash
 al stat -c            # Show scheduler service status + running agents
 al logs scheduler -c  # Tail scheduler logs from CloudWatch
-al cloud teardown     # Tear down scheduler + all cloud resources
+al teardown cloud     # Tear down scheduler + all cloud resources
 ```
 
 ### Manual deployment (alternative)
@@ -741,13 +741,13 @@ The scheduler builds images via CodeBuild, launches containers on ECS Fargate, a
 
 **"No AWS credentials found"** — Set `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` env vars or run `aws configure`.
 
-**"Unable to assume the service linked role"** — ECS needs a service-linked role the first time it's used in an account. `al cloud setup` creates this automatically, but if you set up manually: `aws iam create-service-linked-role --aws-service-name ecs.amazonaws.com`.
+**"Unable to assume the service linked role"** — ECS needs a service-linked role the first time it's used in an account. `al setup cloud` creates this automatically, but if you set up manually: `aws iam create-service-linked-role --aws-service-name ecs.amazonaws.com`.
 
-**"Couldn't create a service-linked role for App Runner"** — Same issue for App Runner. `al cloud setup` creates this automatically, but if you set up manually: `aws iam create-service-linked-role --aws-service-name apprunner.amazonaws.com`. If `al cloud setup` itself fails with this error, your IAM user needs `iam:CreateServiceLinkedRole` permission — see [Service-linked roles](#service-linked-roles).
+**"Couldn't create a service-linked role for App Runner"** — Same issue for App Runner. `al setup cloud` creates this automatically, but if you set up manually: `aws iam create-service-linked-role --aws-service-name apprunner.amazonaws.com`. If `al setup cloud` itself fails with this error, your IAM user needs `iam:CreateServiceLinkedRole` permission — see [Service-linked roles](#service-linked-roles).
 
 **"ECS was unable to assume the role 'arn:aws:iam::...:role/al-AGENT-task-role'"** — This is the most common issue with multiple agents. It means the IAM task role for your second (or subsequent) agent doesn't exist or has incorrect permissions. This typically happens because:
 
-1. You ran `al cloud setup` with only one agent, then added more agents later
+1. You ran `al setup cloud` with only one agent, then added more agents later
 2. The per-agent role creation failed during setup
 3. The role exists but has an incorrect trust policy
 
@@ -762,7 +762,7 @@ The scheduler builds images via CodeBuild, launches containers on ECS Fargate, a
 
 **CodeBuild build fails** — Check the build logs linked in the error message. Common causes: the `al-codebuild-role` is missing or lacks ECR push permissions, or the S3 bucket doesn't exist. Verify the role exists and has the permissions listed in the "How CodeBuild works" section above.
 
-**"The specified log group does not exist"** — The CloudWatch log group `/ecs/action-llama` hasn't been created. The runtime creates it automatically on first launch, but the operator IAM user needs `logs:CreateLogGroup` permission. Either re-run `al cloud setup` (which creates it), or create it manually:
+**"The specified log group does not exist"** — The CloudWatch log group `/ecs/action-llama` hasn't been created. The runtime creates it automatically on first launch, but the operator IAM user needs `logs:CreateLogGroup` permission. Either re-run `al setup cloud` (which creates it), or create it manually:
 
 ```bash
 aws logs create-log-group --log-group-name /ecs/action-llama --region us-east-1
@@ -770,7 +770,7 @@ aws logs create-log-group --log-group-name /ecs/action-llama --region us-east-1
 
 If you get `AccessDeniedException`, add the `logs:CreateLogGroup` action to your operator IAM policy (see the operator policy above).
 
-**"not authorized to perform: logs:FilterLogEvents"** — Your operator IAM user is missing CloudWatch Logs read permissions. Running `al cloud setup` grants these automatically (the `ActionLlamaOperator` inline policy). If you set up before this was added, re-run `al cloud setup` or manually add the Logs statement from the operator policy above.
+**"not authorized to perform: logs:FilterLogEvents"** — Your operator IAM user is missing CloudWatch Logs read permissions. Running `al setup cloud` grants these automatically (the `ActionLlamaOperator` inline policy). If you set up before this was added, re-run `al setup cloud` or manually add the Logs statement from the operator policy above.
 
 **Logs are delayed** — This is expected. CloudWatch Logs has a ~5-10 second ingestion delay. The TUI shows a warning when running in ECS mode.
 

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -110,7 +110,7 @@ async function executeAgentChat(opts: ChatOpts & { agent: string }): Promise<voi
   if (cloudMode) {
     const cloud = globalConfig.cloud;
     if (!cloud) {
-      throw new Error("No [cloud] section found in config.toml. Run 'al cloud setup' first.");
+      throw new Error("No [cloud] section found in config.toml. Run 'al setup cloud' first.");
     }
     const { createBackendFromCloudConfig } = await import("../../shared/remote.js");
     const { setDefaultBackend } = await import("../../shared/credentials.js");

--- a/src/cli/commands/cloud-deploy.ts
+++ b/src/cli/commands/cloud-deploy.ts
@@ -24,7 +24,7 @@ export async function execute(opts: { project: string }): Promise<void> {
   const cloud = globalConfig.cloud;
 
   if (!cloud) {
-    throw new Error("No [cloud] section found in config.toml. Run 'al cloud setup' first.");
+    throw new Error("No [cloud] section found in config.toml. Run 'al setup cloud' first.");
   }
 
   const provider = await createCloudProvider(cloud);

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -79,7 +79,7 @@ export async function execute(opts: { project: string; cloud?: boolean; checkOnl
     if (!cloudConfig) {
       throw new ConfigError(
         "No [cloud] section found in config.toml. " +
-        "Run 'al cloud setup' to configure a cloud provider first."
+        "Run 'al setup cloud' to configure a cloud provider first."
       );
     }
 
@@ -131,7 +131,7 @@ async function checkCredentials(
     if (!cloudConfig) {
       throw new ConfigError(
         "No [cloud] section found in config.toml. " +
-        "Run 'al cloud setup' to configure a cloud provider first."
+        "Run 'al setup cloud' to configure a cloud provider first."
       );
     }
 

--- a/src/cli/commands/logs.ts
+++ b/src/cli/commands/logs.ts
@@ -413,7 +413,7 @@ export async function execute(
     const globalConfig = loadGlobalConfig(projectPath);
     const cloud = globalConfig.cloud;
     if (!cloud) {
-      throw new Error("No [cloud] section found in config.toml. Run 'al cloud setup' first.");
+      throw new Error("No [cloud] section found in config.toml. Run 'al setup cloud' first.");
     }
 
     const { createCloudProvider } = await import("../../cloud/provider.js");

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -43,7 +43,7 @@ export async function execute(agent: string, opts: { project: string; cloud?: bo
     // Cloud mode: use cloud runtime via provider
     const cloud = globalConfig.cloud;
     if (!cloud) {
-      throw new Error("No [cloud] section found in config.toml. Run 'al cloud setup' first.");
+      throw new Error("No [cloud] section found in config.toml. Run 'al setup cloud' first.");
     }
 
     const { createCloudProvider } = await import("../../cloud/provider.js");

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -36,7 +36,7 @@ export async function execute(opts: { project: string; cloud?: boolean; headless
   // Cloud mode: set up cloud backend
   if (opts.cloud) {
     if (!globalConfig.cloud) {
-      throw new Error("No [cloud] section found in config.toml. Run 'al cloud setup' first.");
+      throw new Error("No [cloud] section found in config.toml. Run 'al setup cloud' first.");
     }
     const { setDefaultBackend } = await import("../../shared/credentials.js");
     const { createBackendFromCloudConfig } = await import("../../shared/remote.js");

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -11,7 +11,7 @@ export async function execute(opts: { project: string; cloud?: boolean }): Promi
     const globalConfig = loadGlobalConfig(projectPath);
     const cloud = globalConfig.cloud;
     if (!cloud) {
-      throw new Error("No [cloud] section found in config.toml. Run 'al cloud setup' first.");
+      throw new Error("No [cloud] section found in config.toml. Run 'al setup cloud' first.");
     }
 
     const { createCloudProvider } = await import("../../cloud/provider.js");

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -190,14 +190,14 @@ credsCmd
     await rm(ref);
   }));
 
-// --- Cloud management ---
+// --- Setup management ---
 
-const cloudCmd = program
-  .command("cloud")
-  .description("Cloud infrastructure management");
-
-cloudCmd
+const setupCmd = program
   .command("setup")
+  .description("Setup infrastructure and configuration");
+
+setupCmd
+  .command("cloud")
   .description("Interactive wizard: pick provider, configure, push creds, provision IAM")
   .option("-p, --project <dir>", "project directory", ".")
   .action(withCommand(async (opts) => {
@@ -205,21 +205,33 @@ cloudCmd
     await execute(opts);
   }));
 
+// --- Teardown management ---
+
+const teardownCmd = program
+  .command("teardown")
+  .description("Teardown infrastructure and configuration");
+
+teardownCmd
+  .command("cloud")
+  .description("Delete per-agent IAM resources and remove [cloud] config")
+  .option("-p, --project <dir>", "project directory", ".")
+  .action(withCommand(async (opts) => {
+    const { execute } = await import("./commands/cloud-teardown.js");
+    await execute(opts);
+  }));
+
+// --- Cloud management ---
+
+const cloudCmd = program
+  .command("cloud")
+  .description("Cloud infrastructure management");
+
 cloudCmd
   .command("deploy")
   .description("Build and deploy scheduler + agents to the cloud")
   .option("-p, --project <dir>", "project directory", ".")
   .action(withCommand(async (opts) => {
     const { execute } = await import("./commands/cloud-deploy.js");
-    await execute(opts);
-  }));
-
-cloudCmd
-  .command("teardown")
-  .description("Delete per-agent IAM resources and remove [cloud] config")
-  .option("-p, --project <dir>", "project directory", ".")
-  .action(withCommand(async (opts) => {
-    const { execute } = await import("./commands/cloud-teardown.js");
     await execute(opts);
   }));
 

--- a/src/cloud/aws/iam.ts
+++ b/src/cloud/aws/iam.ts
@@ -328,7 +328,7 @@ export async function validateEcsRoles(projectPath: string, cloud: EcsCloudConfi
     }, null, 2));
 
     console.log(`\nAlternatively, re-run the cloud setup to fix all issues:`);
-    console.log(`  al cloud setup`);
+    console.log(`  al setup cloud`);
 
     // Throw error to prevent proceeding with invalid configuration
     throw new CloudProviderError(`${missing.length + hasIncorrectTrust.length} IAM task role(s) have issues that will prevent ECS tasks from starting. Fix the roles above before proceeding.`);

--- a/src/cloud/aws/provision.ts
+++ b/src/cloud/aws/provision.ts
@@ -60,7 +60,7 @@ export async function setupEcsCloud(cloud: EcsCloudConfig): Promise<boolean> {
     console.log("  1. Install the AWS CLI:");
     console.log("     https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html\n");
     console.log("  2. Run: aws configure\n");
-    console.log("  3. Then re-run: al cloud setup\n");
+    console.log("  3. Then re-run: al setup cloud\n");
     console.log("  Alternatively, set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.\n");
     return false;
   }

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -145,7 +145,7 @@ function validateCloudConfig(raw: any): CloudConfig {
     if (missing.length > 0) {
       throw new ConfigError(
         `ECS cloud config is missing required fields: ${missing.map((k) => `cloud.${k}`).join(", ")}. ` +
-        `Run 'al cloud setup' to configure.`
+        `Run 'al setup cloud' to configure.`
       );
     }
     return raw as EcsCloudConfig;
@@ -157,7 +157,7 @@ function validateCloudConfig(raw: any): CloudConfig {
     if (missing.length > 0) {
       throw new ConfigError(
         `Cloud Run config is missing required fields: ${missing.map((k) => `cloud.${k}`).join(", ")}. ` +
-        `Run 'al cloud setup' to configure.`
+        `Run 'al setup cloud' to configure.`
       );
     }
     return raw as CloudRunCloudConfig;


### PR DESCRIPTION
Closes #80

Renames CLI commands for better consistency:
- al cloud setup → al setup cloud
- al cloud teardown → al teardown cloud

Updated all documentation and source code references.