### PR TITLE
fix: al logs -c not working

### DIFF
--- a/.changeset/fix-apprunner-logs.md
+++ b/.changeset/fix-apprunner-logs.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fixed cloud scheduler logs command (`al logs -c`) not working due to incorrect App Runner log group naming convention. The function now dynamically discovers the correct CloudWatch log group pattern used by App Runner services and provides better error messaging when the service is not deployed or no logs are available yet.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@action-llama/action-llama",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@action-llama/action-llama",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-apprunner": "^3.1006.0",

--- a/src/cloud/aws/deploy.ts
+++ b/src/cloud/aws/deploy.ts
@@ -16,6 +16,7 @@ import {
 import {
   CloudWatchLogsClient,
   FilterLogEventsCommand,
+  DescribeLogGroupsCommand,
 } from "@aws-sdk/client-cloudwatch-logs";
 import { AWS_CONSTANTS } from "./constants.js";
 import type { EcsCloudConfig } from "../../shared/config.js";
@@ -148,7 +149,26 @@ export async function getAppRunnerStatus(cloudConfig: EcsCloudConfig): Promise<A
  */
 export async function getAppRunnerLogs(cloudConfig: EcsCloudConfig, limit: number): Promise<string[]> {
   const logsClient = new CloudWatchLogsClient({ region: cloudConfig.awsRegion! });
-  const logGroup = AWS_CONSTANTS.APPRUNNER_LOG_GROUP;
+  
+  // First verify the App Runner service exists
+  const serviceInfo = await getAppRunnerStatus(cloudConfig);
+  if (!serviceInfo) {
+    throw new Error("App Runner service not deployed. Run 'al deploy scheduler -c' first.");
+  }
+
+  // Get the service ID from the service ARN for log group discovery
+  const serviceId = serviceInfo.serviceArn.split('/').pop();
+  const serviceName = AWS_CONSTANTS.SCHEDULER_SERVICE;
+  
+  // Try to find the correct log group using App Runner's naming convention
+  const logGroup = await findAppRunnerLogGroup(logsClient, serviceName, serviceId);
+  
+  if (!logGroup) {
+    throw new Error(
+      `No log group found for App Runner service ${serviceName}. ` +
+      `The service may not have started logging yet. Try again in a few moments.`
+    );
+  }
 
   try {
     const allEvents: string[] = [];
@@ -195,6 +215,70 @@ export async function teardownAppRunner(cloudConfig: EcsCloudConfig): Promise<vo
     ServiceArn: existing.serviceArn,
   }));
   console.log("  App Runner service deletion initiated");
+}
+
+/**
+ * Find the CloudWatch log group for an App Runner service.
+ * App Runner creates log groups with the pattern: /aws/apprunner/{service-name}/{service-id}/application
+ */
+async function findAppRunnerLogGroup(
+  logsClient: CloudWatchLogsClient,
+  serviceName: string,
+  serviceId?: string
+): Promise<string | null> {
+  try {
+    let nextToken: string | undefined;
+    const logGroupPatterns = [
+      // Current App Runner naming pattern
+      serviceId ? `/aws/apprunner/${serviceName}/${serviceId}/application` : null,
+      // Fallback: scan for any log group matching the service name pattern
+      `/aws/apprunner/${serviceName}`,
+      // Legacy pattern (in case it still works somewhere)
+      `/apprunner/${serviceName}`,
+    ].filter(Boolean) as string[];
+
+    // First try exact patterns
+    for (const pattern of logGroupPatterns) {
+      const res = await logsClient.send(new DescribeLogGroupsCommand({
+        logGroupNamePrefix: pattern,
+        limit: 10,
+      }));
+
+      if (res.logGroups && res.logGroups.length > 0) {
+        // Return the most recent log group
+        const sortedGroups = res.logGroups
+          .filter(g => g.logGroupName)
+          .sort((a, b) => (b.creationTime || 0) - (a.creationTime || 0));
+        
+        if (sortedGroups[0]?.logGroupName) {
+          return sortedGroups[0].logGroupName;
+        }
+      }
+    }
+
+    // Fallback: scan for any App Runner log groups containing the service name
+    do {
+      const res = await logsClient.send(new DescribeLogGroupsCommand({
+        logGroupNamePrefix: "/aws/apprunner/",
+        ...(nextToken ? { nextToken } : {}),
+        limit: 50,
+      }));
+
+      for (const group of res.logGroups ?? []) {
+        if (group.logGroupName?.includes(serviceName)) {
+          return group.logGroupName;
+        }
+      }
+
+      nextToken = res.nextToken;
+    } while (nextToken);
+
+    return null;
+  } catch (err: any) {
+    // If we can't list log groups, fall back to the legacy pattern
+    console.warn(`Warning: Could not list CloudWatch log groups (${err.message}). Trying legacy pattern.`);
+    return AWS_CONSTANTS.APPRUNNER_LOG_GROUP;
+  }
 }
 
 // --- Internal helpers ---


### PR DESCRIPTION
Closes #84

## Summary

Fixed the cloud scheduler logs command () not working due to incorrect App Runner log group naming convention.

## Root Cause

The issue was that App Runner's CloudWatch log group naming pattern has changed. The hardcoded log group path  is no longer accurate. App Runner now uses the pattern .

## Changes

1. **Dynamic log group discovery**: Modified  function to dynamically find the correct log group using AWS CloudWatch APIs
2. **Better error handling**: Added validation to ensure the App Runner service exists before attempting to fetch logs
3. **Improved error messages**: Provides clearer feedback when service is not deployed or hasn't started logging yet
4. **Fallback support**: Falls back to legacy naming pattern if log group discovery fails

## Testing

- All 677 existing tests pass
- Build completes successfully
- Changes follow existing code patterns and conventions

The fix searches for log groups using multiple patterns:
- Current App Runner pattern:  
- Fallback patterns for compatibility
- Graceful error handling for missing services or log groups