### PR TITLE
feat: add --expose flag to al start for VPS/remote server deployment

### DIFF
--- a/.changeset/add-expose-flag.md
+++ b/.changeset/add-expose-flag.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Added `--expose` / `-e` flag to `al start` for VPS deployment. Binds the gateway to `0.0.0.0` (public) while keeping all local-mode features enabled (web UI, control routes, filesystem credentials, SQLite state). Closes #91.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Use cases:
 
 - A developer agent that watches for new Github issues and reacts (works great with OpenAI Codex for code generation)
 - A reviewer agent that watches for new Github Pull Requests and reviews them then merges if all ok
+- Deploy on a VPS (DigitalOcean, Vultr, Hetzner) for cost-effective remote hosting
 
 Have as many agents as you like. Customize the behaviour as you wish. The system is MIT licensed and fully extensible.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -154,6 +154,7 @@ al start -p .
 al start -p ./my-project
 al start -c                   # Run on cloud
 al start -w                   # Enable web dashboard
+al start -e -g                # VPS deployment: expose gateway publicly
 ```
 
 | Option | Description |
@@ -161,6 +162,9 @@ al start -w                   # Enable web dashboard
 | `-p, --project <dir>` | Project directory (default: `.`) |
 | `-c, --cloud` | Run on cloud infrastructure |
 | `-w, --web-ui` | Enable web dashboard (see [Web Dashboard](web-dashboard.md)) |
+| `-e, --expose` | Bind gateway to `0.0.0.0` (public) while keeping local-mode features |
+| `-g, --gateway` | Enable HTTP gateway server (required for webhooks and `--expose`) |
+| `-H, --headless` | Non-interactive mode (no TUI, no credential prompts) |
 
 ## `al stat`
 

--- a/docs/vps-deployment.md
+++ b/docs/vps-deployment.md
@@ -1,0 +1,177 @@
+# VPS Deployment
+
+Deploy Action Llama on any VPS (DigitalOcean, Vultr, Hetzner, etc.) for cost-effective remote hosting. This approach uses local-mode features (Docker, filesystem credentials, SQLite) with public gateway access.
+
+## Quick Start
+
+On your VPS:
+
+```bash
+# Install Action Llama
+npm install -g @action-llama/action-llama
+
+# Set up your project (or clone from git)
+al new my-project
+cd my-project
+
+# Configure credentials and check setup
+al doctor
+
+# Start with public gateway binding
+al start -g -w --expose --headless
+```
+
+## Key Features
+
+The `--expose` flag enables VPS deployment by:
+
+- **Binding gateway to `0.0.0.0`** — makes webhooks accessible from external services
+- **Preserving local-mode features** — web UI, control routes, filesystem credentials, SQLite state
+- **No cloud infrastructure required** — works on any Linux VPS
+
+## TLS Setup with Caddy
+
+For production, put a reverse proxy in front with TLS termination:
+
+### 1. Install Caddy
+
+```bash
+# Ubuntu/Debian
+sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+sudo apt update && sudo apt install caddy
+```
+
+### 2. Configure Caddy
+
+Edit `/etc/caddy/Caddyfile`:
+
+```
+your-domain.com {
+    reverse_proxy localhost:8080
+}
+```
+
+### 3. Start Caddy
+
+```bash
+sudo systemctl enable caddy
+sudo systemctl start caddy
+```
+
+## Process Management with systemd
+
+Create `/etc/systemd/system/action-llama.service`:
+
+```ini
+[Unit]
+Description=Action Llama Scheduler
+After=network.target
+
+[Service]
+Type=simple
+User=action-llama
+WorkingDirectory=/home/action-llama/my-project
+Environment=NODE_ENV=production
+ExecStart=/usr/local/bin/al start -g -w --expose --headless
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Start the service:
+
+```bash
+sudo systemctl enable action-llama
+sudo systemctl start action-llama
+```
+
+## Alternative: nohup
+
+For simpler setups, use `nohup`:
+
+```bash
+nohup al start -g -w --expose --headless > action-llama.log 2>&1 &
+```
+
+## Firewall Configuration
+
+Ensure your VPS firewall allows:
+
+- Port 22 (SSH)
+- Port 80 (HTTP, for Caddy)
+- Port 443 (HTTPS, for Caddy)
+- Port 8080 only if not using a reverse proxy
+
+Example with `ufw`:
+
+```bash
+sudo ufw allow ssh
+sudo ufw allow http
+sudo ufw allow https
+sudo ufw enable
+```
+
+## Security Considerations
+
+- **Use TLS in production** — Don't expose port 8080 directly without HTTPS
+- **Gateway API key** — Action Llama generates an API key for dashboard access (run `al doctor` to view it)
+- **Credentials isolation** — Each agent runs in a Docker container with only its required credentials
+- **User separation** — Run Action Llama as a non-root user
+
+## Monitoring
+
+Check service status:
+
+```bash
+# systemd
+sudo systemctl status action-llama
+
+# Logs
+al logs scheduler
+journalctl -u action-llama -f
+```
+
+## Cost Comparison
+
+| Provider | vCPU | RAM | Storage | Price/month |
+|----------|------|-----|---------|-------------|
+| DigitalOcean | 1 | 1GB | 25GB SSD | $6 |
+| Vultr | 1 | 1GB | 25GB SSD | $6 |
+| Hetzner | 1 | 2GB | 20GB SSD | €4.15 |
+| Linode | 1 | 1GB | 25GB SSD | $5 |
+
+Compare to managed cloud solutions that may cost $50+ per month for similar agent workloads.
+
+## Troubleshooting
+
+### Gateway not accessible externally
+
+- Check firewall settings
+- Verify `--expose` flag is used
+- Ensure `-g` (gateway) flag is enabled
+
+### Docker issues
+
+```bash
+# Check Docker daemon
+sudo systemctl status docker
+
+# Test Docker access
+docker ps
+```
+
+### Webhook delivery failures
+
+- Check reverse proxy configuration
+- Verify TLS certificate is valid
+- Test webhook URL accessibility from external services
+
+### Out of disk space
+
+- Clean up old Docker images: `docker system prune -a`
+- Rotate logs: configure systemd journal limits
+- Monitor disk usage: `df -h`

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -5,7 +5,7 @@ import { startScheduler } from "../../scheduler/index.js";
 import { StatusTracker } from "../../tui/status-tracker.js";
 import { execute as runDoctor } from "./doctor.js";
 
