### PR TITLE
fix: Add Hetzner VPS provisioning support

### DIFF
--- a/.changeset/add-hetzner-vps-provisioning.md
+++ b/.changeset/add-hetzner-vps-provisioning.md
@@ -1,0 +1,8 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Added support for Hetzner VPS provisioning alongside existing Vultr support. 
+Users can now provision Hetzner Cloud servers via `al setup cloud` with the 
+same Cloudflare HTTPS integration. Requires a `hetzner_api_key` credential.
+Closes #119.

--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -74,9 +74,10 @@ al doctor -c    # Push creds to VPS via SSH
 al start -c     # Start on VPS
 ```
 
-Setup supports two paths:
+Setup supports three paths:
 - **Connect to an existing server** — any provider, any server with Docker installed
 - **Provision a new Vultr VPS** — automated instance creation with cloud-init Docker install
+- **Provision a new Hetzner VPS** — automated server creation with cloud-init Docker install
 
 See [VPS docs](vps-deployment.md) for full setup.
 

--- a/docs/vps-deployment.md
+++ b/docs/vps-deployment.md
@@ -38,13 +38,23 @@ Requirements:
 
 #### Provision a new Vultr VPS
 
-Automated provisioning with Vultr as the first supported backend:
+Automated provisioning with Vultr as a supported backend:
 
 1. Configure `vultr_api_key` credential first: `al creds add vultr_api_key`
 2. Run `al setup cloud` and select "Provision a new Vultr VPS"
 3. Pick region, plan (minimum 2 vCPU / 2GB RAM), and SSH key
 4. Instance is created with cloud-init that installs Docker automatically
 5. Action Llama waits for the instance to become ready
+
+#### Provision a new Hetzner VPS
+
+Automated provisioning with Hetzner Cloud:
+
+1. Configure `hetzner_api_key` credential first: `al creds add hetzner_api_key`
+2. Run `al setup cloud` and select "Provision a new Hetzner VPS"
+3. Pick server type, location, OS image, and SSH key
+4. Server is created with cloud-init that installs Docker automatically
+5. Action Llama waits for the server to become ready
 
 ### How It Works
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@action-llama/action-llama",
-  "version": "0.11.11",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@action-llama/action-llama",
-      "version": "0.11.11",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/src/cloud/vps/hetzner-api.ts
+++ b/src/cloud/vps/hetzner-api.ts
@@ -1,0 +1,246 @@
+/**
+ * Hetzner Cloud API v1 client.
+ * Plain fetch() wrapper — no SDK dependency.
+ */
+
+const BASE_URL = "https://api.hetzner.cloud/v1";
+
+export interface HetznerLocation {
+  id: number;
+  name: string;
+  description: string;
+  country: string;
+  city: string;
+  latitude: number;
+  longitude: number;
+  network_zone: string;
+}
+
+export interface HetznerServerType {
+  id: number;
+  name: string;
+  description: string;
+  cores: number;
+  memory: number; // GB
+  disk: number; // GB
+  architecture: string;
+  prices: Array<{
+    location: string;
+    price_hourly: {
+      net: string;
+      gross: string;
+    };
+    price_monthly: {
+      net: string;
+      gross: string;
+    };
+  }>;
+  supported_images: number[];
+  available_locations?: number[];
+}
+
+export interface HetznerImage {
+  id: number;
+  type: string;
+  status: string;
+  name: string;
+  description: string;
+  os_flavor: string;
+  os_version: string;
+  architecture: string;
+  deprecated: string | null;
+}
+
+export interface HetznerSshKey {
+  id: number;
+  name: string;
+  fingerprint: string;
+  public_key: string;
+  labels: Record<string, string>;
+  created: string;
+}
+
+export interface HetznerServer {
+  id: number;
+  name: string;
+  status: string;
+  public_net: {
+    ipv4: {
+      ip: string;
+      blocked: boolean;
+    };
+    ipv6: {
+      ip: string;
+      blocked: boolean;
+    };
+  };
+  server_type: {
+    id: number;
+    name: string;
+    cores: number;
+    memory: number;
+    disk: number;
+  };
+  datacenter: {
+    id: number;
+    name: string;
+    location: {
+      id: number;
+      name: string;
+      country: string;
+      city: string;
+    };
+  };
+  created: string;
+}
+
+export interface HetznerFirewall {
+  id: number;
+  name: string;
+  labels: Record<string, string>;
+  rules: Array<{
+    direction: "in" | "out";
+    port?: string;
+    protocol: "tcp" | "udp" | "icmp" | "esp" | "gre";
+    source_ips: string[];
+    destination_ips?: string[];
+    description?: string;
+  }>;
+  applied_to: Array<{
+    type: string;
+    server?: number;
+  }>;
+  created: string;
+}
+
+class HetznerApiError extends Error {
+  constructor(public statusCode: number, message: string) {
+    super(message);
+    this.name = "HetznerApiError";
+  }
+}
+
+async function hetznerFetch(
+  apiKey: string,
+  path: string,
+  options: RequestInit = {},
+): Promise<any> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      ...options.headers,
+    },
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: { message: "Unknown error" } }));
+    const errorMessage = body.error?.message || `HTTP ${res.status}`;
+    throw new HetznerApiError(res.status, `Hetzner API ${path} failed: ${errorMessage}`);
+  }
+
+  // Some endpoints return 204 No Content
+  if (res.status === 204) return undefined;
+  return res.json();
+}
+
+export async function listLocations(apiKey: string): Promise<HetznerLocation[]> {
+  const data = await hetznerFetch(apiKey, "/locations");
+  return data.locations;
+}
+
+export async function listServerTypes(apiKey: string): Promise<HetznerServerType[]> {
+  const data = await hetznerFetch(apiKey, "/server_types");
+  // Hetzner API includes supported locations per server type
+  return data.server_types;
+}
+
+export async function listImages(apiKey: string): Promise<HetznerImage[]> {
+  // Filter to only OS images (not snapshots/backups)
+  const data = await hetznerFetch(apiKey, "/images?type=system");
+  return data.images;
+}
+
+export async function listSshKeys(apiKey: string): Promise<HetznerSshKey[]> {
+  const data = await hetznerFetch(apiKey, "/ssh_keys");
+  return data.ssh_keys;
+}
+
+export async function createSshKey(apiKey: string, name: string, publicKey: string): Promise<HetznerSshKey> {
+  const data = await hetznerFetch(apiKey, "/ssh_keys", {
+    method: "POST",
+    body: JSON.stringify({ name, public_key: publicKey }),
+  });
+  return data.ssh_key;
+}
+
+export async function createServer(
+  apiKey: string,
+  opts: {
+    name: string;
+    server_type: string;
+    location: string;
+    image: string | number;
+    ssh_keys: number[];
+    user_data?: string; // cloud-init script (not base64 for Hetzner)
+    firewalls?: number[];
+    labels?: Record<string, string>;
+  },
+): Promise<HetznerServer> {
+  const data = await hetznerFetch(apiKey, "/servers", {
+    method: "POST",
+    body: JSON.stringify(opts),
+  });
+  return data.server;
+}
+
+export async function getServer(apiKey: string, serverId: number): Promise<HetznerServer> {
+  const data = await hetznerFetch(apiKey, `/servers/${serverId}`);
+  return data.server;
+}
+
+export async function deleteServer(apiKey: string, serverId: number): Promise<void> {
+  await hetznerFetch(apiKey, `/servers/${serverId}`, { method: "DELETE" });
+}
+
+// --- Firewalls ---
+
+export async function listFirewalls(apiKey: string): Promise<HetznerFirewall[]> {
+  const data = await hetznerFetch(apiKey, "/firewalls");
+  return data.firewalls;
+}
+
+export async function createFirewall(
+  apiKey: string,
+  name: string,
+  rules: Array<{
+    direction: "in" | "out";
+    protocol: "tcp" | "udp" | "icmp" | "esp" | "gre";
+    source_ips: string[];
+    port?: string;
+    description?: string;
+  }>,
+): Promise<HetznerFirewall> {
+  const data = await hetznerFetch(apiKey, "/firewalls", {
+    method: "POST",
+    body: JSON.stringify({ name, rules }),
+  });
+  return data.firewall;
+}
+
+export async function applyFirewallToServer(
+  apiKey: string,
+  firewallId: number,
+  serverId: number,
+): Promise<void> {
+  await hetznerFetch(apiKey, `/firewalls/${firewallId}/actions/apply_to_resources`, {
+    method: "POST",
+    body: JSON.stringify({
+      apply_to: [{
+        type: "server",
+        server: { id: serverId },
+      }],
+    }),
+  });
+}

--- a/src/cloud/vps/provision.ts
+++ b/src/cloud/vps/provision.ts
@@ -64,6 +64,7 @@ export async function setupVpsCloud(onInstanceCreated?: OnInstanceCreated): Prom
     choices: [
       { name: "Connect to an existing server (any provider)", value: "existing" as const },
       { name: "Provision a new Vultr VPS", value: "vultr" as const },
+      { name: "Provision a new Hetzner VPS", value: "hetzner" as const },
     ],
   });
 
@@ -71,10 +72,14 @@ export async function setupVpsCloud(onInstanceCreated?: OnInstanceCreated): Prom
     return setupExistingServer();
   }
 
-  // Offer Cloudflare HTTPS before Vultr provisioning
+  // Offer Cloudflare HTTPS before VPS provisioning
   const cfConfig = await promptCloudflareHttps();
 
-  return provisionVultr(onInstanceCreated, cfConfig);
+  if (mode === "vultr") {
+    return provisionVultr(onInstanceCreated, cfConfig);
+  }
+
+  return provisionHetzner(onInstanceCreated, cfConfig);
 }
 
 /**
@@ -529,6 +534,443 @@ async function provisionVultr(onInstanceCreated?: OnInstanceCreated, cfConfig?: 
   if (sshKeyPath !== VPS_CONSTANTS.DEFAULT_SSH_KEY_PATH) result.sshKeyPath = sshKeyPath;
 
   // Post-VPS Cloudflare HTTPS setup
+  if (cfConfig) {
+    try {
+      result.cloudflareHostname = cfConfig.hostname;
+      result.cloudflareZoneId = cfConfig.zoneId;
+
+      const {
+        upsertDnsRecord,
+        createOriginCertificate,
+        setSslMode,
+      } = await import("./cloudflare-api.js");
+      const { installNginx, configureNginx } = await import("./nginx.js");
+
+      // 1. DNS record
+      console.log(`\nCreating DNS record: ${cfConfig.hostname} → ${sshConfig.host}...`);
+      try {
+        const dnsRecord = await upsertDnsRecord(cfConfig.apiToken, cfConfig.zoneId, cfConfig.hostname, sshConfig.host, true);
+        result.cloudflareDnsRecordId = dnsRecord.id;
+        console.log(`DNS record created (${dnsRecord.id}).`);
+      } catch (err: any) {
+        console.error(`Warning: DNS record creation failed: ${err.message}`);
+        console.error(`Falling back to http://${sshConfig.host}:${VPS_CONSTANTS.DEFAULT_GATEWAY_PORT}`);
+        return result;
+      }
+
+      // 2. Origin CA certificate
+      let cert: string, key: string;
+      try {
+        const existingCert = await backend.read("cloudflare_origin_cert", cfConfig.hostname, "certificate");
+        const existingKey = await backend.read("cloudflare_origin_cert", cfConfig.hostname, "private_key");
+        const shouldGenerate = existingCert && existingKey
+          ? await confirm({ message: "Origin CA certificate already exists. Regenerate?", default: false })
+          : true;
+
+        if (shouldGenerate) {
+          console.log("Generating Cloudflare Origin CA certificate...");
+          const originCert = await createOriginCertificate(cfConfig.apiToken, [cfConfig.hostname], 5475);
+          cert = originCert.certificate;
+          key = originCert.private_key;
+          console.log("Origin CA certificate generated.");
+          await writeCredentialFields("cloudflare_origin_cert", cfConfig.hostname, {
+            certificate: cert,
+            private_key: key,
+          });
+          console.log(`Origin CA cert saved to credentials (cloudflare_origin_cert/${cfConfig.hostname}).`);
+        } else {
+          cert = existingCert!;
+          key = existingKey!;
+          console.log("Using existing Origin CA certificate.");
+        }
+      } catch (err: any) {
+        console.error(`Warning: Origin CA certificate creation failed: ${err.message}`);
+        console.error("You can generate one manually at https://dash.cloudflare.com → SSL/TLS → Origin Server.");
+        return result;
+      }
+
+      // 3. Install nginx
+      console.log("Installing nginx...");
+      try {
+        await installNginx(sshConfig);
+        console.log("nginx installed.");
+      } catch (err: any) {
+        console.error(`Warning: nginx installation failed: ${err.message}`);
+        console.error(`SSH into the server and install manually: ssh ${sshConfig.user}@${sshConfig.host}`);
+        return result;
+      }
+
+      // 4. Configure nginx with cert
+      console.log("Configuring nginx TLS reverse proxy...");
+      try {
+        await configureNginx(sshConfig, cfConfig.hostname, cert, key, VPS_CONSTANTS.DEFAULT_GATEWAY_PORT);
+        console.log("nginx configured.");
+      } catch (err: any) {
+        console.error(`Warning: nginx configuration failed: ${err.message}`);
+        console.error(`SSH into the server to configure manually: ssh ${sshConfig.user}@${sshConfig.host}`);
+        return result;
+      }
+
+      // 5. Set SSL mode to strict
+      console.log("Setting Cloudflare SSL mode to strict...");
+      try {
+        await setSslMode(cfConfig.apiToken, cfConfig.zoneId, "strict");
+        console.log("SSL mode set to strict.");
+      } catch (err: any) {
+        console.error(`Warning: Failed to set SSL mode: ${err.message}`);
+        console.error("Set SSL/TLS mode to 'Full (strict)' manually in the Cloudflare dashboard.");
+      }
+
+      // 6. Verify nginx is proxying correctly
+      const healthCheck = await sshExec(sshConfig, "curl -sf http://localhost/health", 10_000);
+      if (healthCheck.exitCode === 0) {
+        console.log("nginx reverse proxy verified.");
+      } else {
+        console.log("Note: nginx health check returned non-zero (gateway may not be running yet).");
+      }
+
+      result.gatewayUrl = `https://${cfConfig.hostname}`;
+    } catch (err: any) {
+      console.error(`Cloudflare HTTPS setup encountered an error: ${err.message}`);
+      console.error(`VPS is still available at ${sshConfig.host}. HTTPS can be configured manually.`);
+    }
+  }
+
+  return result;
+}
+
+async function provisionHetzner(onInstanceCreated?: OnInstanceCreated, cfConfig?: CloudflareConfig | null): Promise<Record<string, unknown> | null> {
+  // 1. Read Hetzner API key — prompt inline if missing
+  const backend = new FilesystemBackend();
+  let apiKeyValue = await backend.read("hetzner_api_key", "default", "api_key");
+  if (!apiKeyValue) {
+    console.log("Hetzner API key not found.");
+    const enteredKey = await password({
+      message: "Enter your Hetzner API key (from https://console.hetzner.cloud → Security → API tokens):",
+      mask: "*",
+      validate: (v: string) => v.trim() ? true : "API key is required",
+    });
+    apiKeyValue = enteredKey.trim();
+    await writeCredentialField("hetzner_api_key", "default", "api_key", apiKeyValue);
+    console.log("Hetzner API key saved.");
+  }
+
+  const {
+    listLocations,
+    listServerTypes,
+    listImages,
+    listSshKeys,
+    createSshKey,
+    createServer,
+    getServer,
+    listFirewalls,
+    createFirewall,
+    applyFirewallToServer,
+  } = await import("./hetzner-api.js");
+
+  // Fetch server types + locations + OS images + SSH keys in parallel
+  console.log("\nFetching Hetzner catalog...");
+  const [serverTypes, locations, allImages, existingKeys] = await Promise.all([
+    listServerTypes(apiKeyValue),
+    listLocations(apiKeyValue),
+    listImages(apiKeyValue),
+    listSshKeys(apiKeyValue),
+  ]);
+
+  // Filter to x86 Linux images
+  const linuxImages = allImages.filter((img) => 
+    img.architecture === "x86" && 
+    !img.deprecated &&
+    (img.os_flavor === "ubuntu" || img.os_flavor === "debian" || img.os_flavor === "fedora" || img.os_flavor === "centos" || img.os_flavor === "rocky" || img.os_flavor === "alma")
+  );
+
+  // Step-based wizard: Esc goes back to the previous step
+  // Steps: 0=Server Type, 1=Location, 2=OS, 3=SSH key
+  let step = 0;
+  let serverTypeChoice = "";
+  let locationChoice = "";
+  let imageChoice = "";
+  let sshKeyId = 0;
+  let sshKeyPath: string = VPS_CONSTANTS.DEFAULT_SSH_KEY_PATH;
+
+  while (step < 4) {
+    if (step === 0) {
+      // Pick server type first (searchable)
+      const typeChoices = serverTypes
+        .sort((a, b) => {
+          // Sort by monthly price (parse from string)
+          const priceA = parseFloat(a.prices[0]?.price_monthly.gross || "0");
+          const priceB = parseFloat(b.prices[0]?.price_monthly.gross || "0");
+          return priceA - priceB;
+        })
+        .map((st) => {
+          const price = st.prices[0]?.price_monthly.gross || "0";
+          return {
+            name: `${st.name} — ${st.cores} vCPU / ${st.memory}GB RAM / ${st.disk}GB SSD — €${price}/mo`,
+            value: st.name,
+          };
+        });
+
+      const result = await searchWithEsc({ message: "Server Type:", choices: typeChoices });
+      if (result === null) return null; // Esc at first step → abort
+      serverTypeChoice = result;
+      step++;
+    } else if (step === 1) {
+      // Pick location (filtered to where the selected server type is available)
+      const selectedType = serverTypes.find((st) => st.name === serverTypeChoice)!;
+      const availableLocationIds = new Set(selectedType.available_locations || []);
+      
+      const locationChoices = locations
+        .filter((loc) => availableLocationIds.has(loc.id))
+        .sort((a, b) => a.city.localeCompare(b.city))
+        .map((loc) => ({
+          name: `${loc.city}, ${loc.country} (${loc.name})`,
+          value: loc.name,
+        }));
+
+      if (locationChoices.length === 0) {
+        console.error("This server type is not available in any location.");
+        step--;
+        continue;
+      }
+
+      const result = await searchWithEsc({ message: "Location:", choices: locationChoices });
+      if (result === null) { step--; continue; }
+      locationChoice = result;
+      step++;
+    } else if (step === 2) {
+      // Pick OS image
+      const imageChoices = linuxImages
+        .sort((a, b) => {
+          // Prefer Ubuntu, then Debian, then alphabetical
+          const rank = (img: typeof a) => {
+            if (img.os_flavor === "ubuntu") return 0;
+            if (img.os_flavor === "debian") return 1;
+            return 2;
+          };
+          return rank(a) - rank(b) || a.description.localeCompare(b.description);
+        })
+        .map((img) => ({
+          name: img.description,
+          value: img.name,
+        }));
+
+      // Auto-select Ubuntu 22.04 if available
+      const ubuntu2204 = linuxImages.find((img) => img.name === "ubuntu-22.04");
+      if (ubuntu2204) {
+        imageChoice = ubuntu2204.name;
+        console.log(`OS: ${ubuntu2204.description} (auto-selected)`);
+      } else {
+        const result = await searchWithEsc({ message: "OS image:", choices: imageChoices });
+        if (result === null) { step--; continue; }
+        imageChoice = result;
+      }
+      step++;
+    } else if (step === 3) {
+      // SSH key — use vps_ssh credential, Hetzner keys, or create new
+      const { loadCredentialFields, credentialExists: credExists } = await import("../../shared/credentials.js");
+      const { promptCredential } = await import("../../credentials/prompter.js");
+      const { resolveCredential } = await import("../../credentials/registry.js");
+
+      // Check for existing vps_ssh credential
+      const hasVpsSsh = await credExists("vps_ssh", "default");
+      const vpsSshFields = hasVpsSsh ? await loadCredentialFields("vps_ssh", "default") : undefined;
+
+      // Build choices
+      const keyChoices: Array<{ name: string; value: string }> = [];
+
+      if (vpsSshFields?.public_key) {
+        const preview = vpsSshFields.public_key.slice(0, 40) + "...";
+        keyChoices.push({ name: `Action Llama VPS key (${preview})`, value: "__al_credential__" });
+      }
+
+      for (const k of existingKeys) {
+        keyChoices.push({
+          name: `Hetzner: ${k.name} (${k.public_key.slice(0, 30)}...)`,
+          value: String(k.id),
+        });
+      }
+
+      keyChoices.push({ name: "Set up a new VPS SSH key", value: "__new__" });
+
+      const result = await searchWithEsc({ message: "SSH key:", choices: keyChoices });
+      if (result === null) { step--; continue; }
+
+      const vpsSshKeyPath = resolve(credentialDir("vps_ssh", "default"), "private_key");
+
+      if (result === "__new__") {
+        // Run the vps_ssh credential prompt
+        const def = resolveCredential("vps_ssh");
+        const promptResult = await promptCredential(def, "default");
+        if (!promptResult) {
+          continue; // User cancelled — stay on this step
+        }
+        // Persist the credential before uploading to Hetzner
+        await writeCredentialFields("vps_ssh", "default", promptResult.values);
+        sshKeyPath = vpsSshKeyPath;
+        const pubKey = promptResult.values.public_key;
+        // Upload to Hetzner
+        const uploaded = await createSshKey(apiKeyValue, "action-llama", pubKey);
+        sshKeyId = uploaded.id;
+        console.log("SSH key uploaded to Hetzner.");
+      } else if (result === "__al_credential__") {
+        sshKeyPath = vpsSshKeyPath;
+        // Upload the existing vps_ssh public key to Hetzner if not already there
+        const pubKey = vpsSshFields!.public_key;
+        const alreadyOnHetzner = existingKeys.find((k) => k.public_key.trim() === pubKey.trim());
+        if (alreadyOnHetzner) {
+          sshKeyId = alreadyOnHetzner.id;
+        } else {
+          const uploaded = await createSshKey(apiKeyValue, "action-llama", pubKey);
+          sshKeyId = uploaded.id;
+          console.log("VPS SSH key uploaded to Hetzner.");
+        }
+      } else {
+        sshKeyId = parseInt(result);
+      }
+      step++;
+    }
+  }
+
+  // Set up Hetzner firewall (allow SSH + gateway inbound)
+  const AL_FW_NAME = "action-llama";
+  let firewallId: number | undefined;
+
+  console.log("\nConfiguring Hetzner firewall...");
+  const existingFirewalls = await listFirewalls(apiKeyValue);
+  const existingFw = existingFirewalls.find((fw) => fw.name === AL_FW_NAME);
+
+  if (existingFw) {
+    firewallId = existingFw.id;
+  } else {
+    // Create firewall with SSH + web ports
+    const webPorts = cfConfig
+      ? [
+          { port: "80", description: "HTTP redirect" },
+          { port: "443", description: "HTTPS" },
+        ]
+      : [
+          { port: String(VPS_CONSTANTS.DEFAULT_GATEWAY_PORT), description: "Gateway" },
+        ];
+
+    const rules = [
+      {
+        direction: "in" as const,
+        protocol: "tcp" as const,
+        source_ips: ["0.0.0.0/0", "::/0"],
+        port: "22",
+        description: "SSH",
+      },
+      ...webPorts.map((wp) => ({
+        direction: "in" as const,
+        protocol: "tcp" as const,
+        source_ips: ["0.0.0.0/0", "::/0"],
+        port: wp.port,
+        description: wp.description,
+      })),
+    ];
+    const firewall = await createFirewall(apiKeyValue, AL_FW_NAME, rules);
+    firewallId = firewall.id;
+    console.log("Hetzner firewall created.");
+  }
+
+  // Create server
+  console.log("Provisioning Hetzner server...");
+  const server = await createServer(apiKeyValue, {
+    name: "action-llama",
+    server_type: serverTypeChoice,
+    location: locationChoice,
+    image: imageChoice,
+    ssh_keys: [sshKeyId],
+    user_data: VPS_CONSTANTS.CLOUD_INIT_SCRIPT,
+    firewalls: firewallId ? [firewallId] : undefined,
+    labels: { "managed-by": "action-llama" },
+  });
+  console.log(`Server ${server.id} created.`);
+
+  // Persist immediately so the instance can be deprovisioned even if we're interrupted
+  const partialResult: Record<string, unknown> = {
+    provider: "vps",
+    host: "PENDING",
+    hetznerServerId: server.id,
+    hetznerLocation: locationChoice,
+  };
+  if (onInstanceCreated) onInstanceCreated(partialResult);
+
+  // Poll until active + SSH available + Docker installed
+  console.log("Waiting for server to become active...");
+  const sshConfig: SshConfig = {
+    host: "",
+    user: VPS_CONSTANTS.DEFAULT_SSH_USER,
+    port: VPS_CONSTANTS.DEFAULT_SSH_PORT,
+    keyPath: sshKeyPath,
+  };
+
+  const startTime = Date.now();
+  const maxWaitMs = 10 * 60 * 1000; // 10 minutes
+
+  while (Date.now() - startTime < maxWaitMs) {
+    const current = await getServer(apiKeyValue, server.id);
+
+    if (current.status === "running" && current.public_net.ipv4.ip) {
+      sshConfig.host = current.public_net.ipv4.ip;
+
+      // Update persisted config with real IP as soon as we know it
+      if (partialResult.host === "PENDING") {
+        partialResult.host = current.public_net.ipv4.ip;
+        if (onInstanceCreated) onInstanceCreated(partialResult);
+        console.log(`Server running at ${current.public_net.ipv4.ip}. Waiting for SSH...`);
+      }
+
+      // Wait for SSH
+      const sshReady = await testConnection(sshConfig);
+      if (sshReady) {
+        // Check if cloud-init has finished installing Node.js + Docker
+        const nodeCheck = await sshExec(sshConfig, "node --version");
+        const dockerCheck = await sshExec(sshConfig, "docker info --format '{{.ServerVersion}}'");
+        if (nodeCheck.exitCode === 0 && dockerCheck.exitCode === 0) {
+          console.log(`Node.js ${nodeCheck.stdout.trim()}, Docker ${dockerCheck.stdout.trim()} ready on VPS.`);
+          break;
+        }
+        console.log("Waiting for cloud-init to complete (Node.js + Docker)...");
+      }
+    } else {
+      process.stdout.write(".");
+    }
+
+    await new Promise((r) => setTimeout(r, 10_000));
+  }
+
+  if (!sshConfig.host || sshConfig.host === "0.0.0.0") {
+    console.error("\nTimed out waiting for VPS to become ready.");
+    console.error(`Server ${server.id} was created. Use 'al env deprov' to clean up.`);
+    return null;
+  }
+
+  // Final SSH check
+  const ok = await testConnection(sshConfig);
+  if (!ok) {
+    console.error("\nVPS is active but SSH connection failed.");
+    console.error(`Server ${server.id} at ${sshConfig.host} was created. Use 'al env deprov' to clean up.`);
+    return null;
+  }
+
+  const shouldContinue = await confirm({
+    message: `VPS ready at ${sshConfig.host}. Continue with setup?`,
+    default: true,
+  });
+  if (!shouldContinue) return null;
+
+  const result: Record<string, unknown> = {
+    provider: "vps",
+    host: sshConfig.host,
+    hetznerServerId: server.id,
+    hetznerLocation: locationChoice,
+    gatewayUrl: `http://${sshConfig.host}:${VPS_CONSTANTS.DEFAULT_GATEWAY_PORT}`,
+  };
+  if (sshKeyPath !== VPS_CONSTANTS.DEFAULT_SSH_KEY_PATH) result.sshKeyPath = sshKeyPath;
+
+  // Post-VPS Cloudflare HTTPS setup (same as Vultr)
   if (cfConfig) {
     try {
       result.cloudflareHostname = cfConfig.hostname;

--- a/src/cloud/vps/teardown.ts
+++ b/src/cloud/vps/teardown.ts
@@ -65,7 +65,7 @@ export async function teardownVps(_projectPath: string, config: VpsCloudConfig):
     }
   }
 
-  // 4. If this is a Vultr-provisioned instance, delete it
+  // 4. If this is a provisioned instance, delete it
   if (config.vultrInstanceId) {
     const apiKey = await backend.read("vultr_api_key", "default", "api_key");
     if (!apiKey) {
@@ -76,5 +76,15 @@ export async function teardownVps(_projectPath: string, config: VpsCloudConfig):
     const { deleteInstance } = await import("./vultr-api.js");
     await deleteInstance(apiKey, config.vultrInstanceId);
     console.log("Vultr instance deleted.");
+  } else if (config.hetznerServerId) {
+    const apiKey = await backend.read("hetzner_api_key", "default", "api_key");
+    if (!apiKey) {
+      console.log("Hetzner API key not found — delete the server manually at https://console.hetzner.cloud");
+      return;
+    }
+
+    const { deleteServer } = await import("./hetzner-api.js");
+    await deleteServer(apiKey, config.hetznerServerId);
+    console.log("Hetzner server deleted.");
   }
 }

--- a/src/credentials/builtins/hetzner-api-key.ts
+++ b/src/credentials/builtins/hetzner-api-key.ts
@@ -1,0 +1,27 @@
+import type { CredentialDefinition } from "../schema.js";
+
+const hetznerApiKey: CredentialDefinition = {
+  id: "hetzner_api_key",
+  label: "Hetzner API Key",
+  description: "API key for Hetzner Cloud VPS provisioning (not needed at agent runtime)",
+  helpUrl: "https://console.hetzner.cloud/projects",
+  fields: [
+    { name: "api_key", label: "API Key", description: "Hetzner Cloud API key", secret: true },
+  ],
+  envVars: { api_key: "HETZNER_API_KEY" },
+  agentContext: "`HETZNER_API_KEY` — Hetzner Cloud API access (provisioning only, not typically needed by agents)",
+
+  async validate(values) {
+    const res = await fetch("https://api.hetzner.cloud/v1/server_types", {
+      headers: { Authorization: `Bearer ${values.api_key}` },
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({ error: { message: "Unknown error" } }));
+      const errorMessage = body.error?.message || `HTTP ${res.status}`;
+      throw new Error(`Hetzner API key validation failed: ${errorMessage}`);
+    }
+    return true;
+  },
+};
+
+export default hetznerApiKey;

--- a/src/credentials/builtins/index.ts
+++ b/src/credentials/builtins/index.ts
@@ -19,6 +19,7 @@ import netlifyToken from "./netlify-token.js";
 import xTwitterApi from "./x-twitter-api.js";
 import bugsnagToken from "./bugsnag-token.js";
 import vultrApiKey from "./vultr-api-key.js";
+import hetznerApiKey from "./hetzner-api-key.js";
 import vpsSsh from "./vps-ssh.js";
 import cloudflareApiToken from "./cloudflare-api-token.js";
 
@@ -43,6 +44,7 @@ export const builtinCredentials: Record<string, CredentialDefinition> = {
   "x_twitter_api": xTwitterApi,
   "bugsnag_token": bugsnagToken,
   "vultr_api_key": vultrApiKey,
+  "hetzner_api_key": hetznerApiKey,
   "vps_ssh": vpsSsh,
   "cloudflare_api_token": cloudflareApiToken,
 };

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -37,6 +37,9 @@ export interface VpsCloudConfig {
   // Vultr-specific (present only if AL provisioned the instance)
   vultrInstanceId?: string;
   vultrRegion?: string;
+  // Hetzner-specific (present only if AL provisioned the instance)
+  hetznerServerId?: number;
+  hetznerLocation?: string;
   // Cloudflare-specific (present only if HTTPS was configured)
   cloudflareZoneId?: string;
   cloudflareDnsRecordId?: string;


### PR DESCRIPTION
Closes #119

This PR adds support for provisioning Hetzner Cloud VPS instances alongside the existing Vultr support. Users can now choose between Vultr and Hetzner when setting up VPS deployment.

Changes:
- Added hetzner-api.ts with Hetzner Cloud API client
- Added hetzner_api_key credential type
- Updated provision.ts to add Hetzner VPS option
- Added provisionHetzner() function with full workflow
- Updated teardown.ts for Hetzner server deletion
- Updated VpsCloudConfig interface with Hetzner fields
- Updated documentation

Features:
- Server type and location selection
- OS image selection (Ubuntu 22.04 default)
- SSH key management
- Firewall configuration  
- Cloudflare HTTPS integration
- Cloud-init setup with Docker and Node.js