### PR TITLE
Add nginx rate limiting to protect gateway from overload

### DIFF
--- a/.changeset/nginx-rate-limiting.md
+++ b/.changeset/nginx-rate-limiting.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Added nginx rate limiting to VPS deployments to protect the gateway from overload. The nginx configuration now includes rate limiting of 5 requests per second per IP address with a burst allowance of 10 requests. Clients exceeding the rate limit receive HTTP 429 responses. Closes #141.

--- a/src/cloud/vps/nginx.ts
+++ b/src/cloud/vps/nginx.ts
@@ -10,6 +10,9 @@ import { sshExec, scpBuffer, type SshConfig } from "./ssh.js";
  */
 export function generateNginxConfig(hostname: string, gatewayPort: number): string {
   return `# Action Llama — Cloudflare Origin CA TLS termination
+
+# Rate limiting: 5 req/sec per IP with burst of 10
+limit_req_zone $binary_remote_addr zone=al_rate_limit:10m rate=5r/s;
 server {
     listen 80;
     listen [::]:80;
@@ -27,6 +30,10 @@ server {
 
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers on;
+
+    # Apply rate limit to all requests
+    limit_req zone=al_rate_limit burst=10 nodelay;
+    limit_req_status 429;
 
     location / {
         proxy_pass http://127.0.0.1:${gatewayPort};

--- a/test/cloud/vps/nginx.test.ts
+++ b/test/cloud/vps/nginx.test.ts
@@ -43,4 +43,13 @@ describe("generateNginxConfig", () => {
 
     expect(config).toContain("proxy_pass http://127.0.0.1:8080");
   });
+
+  it("includes rate limiting configuration", () => {
+    const config = generateNginxConfig("agents.example.com", 3000);
+
+    expect(config).toContain("limit_req_zone");
+    expect(config).toContain("zone=al_rate_limit:10m rate=5r/s");
+    expect(config).toContain("limit_req zone=al_rate_limit burst=10 nodelay");
+    expect(config).toContain("limit_req_status 429");
+  });
 });


### PR DESCRIPTION
Closes #141

This PR adds nginx-level rate limiting to VPS deployments to protect the Node.js gateway server from overload attacks.

## Changes

- **nginx configuration**: Added  directive with 5 req/s per IP and 10-request burst allowance
- **Rate limiting enforcement**: Applied to all endpoints with HTTP 429 responses for excess requests
- **Tests**: Added comprehensive test coverage for the rate limiting configuration

## Implementation details

- Rate limit zone:  with 10MB shared memory (supports ~160,000 IP addresses)
- Rate: 5 requests per second per IP address
- Burst: 10 requests allowed before rate limiting kicks in
- Response: HTTP 429 (Too Many Requests) for exceeded requests
- The  option ensures burst requests are processed immediately without queuing

This nginx-level protection is more efficient than application-level rate limiting as it blocks requests before they reach the Node.js server. The existing webhook rate limiter (120 req/min) remains as a secondary defense layer.

Rate limiting will be automatically applied on VPS deployments via .