### PR TITLE
Fix EPIPE race condition in al-call test

### DIFF
--- a/test/gateway/command-exit-codes.test.ts
+++ b/test/gateway/command-exit-codes.test.ts
@@ -290,7 +290,7 @@ describe("command exit codes", () => {
     });
 
     it("exit 5 — no gateway", async () => {
-      const r = await run("al-call", ["agent-b"], { GATEWAY_URL: "", SHUTDOWN_SECRET: "x" }, "ctx");
+      const r = await run("al-call", ["agent-b"], { GATEWAY_URL: "", SHUTDOWN_SECRET: "x" });
       expect(r.exitCode).toBe(5);
     });
   });


### PR DESCRIPTION
Closes #149

This fixes a race condition in test/gateway/command-exit-codes.test.ts that was causing an unhandled EPIPE error during the 'exit 5 — no gateway' test for al-call.

The issue occurred because the al-call script exits immediately when GATEWAY_URL is empty, but the test was still trying to write stdin data to the already-exited process.

The fix removes the stdin parameter from the test since the script exits before reading stdin anyway.