### PR TITLE
docs: document 'orgs' and 'org' filters for GitHub webhook triggers

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -49,12 +49,40 @@ An agent must have at least one of `schedule` or `webhooks` (or both).
 | Field | Type | Description |
 |-------|------|-------------|
 | `repos` | string[] | Only trigger for these repos |
+| `orgs` | string[] | Only trigger for these GitHub organizations |
+| `org` | string | Only trigger for this GitHub organization (convenience shorthand for `orgs`) |
 | `events` | string[] | GitHub event types (issues, pull_request, push, etc.) |
 | `actions` | string[] | Event actions (opened, labeled, closed, etc.) |
 | `labels` | string[] | Only when issue/PR has these labels |
 | `assignee` | string | Only when assigned to this user |
 | `author` | string | Only for this author |
 | `branches` | string[] | Only for these branches |
+
+### Example Configuration
+
+Filter by organization(s):
+
+```toml
+# Multiple organizations using orgs
+[[webhooks]]
+source = "my-github"
+orgs = ["acme", "example-org"]
+events = ["issues"]
+
+# Single organization using org (convenience shorthand)
+[[webhooks]]
+source = "my-github"
+org = "acme"
+events = ["pull_request"]
+
+# Combine with other filters
+[[webhooks]]
+source = "my-github"
+org = "acme"
+repos = ["acme/frontend", "acme/api"]
+events = ["issues", "pull_request"]
+actions = ["opened", "labeled"]
+```
 
 ### Setup
 


### PR DESCRIPTION
Addresses issue #105

This PR updates the GitHub Webhooks documentation to include the recently added `orgs` and `org` filter fields (commit 653cd03).

## Changes Made:
- Added `orgs` and `org` fields to the GitHub Webhooks filter fields table
- Documented that `orgs` accepts an array of organization names
- Documented that `org` is a convenience shorthand for filtering by a single organization
- Added comprehensive example configurations showing:
  - Multiple organizations using `orgs = ["acme", "example-org"]`
  - Single organization using `org = "acme"`
  - Combining organization filters with other webhook filters

## Background:
The recent commit 653cd03 fixed an issue where the `orgs` field was being silently dropped when building GitHub webhook filters. This PR ensures users can discover and properly use this filtering capability for organization-level webhook filtering.

## Testing:
- [x] Reviewed commit 653cd03 to understand the implementation
- [x] Verified documentation accurately reflects both `orgs` and `org` functionality  
- [x] Added clear examples that demonstrate practical usage patterns