### PR TITLE
feat: preflight steps — declarative data staging before agent runs

### DIFF
--- a/.changeset/preflight-steps.md
+++ b/.changeset/preflight-steps.md
@@ -1,0 +1,10 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Added preflight steps system for declarative data staging before agent runs.
+Define `[[preflight]]` steps in `agent-config.toml` to clone repos, fetch URLs,
+or run shell commands — all inside the container after credentials load but
+before the LLM session starts. Three built-in providers: `shell`, `http`, and
+`git-clone`. Params support `${VAR}` env var interpolation. Steps marked
+`required: false` log a warning and continue on failure. Closes #85.

--- a/docs/agent-config-reference.md
+++ b/docs/agent-config-reference.md
@@ -44,6 +44,30 @@ labels = ["agent"]                        # Only trigger on issues with these la
 source = "my-sentry"                      # Required: references [webhooks.my-sentry] in config.toml
 resources = ["error", "event_alert"]      # Sentry resource types (optional)
 
+# Optional: preflight steps — run before the LLM session starts
+# Each step runs a built-in provider to stage data the agent will reference
+[[preflight]]
+provider = "git-clone"                    # Clone a repo into the workspace
+required = true                           # If true (default), abort if this step fails
+[preflight.params]
+repo = "acme/app"                         # Short "owner/repo" or full URL
+dest = "/tmp/repo"
+depth = 1                                 # Optional: shallow clone
+
+[[preflight]]
+provider = "http"                         # Fetch a URL and write the response to a file
+required = false                          # Optional step — warn and continue on failure
+[preflight.params]
+url = "https://api.internal/v1/flags"
+output = "/tmp/context/flags.json"
+headers = { Authorization = "Bearer ${INTERNAL_TOKEN}" }
+
+[[preflight]]
+provider = "shell"                        # Run a shell command
+[preflight.params]
+command = "gh issue list --repo acme/app --label P1 --json number,title,body --limit 20"
+output = "/tmp/context/issues.json"       # Optional: capture stdout to file
+
 # Optional: custom parameters injected into the agent prompt
 [params]
 repos = ["acme/app", "acme/api"]
@@ -67,6 +91,7 @@ sentryProjects = ["web-app", "api"]
 | `model.thinkingLevel` | string | No | Thinking budget level: off, minimal, low, medium, high, xhigh. Only relevant for Claude Sonnet/Opus. Omit for other models. |
 | `model.authType` | string | Yes* | Auth method for the provider |
 | `webhooks` | array | No* | Array of webhook trigger objects |