-export async function execute(opts: { project: string; cloud?: boolean; headless?: boolean; gateway?: boolean; webUi?: boolean }): Promise<void> {
+export async function execute(opts: { project: string; cloud?: boolean; headless?: boolean; gateway?: boolean; webUi?: boolean; expose?: boolean }): Promise<void> {
   const projectPath = resolve(opts.project);
 
   // Guard: refuse to run if the project path looks like an agent directory
@@ -19,6 +19,11 @@ export async function execute(opts: { project: string; cloud?: boolean; headless
   // Auto-enable gateway when web UI is requested
   if (opts.webUi && !opts.gateway) {
     opts.gateway = true;
+  }
+
+  // Warn if --expose is used without a gateway API key configured
+  if (opts.expose && !opts.gateway) {
+    console.warn("Warning: --expose flag used but gateway is not enabled. Use -g/--gateway to enable the gateway server for external access.");
   }
 
   // Ensure all credentials are present before starting
@@ -74,7 +79,7 @@ export async function execute(opts: { project: string; cloud?: boolean; headless
   }
 
   const { cronJobs, runnerPools, gateway, webhookRegistry, webhookUrls } = await startScheduler(
-    projectPath, globalConfig, statusTracker, opts.cloud, opts.gateway, opts.webUi
+    projectPath, globalConfig, statusTracker, opts.cloud, opts.gateway, opts.webUi, opts.expose
   );
 
   const gatewayPort = gateway ? (globalConfig.gateway?.port || 8080) : null;

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -77,6 +77,7 @@ program
   .option("-H, --headless", "non-interactive mode (no TUI, no credential prompts, for CI/deploy environments)")
   .option("-g, --gateway", "enable the HTTP gateway server (required for webhooks, locks, and web UI)")
   .option("-w, --web-ui", "enable web dashboard at http://localhost:<port>/dashboard (auto-enables gateway)")
+  .option("-e, --expose", "bind gateway to 0.0.0.0 (public) while keeping local mode features")
   .action(withCommand(async (opts) => {
     initializeTelemetryForProject(opts.project);
     const { execute } = await import("./commands/start.js");

--- a/src/scheduler/index.ts
+++ b/src/scheduler/index.ts
@@ -286,7 +286,7 @@ async function runWithReruns(
   );
 }
 
-export async function startScheduler(projectPath: string, globalConfigOverride?: GlobalConfig, statusTracker?: StatusTracker, cloudMode?: boolean, gatewayEnabled?: boolean, webUI?: boolean) {
+export async function startScheduler(projectPath: string, globalConfigOverride?: GlobalConfig, statusTracker?: StatusTracker, cloudMode?: boolean, gatewayEnabled?: boolean, webUI?: boolean, expose?: boolean) {
   const mkLogger = statusTracker ? createFileOnlyLogger : createLogger;
   const logger = mkLogger(projectPath, "scheduler");
   logger.info("Starting scheduler...");
@@ -433,7 +433,7 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
     const gatewayPort = globalConfig.gateway?.port || 8080;
     gateway = await startGateway({
       port: gatewayPort,
-      hostname: cloudMode ? "0.0.0.0" : "127.0.0.1",
+      hostname: (cloudMode || expose) ? "0.0.0.0" : "127.0.0.1",
       logger: mkLogger(projectPath, "gateway"),
       killContainer: undefined, // Runtime not ready yet, will handle container ops later
       webhookRegistry,

--- a/test/cli/commands/start.test.ts
+++ b/test/cli/commands/start.test.ts
@@ -44,6 +44,7 @@ describe("start", () => {
       expect.any(StatusTracker),
       undefined,
       undefined,
+      undefined,
       undefined
     );
 


### PR DESCRIPTION
Closes #91

## Summary

Add `--expose` / `-e` flag to `al start` that binds the gateway to `0.0.0.0` while keeping all local-mode features enabled. This allows users to deploy Action Llama on cost-effective VPS providers like DigitalOcean, Vultr, or Hetzner without requiring full cloud infrastructure setup.

## Implementation

- **CLI**: Added `--expose` / `-e` option to the start command
- **Core logic**: Modified hostname binding in scheduler to use `(cloudMode || expose)`
- **Validation**: Added startup warning when `--expose` is used without gateway enabled
- **Testing**: Updated tests to handle new parameter
- **Documentation**: Updated README.md, docs/commands.md, and added comprehensive VPS deployment guide

## Key Features

- Binds gateway to `0.0.0.0` for public access
- Preserves all local-mode features (web UI, control routes, filesystem credentials, SQLite state)
- Zero new infrastructure requirements
- Works with any Linux VPS
- Comprehensive deployment guide with TLS, systemd, and security considerations

## User Flow

```bash
# On a VPS:
al doctor
al start -g -w --expose --headless
# Put Caddy/nginx in front for TLS
```

## Changes Made

1. `src/cli/main.ts` - Added `--expose` / `-e` option
2. `src/cli/commands/start.ts` - Thread expose option and add warning
3. `src/scheduler/index.ts` - Updated hostname logic
4. `test/cli/commands/start.test.ts` - Updated test expectations
5. `README.md` - Added VPS use case
6. `docs/commands.md` - Documented new flag
7. `docs/vps-deployment.md` - Comprehensive deployment guide
8. `.changeset/add-expose-flag.md` - Added changeset for release