### PR TITLE
fix: make env logs environment name optional

### DIFF
--- a/.changeset/env-logs-optional-name.md
+++ b/.changeset/env-logs-optional-name.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Made the environment name parameter optional for the `al env logs` command. When no environment is specified, the command now uses the configured environment from `.env.toml` or the `AL_ENV` environment variable, consistent with other AL commands that support environment resolution. Closes #136.

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -8,6 +8,7 @@ import {
   environmentPath,
   loadEnvToml,
   writeEnvToml,
+  resolveEnvironmentName,
   type EnvironmentConfig,
 } from "../../shared/environment.js";
 import { ConfigError } from "../../shared/errors.js";
@@ -271,18 +272,25 @@ export async function deprov(name: string, opts: { project: string }): Promise<v
 }
 
 export async function logs(
-  name: string,
-  opts: { lines?: string; follow?: boolean },
+  name: string | undefined,
+  opts: { project: string; lines?: string; follow?: boolean },
 ): Promise<void> {
-  if (!environmentExists(name)) {
+  const resolvedName = resolveEnvironmentName(name, opts.project);
+  if (!resolvedName) {
     throw new ConfigError(
-      `Environment "${name}" not found. Run 'al env list' to see available environments.`
+      "No environment specified. Specify an environment name or configure one in .env.toml"
     );
   }
 
-  const config = loadEnvironmentConfig(name);
+  if (!environmentExists(resolvedName)) {
+    throw new ConfigError(
+      `Environment "${resolvedName}" not found. Run 'al env list' to see available environments.`
+    );
+  }
+
+  const config = loadEnvironmentConfig(resolvedName);
   if (!config.server) {
-    throw new ConfigError(`Environment "${name}" has no [server] config.`);
+    throw new ConfigError(`Environment "${resolvedName}" has no [server] config.`);
   }
 
   const serverConfig = validateServerConfig(config.server);

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -264,10 +264,11 @@ envCmd
 envCmd
   .command("logs")
   .description("View server system logs for an environment")
-  .argument("<name>", "environment name")
+  .argument("[name]", "environment name (defaults to configured environment)")
+  .option("-p, --project <dir>", "project directory", ".")
   .option("-n, --lines <N>", "number of recent log lines to show", "50")
   .option("-f, --follow", "follow log output in real-time")
-  .action(withCommand(async (name: string, opts: { lines: string; follow?: boolean }) => {
+  .action(withCommand(async (name: string | undefined, opts: { project: string; lines: string; follow?: boolean }) => {
     const { logs } = await import("./commands/env.js");
     await logs(name, opts);
   }));


### PR DESCRIPTION
Closes #136

This PR implements the requested change to make the environment name parameter optional for the `al env logs` command.

## Changes

- Updated CLI command definition in `src/cli/main.ts` to make the name argument optional
- Added environment resolution logic in `src/cli/commands/env.ts` using the existing `resolveEnvironmentName` function 
- The command now uses the configured environment from `.env.toml` or `AL_ENV` environment variable when no environment is explicitly specified
- Added proper error handling for cases where no environment can be resolved
- Maintains backward compatibility - existing scripts using `al env logs <name>` will continue to work

## Testing

- Build passes successfully 
- Most tests pass (2 unrelated test failures in start command tests)
- Manual testing confirmed the feature works as expected

The behavior now matches other AL commands that support environment resolution (e.g., `al start`, `al logs`).