+| `preflight` | array | No | Array of preflight steps that run before the LLM session. See [Preflight](#preflight). |
 | `params` | table | No | Custom key-value params for the agent prompt |
 
 *At least one of `schedule` or `webhooks` is required (unless `scale = 0`). *Required within `[model]` if the agent defines its own model block (otherwise inherits from project `config.toml`).
@@ -142,6 +167,106 @@ timeout = 3600      # 1 hour
 # Omit timeout — uses [local].timeout or defaults to 900s
 # (routes to Lambda on AWS since 900 <= 900)
 ```
+
+## Preflight
+
+Preflight steps run mechanical data-staging tasks after credentials are loaded but before the LLM session starts. They fetch data, clone repos, or run commands to prepare the workspace so the agent starts with everything it needs — instead of spending tokens fetching context at runtime.
+
+### How it works
+
+1. Steps run **sequentially** in the order they appear in `agent-config.toml`
+2. Steps run **inside the container** (or host process in `--no-docker` mode) after credential/env setup
+3. Providers write files to disk — your ACTIONS.md references the staged files
+4. Environment variable interpolation is supported: `${VAR_NAME}` in string params is resolved against `process.env` (which already has credentials injected)
+
+### Step fields
+
+Each `[[preflight]]` entry has these fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `provider` | string | Yes | Provider name: `shell`, `http`, or `git-clone` |
+| `required` | boolean | No | If `true` (default), the agent aborts on failure. If `false`, logs a warning and continues. |
+| `params` | table | Yes | Provider-specific parameters (see below) |
+
+### Built-in providers
+
+#### `shell`
+
+Runs a command via `/bin/sh`. Optionally captures stdout to a file.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `command` | string | Yes | Shell command to execute |
+| `output` | string | No | File path to write stdout to. Parent directories are created automatically. |
+
+```toml
+[[preflight]]
+provider = "shell"
+[preflight.params]
+command = "gh issue list --repo acme/app --label P1 --json number,title,body --limit 20"
+output = "/tmp/context/issues.json"
+```
+
+#### `http`
+
+Fetches a URL and writes the response body to a file.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `url` | string | Yes | URL to fetch |
+| `output` | string | Yes | File path to write the response body |
+| `method` | string | No | HTTP method (default: `GET`) |
+| `headers` | table | No | HTTP headers as key-value pairs |
+| `body` | string | No | Request body (for POST/PUT) |
+
+```toml
+[[preflight]]
+provider = "http"
+required = false
+[preflight.params]
+url = "https://api.internal/v1/feature-flags"
+output = "/tmp/context/flags.json"
+headers = { Authorization = "Bearer ${INTERNAL_TOKEN}" }
+```
+
+#### `git-clone`
+
+Clones a git repository. Short `"owner/repo"` names are expanded to `git@github.com:owner/repo.git`; full URLs are passed through. Git credentials (SSH key, HTTPS token) are already configured from the agent's credentials.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `repo` | string | Yes | Repository: `"owner/repo"` or full URL |
+| `dest` | string | Yes | Local path to clone into |
+| `branch` | string | No | Branch to check out |
+| `depth` | number | No | Shallow clone depth (e.g., `1`) |
+
+```toml
+[[preflight]]
+provider = "git-clone"
+[preflight.params]
+repo = "acme/app"
+dest = "/tmp/repo"
+branch = "main"
+depth = 1
+```
+
+### Referencing staged files in ACTIONS.md
+
+Preflight writes files to disk — your ACTIONS.md tells the LLM what's there:
+
+```markdown
+## Context
+- The repo is cloned at `/tmp/repo`
+- Open P1 issues are at `/tmp/context/issues.json`
+- Feature flags (if available) are at `/tmp/context/flags.json`
+```
+
+### Notes
+
+- The `shell` provider is the escape hatch — anything a built-in provider doesn't cover can be expressed as a shell command
+- There is no per-step timeout — steps are bounded by the container-level timeout
+- Environment variables set inside `shell` child processes do not propagate back to the agent's `process.env`
 
 ## Webhook Trigger Fields
 

--- a/docs/creating-agents.md
+++ b/docs/creating-agents.md
@@ -62,7 +62,36 @@ Your configuration is in the `<agent-config>` block at the start of your prompt.
 
 The ACTIONS.md is injected as the agent's system prompt at runtime. Write it as instructions to the LLM.
 
-### 4. Verify with `al stat`
+### 4. (Optional) Add preflight steps
+
+If your agent needs external context (repo contents, API data, issue lists), add `[[preflight]]` steps to `agent-config.toml`. Preflight runs after credentials are loaded but before the LLM session starts, so the agent begins with everything it needs:
+
+```toml
+[[preflight]]
+provider = "git-clone"
+[preflight.params]
+repo = "your-org/your-repo"
+dest = "/tmp/repo"
+depth = 1
+
+[[preflight]]
+provider = "shell"
+[preflight.params]
+command = "gh issue list --repo your-org/your-repo --label bug --json number,title --limit 20"
+output = "/tmp/context/issues.json"
+```
+
+Then reference the staged files in your ACTIONS.md:
+
+```markdown
+## Context
+- The repo is cloned at `/tmp/repo`
+- Open bug issues are at `/tmp/context/issues.json`
+```
+
+See [Preflight](agent-config-reference.md#preflight) for the full reference.
+
+### 5. Verify with `al stat`
 
 ```bash
 al stat -p .
@@ -70,7 +99,7 @@ al stat -p .
 
 This should show your agent with its schedule and credentials.
 
-### 5. Run with `al start`
+### 6. Run with `al start`
 
 ```bash
 al start -p .
@@ -78,7 +107,7 @@ al start -p .
 
 Your agent will run on its configured schedule and/or respond to webhooks.
 
-### 6. (Optional) Customize the project Dockerfile
+### 7. (Optional) Customize the project Dockerfile
 
 Every project has a `Dockerfile` at the root (created by `al new`) that defines the shared base image for all agents. If your agents need extra system packages, edit it:
 
@@ -100,7 +129,7 @@ USER node
 
 See [Docker docs](docker.md) for the full reference.
 
-### 7. (Cloud only) Re-run `al doctor -c`
+### 8. (Cloud only) Re-run `al doctor -c`
 
 If you're running agents on cloud infrastructure, re-run `al doctor -c` after adding a new agent. This creates the per-agent IAM resources (service account for Cloud Run, task role for ECS) and grants the new agent access to its declared secrets.
 

--- a/src/agents/container-entry.ts
+++ b/src/agents/container-entry.ts
@@ -14,6 +14,7 @@ import { parseCredentialRef, unsanitizeEnvPart } from "../shared/credentials.js"
 import { getExitCodeMessage } from "../shared/exit-codes.js";
 import { ensureSignalDir, readSignals } from "./signals.js";
 import { builtinCredentials } from "../credentials/builtins/index.js";
+import { runPreflight } from "../preflight/runner.js";
 import { initTelemetry } from "../telemetry/index.js";
 import type { TelemetryConfig } from "../telemetry/types.js";
 import { sessionStatsToUsage } from "../shared/usage.js";
@@ -286,6 +287,15 @@ export async function handleInvocation(init: AgentInit): Promise<number> {
       process.env.GIT_AUTHOR_EMAIL = gitEmail;
       process.env.GIT_COMMITTER_EMAIL = gitEmail;
     }
+  }
+
+  // Run preflight steps (data staging before LLM session)
+  if (agentConfig.preflight && agentConfig.preflight.length > 0) {
+    const preflightCtx = {
+      env: { ...process.env } as Record<string, string>,
+      logger: emitLog,
+    };
+    await runPreflight(agentConfig.preflight, preflightCtx);
   }
 
   const cwd = "/tmp";

--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -18,6 +18,7 @@ import type { StatusTracker } from "../tui/status-tracker.js";
 import { getExitCodeMessage } from "../shared/exit-codes.js";
 import { AgentError, isUnrecoverableError, UNRECOVERABLE_THRESHOLD } from "../shared/errors.js";
 import { installSignalCommands, readSignals } from "./signals.js";
+import { runPreflight } from "../preflight/runner.js";
 import { withSpan, getTelemetry } from "../telemetry/index.js";
 import { SpanKind } from "@opentelemetry/api";
 import type { TokenUsage } from "../shared/usage.js";
@@ -177,6 +178,19 @@ export class AgentRunner {
           process.env.GIT_AUTHOR_EMAIL = gitEmail;
           process.env.GIT_COMMITTER_EMAIL = gitEmail;
         }
+      }
+
+      // Run preflight steps (data staging before LLM session)
+      if (this.agentConfig.preflight && this.agentConfig.preflight.length > 0) {
+        const preflightCtx = {
+          env: { ...process.env } as Record<string, string>,
+          logger: (level: string, msg: string, data?: Record<string, any>) => {
+            if (level === "error") this.logger.error(data ?? {}, msg);
+            else if (level === "warn") this.logger.warn(data ?? {}, msg);
+            else this.logger.info(data ?? {}, msg);
+          },
+        };
+        await runPreflight(this.agentConfig.preflight, preflightCtx);
       }
 
       // ACTIONS.md must exist on disk (written during al new)

--- a/src/preflight/interpolate.ts
+++ b/src/preflight/interpolate.ts
@@ -1,0 +1,39 @@
+/**
+ * Environment variable interpolation for preflight params.
+ *
+ * Replaces `${VAR_NAME}` tokens in string values with the corresponding
+ * value from the provided env map. Nested objects and arrays are traversed
+ * recursively; non-string leaves are returned as-is.
+ */
+
+const ENV_VAR_RE = /\$\{([A-Za-z_][A-Za-z0-9_]*)}/g;
+
+export function interpolateString(template: string, env: Record<string, string>): string {
+  return template.replace(ENV_VAR_RE, (_match, name: string) => {
+    return env[name] ?? "";
+  });
+}
+
+export function interpolateParams(
+  params: Record<string, unknown>,
+  env: Record<string, string>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(params)) {
+    result[key] = interpolateValue(value, env);
+  }
+  return result;
+}
+
+function interpolateValue(value: unknown, env: Record<string, string>): unknown {
+  if (typeof value === "string") {
+    return interpolateString(value, env);
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => interpolateValue(v, env));
+  }
+  if (value !== null && typeof value === "object") {
+    return interpolateParams(value as Record<string, unknown>, env);
+  }
+  return value;
+}

--- a/src/preflight/providers/git-clone.ts
+++ b/src/preflight/providers/git-clone.ts
@@ -1,0 +1,43 @@
+import { execSync } from "child_process";
+import type { PreflightProvider, PreflightContext } from "../schema.js";
+import { interpolateParams } from "../interpolate.js";
+
+export const gitCloneProvider: PreflightProvider = {
+  id: "git-clone",
+
+  async run(params: Record<string, unknown>, ctx: PreflightContext): Promise<void> {
+    const resolved = interpolateParams(params, ctx.env);
+    const repo = resolved.repo;
+    if (typeof repo !== "string" || !repo) {
+      throw new Error("git-clone provider requires a 'repo' param");
+    }
+    const dest = resolved.dest;
+    if (typeof dest !== "string" || !dest) {
+      throw new Error("git-clone provider requires a 'dest' param");
+    }
+
+    // Expand short "owner/repo" to SSH URL; full URLs pass through
+    const repoUrl = repo.includes("://") || repo.startsWith("git@")
+      ? repo
+      : `git@github.com:${repo}.git`;
+
+    const args = ["git", "clone"];
+    if (typeof resolved.branch === "string" && resolved.branch) {
+      args.push("--branch", resolved.branch);
+    }
+    if (typeof resolved.depth === "number" && resolved.depth > 0) {
+      args.push("--depth", String(resolved.depth));
+    }
+    args.push(repoUrl, dest);
+
+    const cmd = args.join(" ");
+    ctx.logger("info", "preflight git-clone", { repo: repoUrl, dest });
+
+    execSync(cmd, {
+      env: ctx.env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    ctx.logger("info", "preflight git-clone done", { dest });
+  },
+};

--- a/src/preflight/providers/http.ts
+++ b/src/preflight/providers/http.ts
@@ -1,0 +1,41 @@
+import { writeFileSync, mkdirSync } from "fs";
+import { dirname } from "path";
+import type { PreflightProvider, PreflightContext } from "../schema.js";
+import { interpolateString, interpolateParams } from "../interpolate.js";
+
+export const httpProvider: PreflightProvider = {
+  id: "http",
+
+  async run(params: Record<string, unknown>, ctx: PreflightContext): Promise<void> {
+    const resolved = interpolateParams(params, ctx.env);
+    const url = resolved.url;
+    if (typeof url !== "string" || !url) {
+      throw new Error("http provider requires a 'url' param");
+    }
+    const output = resolved.output;
+    if (typeof output !== "string" || !output) {
+      throw new Error("http provider requires an 'output' param");
+    }
+
+    const method = (typeof resolved.method === "string" ? resolved.method : "GET").toUpperCase();
+    const headers: Record<string, string> = {};
+    if (resolved.headers && typeof resolved.headers === "object" && !Array.isArray(resolved.headers)) {
+      for (const [k, v] of Object.entries(resolved.headers as Record<string, unknown>)) {
+        if (typeof v === "string") headers[k] = v;
+      }
+    }
+    const body = typeof resolved.body === "string" ? resolved.body : undefined;
+
+    ctx.logger("info", "preflight http", { method, url: url.slice(0, 200) });
+
+    const response = await fetch(url, { method, headers, body });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText} from ${url}`);
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    mkdirSync(dirname(output), { recursive: true });
+    writeFileSync(output, buffer);
+    ctx.logger("info", "preflight http output written", { path: output, bytes: buffer.length });
+  },
+};

