### PR TITLE
fix: add warning when log endpoints are exposed without auth

### DIFF
--- a/.changeset/protect-log-endpoints-warning.md
+++ b/.changeset/protect-log-endpoints-warning.md
@@ -1,0 +1,7 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Added warning when log endpoints are exposed without authentication. The gateway now
+logs a warning if log routes are registered without an API key configured, helping
+operators identify potential security risks. Closes #121.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@action-llama/action-llama",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@action-llama/action-llama",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -137,6 +137,11 @@ export async function startGateway(opts: GatewayOptions): Promise<GatewayServer>
   if (projectPath) {
     const { registerLogRoutes } = await import("./routes/logs.js");
     registerLogRoutes(app, projectPath);
+    
+    // Warn if log endpoints are exposed without authentication
+    if (!opts.apiKey) {
+      logger.warn("Log endpoints are exposed without authentication. Consider setting up a gateway API key for security.");
+    }
   }
 
   // Control routes (for kill, pause, resume commands)

--- a/test/gateway/auth-logs.test.ts
+++ b/test/gateway/auth-logs.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { startGateway } from "../../src/gateway/index.js";
+
+describe("Gateway log endpoints authentication", () => {
+  let gateway: any;
+  const TEST_API_KEY = "test-secret-key-123";
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+
+  beforeAll(async () => {
+    gateway = await startGateway({
+      port: 0, // Random port
+      logger,
+      apiKey: TEST_API_KEY,
+      projectPath: "/tmp", // Required for log routes to be registered
+      webUI: true, // Enable dashboard routes
+      statusTracker: {
+        getAllAgents: () => [],
+        getSchedulerInfo: () => ({}),
+        getRecentLogs: () => [],
+        on: vi.fn(),
+        removeListener: vi.fn(),
+      } as any, // Mock status tracker
+    });
+  });
+
+  afterAll(async () => {
+    await gateway.close();
+  });
+
+  it("should protect /api/logs/scheduler endpoint", async () => {
+    const addr = gateway.server.address() as any;
+    const baseUrl = `http://localhost:${addr.port}`;
+
+    // Without auth - should return 401
+    const res1 = await fetch(`${baseUrl}/api/logs/scheduler`);
+    expect(res1.status).toBe(401);
+    const body1 = await res1.json();
+    expect(body1.error).toBe("Unauthorized");
+
+    // With valid auth - should return 200
+    const res2 = await fetch(`${baseUrl}/api/logs/scheduler`, {
+      headers: { Authorization: `Bearer ${TEST_API_KEY}` },
+    });
+    expect(res2.status).toBe(200);
+  });
+
+  it("should protect /api/logs/agents/:name endpoint", async () => {
+    const addr = gateway.server.address() as any;
+    const baseUrl = `http://localhost:${addr.port}`;
+
+    // Without auth - should return 401
+    const res1 = await fetch(`${baseUrl}/api/logs/agents/test-agent`);
+    expect(res1.status).toBe(401);
+
+    // With valid auth - should return 200
+    const res2 = await fetch(`${baseUrl}/api/logs/agents/test-agent`, {
+      headers: { Authorization: `Bearer ${TEST_API_KEY}` },
+    });
+    expect(res2.status).toBe(200);
+  });
+
+  it("should protect /api/logs/agents/:name/:instanceId endpoint", async () => {
+    const addr = gateway.server.address() as any;
+    const baseUrl = `http://localhost:${addr.port}`;
+
+    // Without auth - should return 401
+    const res1 = await fetch(`${baseUrl}/api/logs/agents/test-agent/1`);
+    expect(res1.status).toBe(401);
+
+    // With valid auth - should return 200
+    const res2 = await fetch(`${baseUrl}/api/logs/agents/test-agent/1`, {
+      headers: { Authorization: `Bearer ${TEST_API_KEY}` },
+    });
+    expect(res2.status).toBe(200);
+  });
+
+  it("should protect dashboard log endpoints with redirect for browser requests", async () => {
+    const addr = gateway.server.address() as any;
+    const baseUrl = `http://localhost:${addr.port}`;
+
+    // Browser request without auth - should redirect to login
+    const res1 = await fetch(`${baseUrl}/dashboard/agents/test-agent/logs`, {
+      headers: { Accept: "text/html" },
+      redirect: "manual",
+    });
+    expect(res1.status).toBe(302);
+    expect(res1.headers.get("location")).toBe("/login");
+
+    // With session cookie - should work
+    const res2 = await fetch(`${baseUrl}/dashboard/agents/test-agent/logs`, {
+      headers: {
+        Accept: "text/html",
+        Cookie: `al_session=${TEST_API_KEY}`,
+      },
+    });
+    expect(res2.status).toBe(200);
+  });
+});


### PR DESCRIPTION
Closes #121

This PR adds a warning message when log endpoints are registered without authentication configured. This helps operators identify potential security risks.

## Changes
- Added warning log when  is set but  is not configured
- Added comprehensive tests to verify log endpoints are protected when auth is enabled
- Verified that all log endpoints ( and ) require authentication when API key is configured

## Testing
- Added new test file  that verifies all log endpoints return 401 without auth and 200 with valid Bearer token
- All existing tests pass