### PR TITLE
fix: use resolved environment name in al stat gateway calls

### DIFF
--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -99,7 +99,7 @@ export async function execute(opts: { project: string; env?: string; agent?: str
   let agentStatuses: Array<{ name: string; enabled: boolean }> = [];
 
   try {
-    const response = await gatewayFetch({ project: projectPath, path: "/control/status", env: opts.env });
+    const response = await gatewayFetch({ project: projectPath, path: "/control/status", env: envName || undefined });
     if (response.ok) {
       const data = await response.json();
       schedulerInfo = data.scheduler;
@@ -186,7 +186,7 @@ export async function execute(opts: { project: string; env?: string; agent?: str
 
   // Fetch and display lock information
   try {
-    const response = await gatewayFetch({ project: projectPath, path: "/locks/status", env: opts.env });
+    const response = await gatewayFetch({ project: projectPath, path: "/locks/status", env: envName || undefined });
     if (response.ok) {
       const data = await response.json();
       if (data.locks && data.locks.length > 0) {


### PR DESCRIPTION
Closes #126

The `al stat` command was not using the resolved environment name when making gateway requests. It correctly resolves the environment from `.env.toml`, but then passes the CLI option directly to `gatewayFetch` instead of the resolved value.

## Changes
- Fixed status endpoint fetch to use `envName || undefined` instead of `opts.env`
- Fixed locks endpoint fetch to use `envName || undefined` instead of `opts.env`

## Testing
- Build passes ✅
- Unit tests pass ✅ (987/988 tests pass, 1 unrelated failure due to missing openssl)

Now `al stat` will properly use the environment specified in `.env.toml` when no `-E` flag is provided.