--- a/src/preflight/providers/shell.ts
+++ b/src/preflight/providers/shell.ts
@@ -1,0 +1,33 @@
+import { execSync } from "child_process";
+import { writeFileSync, mkdirSync } from "fs";
+import { dirname } from "path";
+import type { PreflightProvider, PreflightContext } from "../schema.js";
+import { interpolateString, interpolateParams } from "../interpolate.js";
+
+export const shellProvider: PreflightProvider = {
+  id: "shell",
+
+  async run(params: Record<string, unknown>, ctx: PreflightContext): Promise<void> {
+    const resolved = interpolateParams(params, ctx.env);
+    const command = resolved.command;
+    if (typeof command !== "string" || !command) {
+      throw new Error("shell provider requires a 'command' param");
+    }
+    const output = typeof resolved.output === "string" ? resolved.output : undefined;
+
+    ctx.logger("info", "preflight shell", { command: command.slice(0, 200) });
+
+    const stdout = execSync(command, {
+      shell: "/bin/sh",
+      env: ctx.env,
+      stdio: output ? ["pipe", "pipe", "pipe"] : ["pipe", "inherit", "pipe"],
+      maxBuffer: 50 * 1024 * 1024, // 50 MB
+    });
+
+    if (output) {
+      mkdirSync(dirname(output), { recursive: true });
+      writeFileSync(output, stdout);
+      ctx.logger("info", "preflight shell output written", { path: output, bytes: stdout.length });
+    }
+  },
+};

