### PR TITLE
feat: preserve queues on SIGTERM, add `al stop` command

### DIFF
--- a/.changeset/preserve-queues-add-stop.md
+++ b/.changeset/preserve-queues-add-stop.md
@@ -1,0 +1,10 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Preserve webhook queues on SIGTERM and add `al stop` command. Previously, shutting down
+the scheduler (SIGINT/SIGTERM) called `clearAll()` which deleted queued events from the
+persistent StateStore, losing pending webhook events during rolling updates. Now the signal
+handler only clears in-memory state, preserving persistent queues for the next instance.
+The new `al stop` command intentionally clears both in-memory and persistent queues for a
+clean shutdown. Closes #95.

--- a/src/cli/commands/stop.ts
+++ b/src/cli/commands/stop.ts
@@ -1,0 +1,28 @@
+import { resolve } from "path";
+import { gatewayFetch } from "../gateway-client.js";
+
+export async function execute(opts: { project: string }): Promise<void> {
+  const projectPath = resolve(opts.project);
+
+  let response: Response;
+  try {
+    response = await gatewayFetch({
+      project: projectPath,
+      path: "/control/stop",
+      method: "POST",
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('ECONNREFUSED')) {
+      throw new Error("Gateway not running. Start the scheduler with --gateway (-g) flag.");
+    }
+    throw error;
+  }
+
+  const data = await response.json();
+
+  if (response.ok) {
+    console.log(`${data.message}`);
+  } else {
+    throw new Error(data.error);
+  }
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -84,6 +84,15 @@ program
   }));
 
 program
+  .command("stop")
+  .description("Stop the scheduler and clear pending webhook queues")
+  .option("-p, --project <dir>", "project directory", ".")
+  .action(withCommand(async (opts) => {
+    const { execute } = await import("./commands/stop.js");
+    await execute(opts);
+  }));
+
+program
   .command("doctor")
   .description("Check agents, credentials, webhooks, and config — prompt to fix")
   .option("-p, --project <dir>", "project directory", ".")

--- a/src/gateway/routes/control.ts
+++ b/src/gateway/routes/control.ts
@@ -10,6 +10,7 @@ export interface ControlRoutesDeps {
   triggerAgent?: (name: string) => Promise<boolean>;
   enableAgent?: (name: string) => Promise<boolean>;
   disableAgent?: (name: string) => Promise<boolean>;
+  stopScheduler?: () => Promise<void>;
 }
 
 export function registerControlRoutes(app: Hono, deps: ControlRoutesDeps) {
@@ -62,6 +63,16 @@ export function registerControlRoutes(app: Hono, deps: ControlRoutesDeps) {
       const message = error instanceof Error ? error.message : String(error);
       return c.json({ error: `Failed to resume scheduler: ${message}` }, 500);
     }
+  });
+
+  // POST /control/stop - Stop the scheduler and clear queues
+  app.post("/control/stop", async (c) => {
+    if (!deps.stopScheduler) {
+      return c.json({ error: "Stop not available" }, 503);
+    }
+    // Respond before shutting down so the client gets a response
+    setTimeout(() => { deps.stopScheduler!().catch(() => {}); }, 100);
+    return c.json({ success: true, message: "Scheduler stopping" });
   });
 
   // POST /control/trigger/:name - Trigger an agent run

--- a/src/scheduler/event-queue.ts
+++ b/src/scheduler/event-queue.ts
@@ -95,6 +95,12 @@ export class WorkQueue<T> {
     this.store?.deleteAll(NS).catch(() => {});
   }
 
