### PR TITLE
docs: document webhook trigger field validation in al doctor command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -20,10 +20,25 @@ After setup, create agents by following [Creating Agents](creating-agents.md).
 
 Checks all agent credentials and interactively prompts for any that are missing. Discovers agents in the project, collects their credential requirements (plus any webhook secret credentials), and ensures each one exists on disk. Also generates a gateway API key if one doesn't exist yet (used for dashboard and CLI authentication).
 
+Additionally validates webhook trigger fields in agent configurations to catch common configuration errors early, such as:
+- Using `repository` instead of `repos`
+- Misspelled field names (e.g., `event` instead of `events`)  
+- Provider-specific invalid fields (e.g., using GitHub fields with Sentry webhooks)
+
+When validation errors are found, `al doctor` will display helpful suggestions and exit with an error.
+
 ```bash
 al doctor -p .
 al doctor -p ./my-project
 al doctor -c               # Also push creds to cloud + reconcile IAM
+```
+
+When webhook trigger validation errors are found, you'll see helpful error messages:
+
+```
+Invalid webhook trigger configuration:
+  - Agent "dev" webhook trigger: unrecognized field "repository" for github provider. Did you mean "repos"?
+  - Agent "notifier" webhook trigger: unrecognized field "event" for github provider. Did you mean "events"?
 ```
 
 | Option | Description |


### PR DESCRIPTION
Addresses issue #106

This PR updates the documentation for the `al doctor` command to include information about the recently added webhook trigger field validation functionality (commit 653cd03).

## Changes Made:
- Added explanation that `al doctor` now validates webhook trigger fields to catch configuration errors early
- Listed specific examples of common errors that are caught:
  - Using `repository` instead of `repos`
  - Misspelled field names like `event` instead of `events`
  - Provider-specific invalid fields
- Added example output showing what validation error messages look like with helpful suggestions

## Testing:
- [x] Reviewed the commit 653cd03 to understand the validation functionality
- [x] Verified the documentation accurately reflects the implementation
- [x] Added clear examples that help users understand the feature

This improvement helps users discover that `al doctor` is not just for checking credentials, but also for validating webhook configurations, making it easier to catch configuration mistakes early.