--- a/src/preflight/registry.ts
+++ b/src/preflight/registry.ts
@@ -1,0 +1,23 @@
+import type { PreflightProvider } from "./schema.js";
+import { shellProvider } from "./providers/shell.js";
+import { httpProvider } from "./providers/http.js";
+import { gitCloneProvider } from "./providers/git-clone.js";
+
+const builtinProviders: Record<string, PreflightProvider> = {
+  [shellProvider.id]: shellProvider,
+  [httpProvider.id]: httpProvider,
+  [gitCloneProvider.id]: gitCloneProvider,
+};
+
+export function resolvePreflightProvider(id: string): PreflightProvider {
+  const provider = builtinProviders[id];
+  if (!provider) {
+    const available = Object.keys(builtinProviders).join(", ");
+    throw new Error(`Unknown preflight provider "${id}". Available: ${available}`);
+  }
+  return provider;
+}
+
+export function listPreflightProviders(): string[] {
+  return Object.keys(builtinProviders);
+}

--- a/src/preflight/runner.ts
+++ b/src/preflight/runner.ts
@@ -1,0 +1,34 @@
+import type { PreflightStep, PreflightContext } from "./schema.js";
+import { resolvePreflightProvider } from "./registry.js";
+
+/**
+ * Run all preflight steps sequentially. If a required step fails, throws.
+ * Optional steps log a warning and continue.
+ */
+export async function runPreflight(
+  steps: PreflightStep[],
+  ctx: PreflightContext,
+): Promise<void> {
+  ctx.logger("info", "preflight starting", { stepCount: steps.length });
+
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    const required = step.required !== false; // default true
+    const label = `[${i + 1}/${steps.length}] ${step.provider}`;
+
+    try {
+      const provider = resolvePreflightProvider(step.provider);
+      await provider.run(step.params, ctx);
+      ctx.logger("info", `preflight step ${label} done`);
+    } catch (err: any) {
+      const msg = err?.message || String(err);
+      if (required) {
+        ctx.logger("error", `preflight step ${label} failed (required)`, { error: msg });
+        throw new Error(`Required preflight step "${step.provider}" failed: ${msg}`);
+      }
+      ctx.logger("warn", `preflight step ${label} failed (optional, continuing)`, { error: msg });
+    }
+  }
+
+  ctx.logger("info", "preflight complete");
+}