+  /** Clear in-memory queues only — persistent state survives for the next instance. */
+  clearInMemory(): void {
+    this.queues.clear();
+    // Does NOT touch this.store — persistent state survives for the next instance
+  }
+
   private persist(agentName: string): void {
     const queue = this.queues.get(agentName);
     if (!queue || queue.length === 0) {

--- a/src/scheduler/index.ts
+++ b/src/scheduler/index.ts
@@ -502,6 +502,19 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
           statusTracker.disableAgent(name);
           return true;
         },
+        stopScheduler: async () => {
+          logger.info("Stop requested via control API");
+          schedulerCtx.shuttingDown = true;
+          webhookQueue.clearAll();
+          agentTriggerQueue.clearInMemory();
+          for (const job of cronJobs) job.stop();
+          if (gateway) await gateway.close();
+          if (stateStore) await stateStore.close();
+          if (telemetry) {
+            try { await telemetry.shutdown(); } catch {}
+          }
+          process.exit(0);
+        },
       },
     });
     logger.info({ port: gatewayPort }, "Gateway started early to show build progress");
@@ -790,8 +803,8 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
   const shutdown = async () => {
     logger.info("Shutting down scheduler...");
     schedulerCtx.shuttingDown = true;
-    webhookQueue.clearAll();
-    agentTriggerQueue.clearAll();
+    webhookQueue.clearInMemory();
+    agentTriggerQueue.clearInMemory();
     for (const job of cronJobs) {
       job.stop();
     }

--- a/test/gateway/routes/control.test.ts
+++ b/test/gateway/routes/control.test.ts
@@ -143,6 +143,26 @@ describe("GET /control/status", () => {
   });
 });
 
+describe("POST /control/stop", () => {
+  it("returns 200 when stopScheduler is available", async () => {
+    const stopScheduler = vi.fn(async () => {});
+    const { app } = setup({ stopScheduler });
+    const res = await app.request("/control/stop", { method: "POST" });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.message).toContain("stopping");
+  });
+
+  it("returns 503 when stopScheduler is undefined", async () => {
+    const { app } = setup({ stopScheduler: undefined });
+    const res = await app.request("/control/stop", { method: "POST" });
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toContain("Stop not available");
+  });
+});
+
 describe("POST /control/pause (scheduler)", () => {
   it("pauses the scheduler", async () => {
     const pauseScheduler = vi.fn(async () => {});

--- a/test/scheduler/event-queue.test.ts
+++ b/test/scheduler/event-queue.test.ts
@@ -120,4 +120,29 @@ describe("WebhookEventQueue", () => {
     expect(queue.size("agent-a")).toBe(0);
     expect(queue.size("agent-b")).toBe(0);
   });
+
+  it("clearInMemory clears in-memory state without touching the store", () => {
+    const mockStore = {
+      get: vi.fn(),
+      set: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      deleteAll: vi.fn().mockResolvedValue(undefined),
+      list: vi.fn().mockResolvedValue([]),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    const queue = new WebhookEventQueue<string>(100, mockStore as any);
+    queue.enqueue("agent-a", "a-event");
+    queue.enqueue("agent-b", "b-event");
+
+    // Reset mock counts after enqueue calls (which trigger persist -> set)
+    mockStore.delete.mockClear();
+    mockStore.deleteAll.mockClear();
+
+    queue.clearInMemory();
+
+    expect(queue.size("agent-a")).toBe(0);
+    expect(queue.size("agent-b")).toBe(0);
+    expect(mockStore.delete).not.toHaveBeenCalled();
+    expect(mockStore.deleteAll).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- SIGTERM/SIGINT now only clears in-memory queue state, preserving persistent queues so new instances pick up pending webhook events during rolling updates
- New `al stop` CLI command provides explicit full shutdown that clears persistent queues via `POST /control/stop`
- Added `clearInMemory()` method to `WorkQueue` for in-memory-only cleanup

## Test plan

- [x] `npm test` — all 757 tests pass (including new tests for `clearInMemory()` and `/control/stop` route)
- [x] `npm run build` — compiles cleanly
- [ ] Manual: `al start -g`, then `al stop` from another terminal — scheduler exits, queues cleared
- [ ] Manual: `al start -g`, Ctrl+C — scheduler exits, persistent queues preserved

Closes #95