--- a/src/preflight/schema.ts
+++ b/src/preflight/schema.ts
@@ -1,0 +1,23 @@
+/**
+ * Preflight step types and provider interface.
+ *
+ * Preflight steps run mechanical data-staging tasks (clone repos, fetch URLs,
+ * run shell commands) inside the container after credentials are loaded but
+ * before the LLM session starts. ACTIONS.md references the staged files.
+ */
+
+export interface PreflightStep {
+  provider: string;              // "git-clone", "http", "shell"
+  required?: boolean;            // default true — if a required step fails, the agent aborts
+  params: Record<string, unknown>;
+}
+
+export interface PreflightContext {
+  env: Record<string, string>;   // process.env snapshot (creds already injected)
+  logger: (level: string, msg: string, data?: Record<string, any>) => void;
+}
+
+export interface PreflightProvider {
+  id: string;
+  run(params: Record<string, unknown>, ctx: PreflightContext): Promise<void>;
+}

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -2,6 +2,7 @@ import { readFileSync, existsSync, readdirSync, statSync } from "fs";
 import { resolve } from "path";
 import { parse as parseTOML } from "smol-toml";
 import type { WebhookTrigger } from "../webhooks/types.js";
+import type { PreflightStep } from "../preflight/schema.js";
 import { ConfigError } from "./errors.js";
 
 // --- Global config (lives at <project>/config.toml) ---
@@ -102,6 +103,7 @@ export interface AgentConfig {
   model: ModelConfig;
   schedule?: string;
   webhooks?: WebhookTrigger[];
+  preflight?: PreflightStep[];
   params?: Record<string, unknown>;
   scale?: number; // Number of concurrent runs allowed (default: 1)
   timeout?: number; // Max runtime in seconds (falls back to global local.timeout, then 900)

--- a/test/preflight/interpolate.test.ts
+++ b/test/preflight/interpolate.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { interpolateString, interpolateParams } from "../../src/preflight/interpolate.js";
+
+describe("interpolateString", () => {
+  const env = { TOKEN: "abc123", HOST: "example.com", EMPTY: "" };
+
+  it("replaces ${VAR} with env value", () => {
+    expect(interpolateString("Bearer ${TOKEN}", env)).toBe("Bearer abc123");
+  });
+
+  it("replaces multiple vars", () => {
+    expect(interpolateString("https://${HOST}/api?t=${TOKEN}", env)).toBe(
+      "https://example.com/api?t=abc123",
+    );
+  });
+
+  it("replaces missing vars with empty string", () => {
+    expect(interpolateString("key=${MISSING}", env)).toBe("key=");
+  });
+
+  it("replaces empty var with empty string", () => {
+    expect(interpolateString("key=${EMPTY}", env)).toBe("key=");
+  });
+
+  it("leaves strings without vars unchanged", () => {
+    expect(interpolateString("plain text", env)).toBe("plain text");
+  });
+
+  it("does not expand $VAR (only ${VAR})", () => {
+    expect(interpolateString("$TOKEN", env)).toBe("$TOKEN");
+  });
+});
+
+describe("interpolateParams", () => {
+  const env = { TOKEN: "secret", BASE: "https://api.test" };
+
+  it("interpolates string values", () => {
+    const result = interpolateParams({ url: "${BASE}/v1", auth: "Bearer ${TOKEN}" }, env);
+    expect(result).toEqual({ url: "https://api.test/v1", auth: "Bearer secret" });
+  });
+
+  it("recurses into nested objects", () => {
+    const result = interpolateParams(
+      { headers: { Authorization: "Bearer ${TOKEN}" } },
+      env,
+    );
+    expect(result).toEqual({ headers: { Authorization: "Bearer secret" } });
+  });
+
+  it("recurses into arrays", () => {
+    const result = interpolateParams({ args: ["--token", "${TOKEN}"] }, env);
+    expect(result).toEqual({ args: ["--token", "secret"] });
+  });
+
+  it("leaves numbers and booleans unchanged", () => {
+    const result = interpolateParams({ depth: 1, verbose: true }, env);
+    expect(result).toEqual({ depth: 1, verbose: true });
+  });
+
+  it("leaves null unchanged", () => {
+    const result = interpolateParams({ value: null }, env);
+    expect(result).toEqual({ value: null });
+  });
+});

--- a/test/preflight/providers/git-clone.test.ts
+++ b/test/preflight/providers/git-clone.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { gitCloneProvider } from "../../../src/preflight/providers/git-clone.js";
+import type { PreflightContext } from "../../../src/preflight/schema.js";
+import * as childProcess from "child_process";
+
+vi.mock("child_process", async () => {
+  const actual = await vi.importActual<typeof childProcess>("child_process");
+  return {
+    ...actual,
+    execSync: vi.fn(),
+  };
+});
+
+const mockedExecSync = vi.mocked(childProcess.execSync);
+
+function makeCtx(env?: Record<string, string>): PreflightContext {
+  return {
+    env: { ...env } as Record<string, string>,
+    logger: () => {},
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("git-clone provider", () => {
+  it("expands short repo name to SSH URL", async () => {
+    mockedExecSync.mockReturnValueOnce(Buffer.from(""));
+    await gitCloneProvider.run(
+      { repo: "acme/app", dest: "/tmp/repo" },
+      makeCtx(),
+    );
+    expect(mockedExecSync).toHaveBeenCalledWith(
+      "git clone git@github.com:acme/app.git /tmp/repo",
+      expect.any(Object),
+    );
+  });
+
+  it("passes full SSH URLs through", async () => {
+    mockedExecSync.mockReturnValueOnce(Buffer.from(""));
+    await gitCloneProvider.run(
+      { repo: "git@github.com:acme/app.git", dest: "/tmp/repo" },
+      makeCtx(),
+    );
+    expect(mockedExecSync).toHaveBeenCalledWith(
+      "git clone git@github.com:acme/app.git /tmp/repo",
+      expect.any(Object),
+    );
+  });
+
+  it("passes full HTTPS URLs through", async () => {
+    mockedExecSync.mockReturnValueOnce(Buffer.from(""));
+    await gitCloneProvider.run(
+      { repo: "https://github.com/acme/app.git", dest: "/tmp/repo" },
+      makeCtx(),
+    );
+    expect(mockedExecSync).toHaveBeenCalledWith(
+      "git clone https://github.com/acme/app.git /tmp/repo",
+      expect.any(Object),
+    );
+  });
+
+  it("adds --branch and --depth flags", async () => {
+    mockedExecSync.mockReturnValueOnce(Buffer.from(""));
+    await gitCloneProvider.run(
+      { repo: "acme/app", dest: "/tmp/repo", branch: "develop", depth: 1 },
+      makeCtx(),
+    );
+    expect(mockedExecSync).toHaveBeenCalledWith(
+      "git clone --branch develop --depth 1 git@github.com:acme/app.git /tmp/repo",
+      expect.any(Object),
+    );
+  });
+
+  it("passes env to child process", async () => {
+    mockedExecSync.mockReturnValueOnce(Buffer.from(""));
+    const env = { GIT_SSH_COMMAND: "ssh -i /key" };
+    await gitCloneProvider.run(
+      { repo: "acme/app", dest: "/tmp/repo" },
+      makeCtx(env),
+    );
+    expect(mockedExecSync).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ env: expect.objectContaining(env) }),
+    );
+  });
+
+  it("throws on missing repo", async () => {
+    await expect(
+      gitCloneProvider.run({ dest: "/tmp/repo" }, makeCtx()),
+    ).rejects.toThrow(/requires a 'repo' param/);
+  });
+
+  it("throws on missing dest", async () => {
+    await expect(
+      gitCloneProvider.run({ repo: "acme/app" }, makeCtx()),
+    ).rejects.toThrow(/requires a 'dest' param/);
+  });
+
+  it("throws when git clone fails", async () => {
+    mockedExecSync.mockImplementationOnce(() => {
+      throw new Error("fatal: repo not found");
+    });
+    await expect(
+      gitCloneProvider.run({ repo: "acme/bad", dest: "/tmp/repo" }, makeCtx()),
+    ).rejects.toThrow(/repo not found/);
+  });
+});

--- a/test/preflight/providers/http.test.ts
+++ b/test/preflight/providers/http.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { httpProvider } from "../../../src/preflight/providers/http.js";
+import { readFileSync, mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import type { PreflightContext } from "../../../src/preflight/schema.js";
+
+let tmpDir: string;
+
+function makeCtx(env?: Record<string, string>): PreflightContext {
+  return {
+    env: { ...env } as Record<string, string>,
+    logger: () => {},
+  };
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "al-preflight-http-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("http provider", () => {
+  it("fetches URL and writes to output", async () => {
+    const body = JSON.stringify({ ok: true });
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(body, { status: 200 }),
+    );
+
+    const output = join(tmpDir, "resp.json");
+    await httpProvider.run(
+      { url: "https://api.test/data", output },
+      makeCtx(),
+    );
+    expect(readFileSync(output, "utf-8")).toBe(body);
+  });
+
+  it("passes headers and method", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("ok", { status: 200 }),
+    );
+
+    const output = join(tmpDir, "resp.txt");
+    await httpProvider.run(
+      {
+        url: "https://api.test/post",
+        output,
+        method: "POST",
+        headers: { Authorization: "Bearer tok" },
+        body: "payload",
+      },
+      makeCtx(),
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith("https://api.test/post", {
+      method: "POST",
+      headers: { Authorization: "Bearer tok" },
+      body: "payload",
+    });
+  });
+
+  it("interpolates env vars in URL and headers", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("ok", { status: 200 }),
+    );
+
+    const output = join(tmpDir, "resp.txt");
+    await httpProvider.run(
+      {
+        url: "https://${HOST}/api",
+        output,
+        headers: { Authorization: "Bearer ${TOKEN}" },
+      },
+      makeCtx({ HOST: "example.com", TOKEN: "secret" }),
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://example.com/api",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer secret" },
+      }),
+    );
+  });
+
+  it("throws on non-ok response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("not found", { status: 404, statusText: "Not Found" }),
+    );
+
+    const output = join(tmpDir, "resp.txt");
+    await expect(
+      httpProvider.run({ url: "https://api.test/bad", output }, makeCtx()),
+    ).rejects.toThrow(/HTTP 404/);
+  });
+
+  it("throws on missing url", async () => {
+    await expect(
+      httpProvider.run({ output: "/tmp/x" }, makeCtx()),
+    ).rejects.toThrow(/requires a 'url' param/);
+  });
+
+  it("throws on missing output", async () => {
+    await expect(
+      httpProvider.run({ url: "https://test" }, makeCtx()),
+    ).rejects.toThrow(/requires an 'output' param/);
+  });
+
+  it("creates parent directories for output", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("data", { status: 200 }),
+    );
+
+    const output = join(tmpDir, "sub", "dir", "resp.txt");
+    await httpProvider.run(
+      { url: "https://api.test", output },
+      makeCtx(),
+    );
+    expect(readFileSync(output, "utf-8")).toBe("data");
+  });
+});

--- a/test/preflight/providers/shell.test.ts
+++ b/test/preflight/providers/shell.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { shellProvider } from "../../../src/preflight/providers/shell.js";
+import { readFileSync, existsSync, mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import type { PreflightContext } from "../../../src/preflight/schema.js";
+
+let tmpDir: string;
+
+function makeCtx(env?: Record<string, string>): PreflightContext {
+  return {
+    env: { ...process.env, ...env } as Record<string, string>,
+    logger: () => {},
+  };
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "al-preflight-shell-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("shell provider", () => {
+  it("runs a command", async () => {
+    const output = join(tmpDir, "out.txt");
+    await shellProvider.run(
+      { command: "echo hello", output },
+      makeCtx(),
+    );
+    expect(readFileSync(output, "utf-8")).toBe("hello\n");
+  });
+
+  it("interpolates env vars in command", async () => {
+    const output = join(tmpDir, "out.txt");
+    await shellProvider.run(
+      { command: "echo ${MY_VAR}", output },
+      makeCtx({ MY_VAR: "world" }),
+    );
+    expect(readFileSync(output, "utf-8")).toBe("world\n");
+  });
+
+  it("creates parent directories for output", async () => {
+    const output = join(tmpDir, "sub", "dir", "out.txt");
+    await shellProvider.run(
+      { command: "echo nested", output },
+      makeCtx(),
+    );
+    expect(existsSync(output)).toBe(true);
+  });
+
+  it("throws on missing command", async () => {
+    await expect(shellProvider.run({}, makeCtx())).rejects.toThrow(/requires a 'command' param/);
+  });
+
+  it("throws on command failure", async () => {
+    await expect(
+      shellProvider.run({ command: "exit 1" }, makeCtx()),
+    ).rejects.toThrow();
+  });
+
+  it("runs without output param (no capture)", async () => {
+    // Should not throw — just runs command
+    await shellProvider.run({ command: "true" }, makeCtx());
+  });
+});

--- a/test/preflight/registry.test.ts
+++ b/test/preflight/registry.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { resolvePreflightProvider, listPreflightProviders } from "../../src/preflight/registry.js";
+
+describe("resolvePreflightProvider", () => {
+  it("resolves shell provider", () => {
+    const p = resolvePreflightProvider("shell");
+    expect(p.id).toBe("shell");
+  });
+
+  it("resolves http provider", () => {
+    const p = resolvePreflightProvider("http");
+    expect(p.id).toBe("http");
+  });
+
+  it("resolves git-clone provider", () => {
+    const p = resolvePreflightProvider("git-clone");
+    expect(p.id).toBe("git-clone");
+  });
+
+  it("throws for unknown provider", () => {
+    expect(() => resolvePreflightProvider("ftp")).toThrow(
+      /Unknown preflight provider "ftp"/,
+    );
+  });
+});
+
+describe("listPreflightProviders", () => {
+  it("returns all built-in provider ids", () => {
+    const ids = listPreflightProviders();
+    expect(ids).toContain("shell");
+    expect(ids).toContain("http");
+    expect(ids).toContain("git-clone");
+  });
+});

--- a/test/preflight/runner.test.ts
+++ b/test/preflight/runner.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+import { runPreflight } from "../../src/preflight/runner.js";
+import type { PreflightStep, PreflightContext } from "../../src/preflight/schema.js";
+
+// Mock the registry to inject fake providers
+vi.mock("../../src/preflight/registry.js", () => ({
+  resolvePreflightProvider: (id: string) => {
+    if (id === "fail") {
+      return {
+        id: "fail",
+        run: async () => { throw new Error("step failed"); },
+      };
+    }
+    if (id === "ok") {
+      return {
+        id: "ok",
+        run: async () => {},
+      };
+    }
+    throw new Error(`Unknown preflight provider "${id}"`);
+  },
+}));
+
+function makeCtx(): PreflightContext & { logs: Array<{ level: string; msg: string }> } {
+  const logs: Array<{ level: string; msg: string }> = [];
+  return {
+    env: {},
+    logger: (level, msg) => { logs.push({ level, msg }); },
+    logs,
+  };
+}
+
+describe("runPreflight", () => {
+  it("runs all steps in order", async () => {
+    const steps: PreflightStep[] = [
+      { provider: "ok", params: {} },
+      { provider: "ok", params: {} },
+    ];
+    const ctx = makeCtx();
+    await runPreflight(steps, ctx);
+    const infoLogs = ctx.logs.filter((l) => l.level === "info");
+    expect(infoLogs.length).toBeGreaterThanOrEqual(3); // starting + 2 done
+  });
+
+  it("throws on required step failure", async () => {
+    const steps: PreflightStep[] = [
+      { provider: "fail", required: true, params: {} },
+    ];
+    const ctx = makeCtx();
+    await expect(runPreflight(steps, ctx)).rejects.toThrow(/Required preflight step "fail" failed/);
+  });
+
+  it("required defaults to true", async () => {
+    const steps: PreflightStep[] = [
+      { provider: "fail", params: {} }, // required omitted → true
+    ];
+    const ctx = makeCtx();
+    await expect(runPreflight(steps, ctx)).rejects.toThrow(/Required preflight step/);
+  });
+
+  it("continues past optional step failure", async () => {
+    const steps: PreflightStep[] = [
+      { provider: "fail", required: false, params: {} },
+      { provider: "ok", params: {} },
+    ];
+    const ctx = makeCtx();
+    await runPreflight(steps, ctx);
+    const warnLogs = ctx.logs.filter((l) => l.level === "warn");
+    expect(warnLogs.length).toBe(1);
+    expect(warnLogs[0].msg).toMatch(/optional/);
+  });
+
+  it("handles empty steps array", async () => {
+    const ctx = makeCtx();
+    await runPreflight([], ctx);
+    expect(ctx.logs.some((l) => l.msg.includes("preflight complete"))).toBe(true);
+  });
+});

--- a/test/shared/config.test.ts
+++ b/test/shared/config.test.ts
@@ -89,6 +89,71 @@ describe("loadAgentConfig", () => {
     expect(loaded.model.model).toBe("claude-sonnet-4-20250514");
   });
 
+  it("parses [[preflight]] array-of-tables with nested params", () => {
+    const agentDir = resolve(tmpDir, "with-preflight");
+    mkdirSync(agentDir, { recursive: true });
+    const toml = `
+credentials = ["github_token:default"]
+schedule = "0 * * * *"
+
+[model]
+provider = "anthropic"
+model = "claude-sonnet-4-20250514"
+thinkingLevel = "medium"
+authType = "api_key"
+
+[[preflight]]
+provider = "git-clone"
+required = true
+[preflight.params]
+repo = "acme/app"
+dest = "/tmp/repo"
+depth = 1
+
+[[preflight]]
+provider = "http"
+required = false
+[preflight.params]
+url = "https://api.test/flags"
+output = "/tmp/flags.json"
+headers = { Authorization = "Bearer \${TOKEN}" }
+
+[[preflight]]
+provider = "shell"
+[preflight.params]
+command = "echo hello"
+output = "/tmp/hello.txt"
+`;
+    writeFileSync(resolve(agentDir, "agent-config.toml"), toml);
+    const loaded = loadAgentConfig(tmpDir, "with-preflight");
+
+    expect(loaded.preflight).toHaveLength(3);
+    expect(loaded.preflight![0].provider).toBe("git-clone");
+    expect(loaded.preflight![0].required).toBe(true);
+    expect(loaded.preflight![0].params.repo).toBe("acme/app");
+    expect(loaded.preflight![0].params.depth).toBe(1);
+
+    expect(loaded.preflight![1].provider).toBe("http");
+    expect(loaded.preflight![1].required).toBe(false);
+    expect((loaded.preflight![1].params.headers as any).Authorization).toBe("Bearer ${TOKEN}");
+
+    expect(loaded.preflight![2].provider).toBe("shell");
+    expect(loaded.preflight![2].required).toBeUndefined(); // omitted → runner treats as true
+    expect(loaded.preflight![2].params.command).toBe("echo hello");
+  });
+
+  it("loads agent config without preflight", () => {
+    const agentDir = resolve(tmpDir, "no-preflight");
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(resolve(agentDir, "agent-config.toml"), stringifyTOML({
+      credentials: ["github_token:default"],
+      model: { provider: "anthropic", model: "claude-sonnet-4-20250514", thinkingLevel: "medium", authType: "api_key" },
+      schedule: "*/5 * * * *",
+    } as Record<string, unknown>));
+    const loaded = loadAgentConfig(tmpDir, "no-preflight");
+    expect(loaded.preflight).toBeUndefined();
+  });
+
   it("throws when agent config is missing", () => {
     expect(() => loadAgentConfig(tmpDir, "nonexistent")).toThrow("Agent config not found");
   });


### PR DESCRIPTION
## Summary

- Adds a `[[preflight]]` system to `agent-config.toml` for declarative data staging before agent runs
- Three built-in providers: `shell` (run commands), `http` (fetch URLs), `git-clone` (clone repos)
- Params support `${VAR}` env var interpolation (resolved against process.env with credentials already injected)
- Steps default to `required: true` — agent aborts on failure. Set `required: false` to warn and continue.
- Hooks into both container mode (`container-entry.ts`) and host mode (`runner.ts`) after credential setup, before LLM session creation

Closes #85

## Test plan

- [x] Unit tests for `interpolateString` / `interpolateParams` (11 tests)
- [x] Unit tests for each provider: shell (6), http (7), git-clone (8)
- [x] Unit tests for registry resolution (5 tests)
- [x] Unit tests for runner orchestration — required/optional/empty steps (5 tests)
- [x] Config parse test for `[[preflight]]` TOML round-trip with nested params (2 tests)
- [x] Full test suite passes (745 tests across 65 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)