### PR TITLE
fix: replace raw API key in session cookie with secure server-side sessions

### DIFF
--- a/.changeset/secure-session-cookies.md
+++ b/.changeset/secure-session-cookies.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fix security issue where the raw API key was stored in the browser session cookie. Login now creates an opaque server-side session ID (64-char hex from 32 random bytes) stored in the StateStore, and only that ID is placed in the cookie. Logout invalidates the session server-side. Falls back to direct cookie comparison when no StateStore is configured (backward compatibility). Closes #151.

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -1,5 +1,6 @@
 import type { Context, Next } from "hono";
 import { timingSafeEqual } from "crypto";
+import type { SessionStore } from "./session-store.js";
 
 /**
  * Timing-safe string comparison.
@@ -16,9 +17,13 @@ export function safeCompare(a: string, b: string): boolean {
  * 1. `Authorization: Bearer <key>` header (CLI / programmatic)
  * 2. `al_session` cookie (browser / Web UI)
  *
+ * When a SessionStore is provided, the cookie value is treated as an opaque
+ * session ID looked up server-side. Without a SessionStore, the cookie value
+ * is compared directly to the API key (backward compatibility).
+ *
  * Browser HTML requests to protected paths are redirected to /login on 401.
  */
-export function authMiddleware(apiKey: string) {
+export function authMiddleware(apiKey: string, sessionStore?: SessionStore) {
   return async (c: Context, next: Next) => {
     // 1. Check Bearer token
     const authHeader = c.req.header("Authorization");
@@ -33,9 +38,21 @@ export function authMiddleware(apiKey: string) {
     // 2. Check session cookie
     const cookie = parseCookie(c.req.header("Cookie") || "");
     const sessionToken = cookie["al_session"];
-    if (sessionToken && safeCompare(sessionToken, apiKey)) {
-      await next();
-      return;
+    if (sessionToken) {
+      if (sessionStore) {
+        // Session store present: validate as opaque session ID
+        const session = await sessionStore.getSession(sessionToken);
+        if (session) {
+          await next();
+          return;
+        }
+      } else {
+        // Backward compatibility: compare cookie value directly to API key
+        if (safeCompare(sessionToken, apiKey)) {
+          await next();
+          return;
+        }
+      }
     }
 
     // 401 — redirect browsers to login page, return JSON for API clients

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -10,6 +10,7 @@ import { registerSignalRoutes, type SignalContext } from "./routes/signals.js";
 import { LockStore } from "./lock-store.js";
 import { CallStore } from "./call-store.js";
 import { ContainerRegistry } from "./container-registry.js";
+import { SessionStore } from "./session-store.js";
 import type { ContainerRegistration } from "./types.js";
 import type { StateStore } from "../shared/state-store.js";
 import type { WebhookRegistry } from "../webhooks/registry.js";
@@ -126,7 +127,8 @@ export async function startGateway(opts: GatewayOptions): Promise<GatewayServer>
   registerShutdownRoute(app, containerRegistry, killFn, logger);
   // Apply auth middleware to protected routes when an API key is configured
   if (opts.apiKey) {
-    const auth = authMiddleware(opts.apiKey);
+    const sessionStore = stateStore ? new SessionStore(stateStore) : undefined;
+    const auth = authMiddleware(opts.apiKey, sessionStore);
     app.use("/control/*", auth);
     app.use("/dashboard/*", auth);
     app.use("/dashboard", auth);
@@ -134,7 +136,7 @@ export async function startGateway(opts: GatewayOptions): Promise<GatewayServer>
     app.use("/api/logs/*", auth);
 
     // Always register login/logout so the auth redirect has a target
-    registerLoginRoutes(app, opts.apiKey);
+    registerLoginRoutes(app, opts.apiKey, sessionStore);
   }
 
   registerLockRoutes(app, containerRegistry, lockStore, logger, { skipStatusEndpoint: opts.skipStatusEndpoint, events: opts.events });

--- a/src/gateway/routes/dashboard.ts
+++ b/src/gateway/routes/dashboard.ts
@@ -5,13 +5,18 @@ import { renderLogsPage } from "../views/logs-page.js";
 import { renderLoginPage } from "../views/login-page.js";
 import { safeCompare } from "../auth.js";
 import type { StatusTracker } from "../../tui/status-tracker.js";
+import type { SessionStore } from "../session-store.js";
 
 /**
  * Register login/logout routes. Call this whenever auth is active so
  * the auth middleware's redirect to /login always has a target — even
  * when the full dashboard (webUI) is disabled.
+ *
+ * When a SessionStore is provided, login creates an opaque session ID stored
+ * server-side and sets that ID in the cookie. Logout deletes the session.
+ * Without a SessionStore the behavior is unchanged (backward compatibility).
  */
-export function registerLoginRoutes(app: Hono, apiKey?: string): void {
+export function registerLoginRoutes(app: Hono, apiKey?: string, sessionStore?: SessionStore): void {
   app.get("/login", (c) => {
     return c.html(renderLoginPage());
   });
@@ -24,18 +29,31 @@ export function registerLoginRoutes(app: Hono, apiKey?: string): void {
     const body = await c.req.parseBody();
     const key = typeof body["key"] === "string" ? body["key"] : "";
     if (safeCompare(key, apiKey)) {
+      let sessionValue: string;
+      if (sessionStore) {
+        sessionValue = await sessionStore.createSession();
+      } else {
+        sessionValue = apiKey;
+      }
       return c.html("", {
         status: 302,
         headers: {
           Location: "/dashboard",
-          "Set-Cookie": `al_session=${apiKey}; HttpOnly; SameSite=Strict; Path=/`,
+          "Set-Cookie": `al_session=${sessionValue}; HttpOnly; SameSite=Strict; Path=/`,
         },
       });
     }
     return c.html(renderLoginPage("Invalid API key"), 401);
   });
 
-  app.post("/logout", (c) => {
+  app.post("/logout", async (c) => {
+    if (sessionStore) {
+      const cookie = c.req.header("Cookie") || "";
+      const sessionId = parseCookieValue(cookie, "al_session");
+      if (sessionId) {
+        await sessionStore.deleteSession(sessionId);
+      }
+    }
     return c.html("", {
       status: 302,
       headers: {
@@ -44,6 +62,15 @@ export function registerLoginRoutes(app: Hono, apiKey?: string): void {
       },
     });
   });
+}
+
+function parseCookieValue(header: string, name: string): string | undefined {
+  for (const part of header.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() === name) return part.slice(eq + 1).trim();
+  }
+  return undefined;
 }
 
 export function registerDashboardRoutes(

--- a/src/gateway/session-store.ts
+++ b/src/gateway/session-store.ts
@@ -1,0 +1,39 @@
+import { randomBytes } from "crypto";
+import type { StateStore } from "../shared/state-store.js";
+import type { Session } from "./types.js";
+
+const NS = "sessions";
+const DEFAULT_TTL_SECONDS = 24 * 60 * 60; // 24 hours
+
+export class SessionStore {
+  private store: StateStore;
+  private ttl: number;
+
+  constructor(store: StateStore, ttlSeconds = DEFAULT_TTL_SECONDS) {
+    this.store = store;
+    this.ttl = ttlSeconds;
+  }
+
+  async createSession(): Promise<string> {
+    const id = randomBytes(32).toString("hex");
+    const session: Session = {
+      id,
+      createdAt: Date.now(),
+      lastAccessed: Date.now(),
+    };
+    await this.store.set<Session>(NS, id, session, { ttl: this.ttl });
+    return id;
+  }
+
+  async getSession(id: string): Promise<Session | null> {
+    const session = await this.store.get<Session>(NS, id);
+    if (!session) return null;
+    session.lastAccessed = Date.now();
+    await this.store.set<Session>(NS, id, session, { ttl: this.ttl });
+    return session;
+  }
+
+  async deleteSession(id: string): Promise<void> {
+    await this.store.delete(NS, id);
+  }
+}

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -24,3 +24,9 @@ export interface ReturnRequest {
   secret: string;
   value: string;
 }
+
+export interface Session {
+  id: string;
+  createdAt: number;
+  lastAccessed: number;
+}

--- a/test/gateway/routes/dashboard.test.ts
+++ b/test/gateway/routes/dashboard.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Hono } from "hono";
 import { registerDashboardRoutes, registerLoginRoutes } from "../../../src/gateway/routes/dashboard.js";
 import { authMiddleware } from "../../../src/gateway/auth.js";
+import type { SessionStore } from "../../../src/gateway/session-store.js";
 
 function mockStatusTracker() {
   return {
@@ -13,15 +14,15 @@ function mockStatusTracker() {
   } as any;
 }
 
-function createTestApp(apiKey?: string) {
+function createTestApp(apiKey?: string, sessionStore?: SessionStore) {
   const app = new Hono();
   if (apiKey) {
-    const auth = authMiddleware(apiKey);
+    const auth = authMiddleware(apiKey, sessionStore);
     app.use("/control/*", auth);
     app.use("/dashboard/*", auth);
     app.use("/dashboard", auth);
     app.use("/locks/status", auth);
-    registerLoginRoutes(app, apiKey);
+    registerLoginRoutes(app, apiKey, sessionStore);
   }
   registerDashboardRoutes(app, mockStatusTracker(), undefined, apiKey);
   return app;
@@ -37,6 +38,18 @@ function createAuthOnlyApp(apiKey: string) {
   app.use("/locks/status", auth);
   registerLoginRoutes(app, apiKey);
   return app;
+}
+
+function mockSessionStore(sessionId?: string): SessionStore {
+  return {
+    createSession: vi.fn().mockResolvedValue(sessionId ?? "mock-session-id"),
+    getSession: vi.fn().mockImplementation(async (id: string) =>
+      id === (sessionId ?? "mock-session-id")
+        ? { id, createdAt: Date.now(), lastAccessed: Date.now() }
+        : null
+    ),
+    deleteSession: vi.fn().mockResolvedValue(undefined),
+  } as any;
 }
 
 describe("dashboard auth", () => {
@@ -91,7 +104,7 @@ describe("dashboard auth", () => {
     expect(res.status).toBe(401);
   });
 
-  it("allows access with correct session cookie", async () => {
+  it("allows access with correct session cookie (no session store — backward compat)", async () => {
     const app = createTestApp("test-key");
     const res = await app.request("/dashboard", {
       headers: { Cookie: "al_session=test-key" },
@@ -99,7 +112,7 @@ describe("dashboard auth", () => {
     expect(res.status).toBe(200);
   });
 
-  it("rejects wrong session cookie", async () => {
+  it("rejects wrong session cookie (no session store — backward compat)", async () => {
     const app = createTestApp("test-key");
     const res = await app.request("/dashboard", {
       headers: { Cookie: "al_session=wrong-key", Accept: "application/json" },
@@ -130,7 +143,7 @@ describe("dashboard auth", () => {
     expect(html).toContain("API Key");
   });
 
-  it("POST /login sets cookie on correct key", async () => {
+  it("POST /login sets cookie on correct key (no session store)", async () => {
     const app = createTestApp("test-key");
     const form = new URLSearchParams({ key: "test-key" });
     const res = await app.request("/login", {
@@ -195,5 +208,63 @@ describe("dashboard auth", () => {
     createTestApp("new-key");
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("AL_DASHBOARD_SECRET is no longer used"));
     warnSpy.mockRestore();
+  });
+
+  describe("session store integration", () => {
+    it("POST /login sets opaque session ID cookie when session store is provided", async () => {
+      const store = mockSessionStore("abc123session");
+      const app = createTestApp("test-key", store);
+      const form = new URLSearchParams({ key: "test-key" });
+      const res = await app.request("/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: form.toString(),
+      });
+      expect(res.status).toBe(302);
+      const cookie = res.headers.get("Set-Cookie") || "";
+      expect(cookie).toContain("al_session=abc123session");
+      expect(cookie).not.toContain("test-key");
+      expect(store.createSession).toHaveBeenCalled();
+    });
+
+    it("allows access with valid session ID cookie when session store is provided", async () => {
+      const store = mockSessionStore("valid-session-id");
+      const app = createTestApp("test-key", store);
+      const res = await app.request("/dashboard", {
+        headers: { Cookie: "al_session=valid-session-id" },
+      });
+      expect(res.status).toBe(200);
+      expect(store.getSession).toHaveBeenCalledWith("valid-session-id");
+    });
+
+    it("rejects unknown session ID cookie when session store is provided", async () => {
+      const store = mockSessionStore("valid-session-id");
+      const app = createTestApp("test-key", store);
+      const res = await app.request("/dashboard", {
+        headers: { Cookie: "al_session=unknown-session-id", Accept: "application/json" },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects raw API key as cookie value when session store is provided", async () => {
+      const store = mockSessionStore("valid-session-id");
+      const app = createTestApp("test-key", store);
+      // The raw API key should not authenticate — only opaque session IDs work
+      const res = await app.request("/dashboard", {
+        headers: { Cookie: "al_session=test-key", Accept: "application/json" },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("POST /logout deletes session from store", async () => {
+      const store = mockSessionStore("my-session");
+      const app = createTestApp("test-key", store);
+      const res = await app.request("/logout", {
+        method: "POST",
+        headers: { Cookie: "al_session=my-session" },
+      });
+      expect(res.status).toBe(302);
+      expect(store.deleteSession).toHaveBeenCalledWith("my-session");
+    });
   });
 });

--- a/test/gateway/session-store.test.ts
+++ b/test/gateway/session-store.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SessionStore } from "../../src/gateway/session-store.js";
+import type { StateStore } from "../../src/shared/state-store.js";
+import type { Session } from "../../src/gateway/types.js";
+
+function mockStateStore(): StateStore & {
+  _data: Map<string, { value: unknown; expiresAt?: number }>;
+} {
+  const data = new Map<string, { value: unknown; expiresAt?: number }>();
+
+  return {
+    _data: data,
+    async get<T>(ns: string, key: string): Promise<T | null> {
+      const entry = data.get(`${ns}:${key}`);
+      if (!entry) return null;
+      if (entry.expiresAt && Date.now() > entry.expiresAt) {
+        data.delete(`${ns}:${key}`);
+        return null;
+      }
+      return entry.value as T;
+    },
+    async set<T>(ns: string, key: string, value: T, opts?: { ttl?: number }): Promise<void> {
+      const expiresAt = opts?.ttl ? Date.now() + opts.ttl * 1000 : undefined;
+      data.set(`${ns}:${key}`, { value, expiresAt });
+    },
+    async delete(ns: string, key: string): Promise<void> {
+      data.delete(`${ns}:${key}`);
+    },
+    async deleteAll(ns: string): Promise<void> {
+      for (const k of data.keys()) {
+        if (k.startsWith(`${ns}:`)) data.delete(k);
+      }
+    },
+    async list<T>(ns: string): Promise<Array<{ key: string; value: T }>> {
+      const results: Array<{ key: string; value: T }> = [];
+      for (const [k, entry] of data.entries()) {
+        if (!k.startsWith(`${ns}:`)) continue;
+        if (entry.expiresAt && Date.now() > entry.expiresAt) continue;
+        results.push({ key: k.slice(ns.length + 1), value: entry.value as T });
+      }
+      return results;
+    },
+    async close(): Promise<void> {},
+  };
+}
+
+describe("SessionStore", () => {
+  it("createSession returns a 64-character hex string", async () => {
+    const store = new SessionStore(mockStateStore());
+    const id = await store.createSession();
+    expect(id).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("createSession returns unique IDs", async () => {
+    const store = new SessionStore(mockStateStore());
+    const ids = await Promise.all(Array.from({ length: 10 }, () => store.createSession()));
+    const unique = new Set(ids);
+    expect(unique.size).toBe(10);
+  });
+
+  it("getSession returns the session after creation", async () => {
+    const store = new SessionStore(mockStateStore());
+    const id = await store.createSession();
+    const session = await store.getSession(id);
+    expect(session).not.toBeNull();
+    expect(session!.id).toBe(id);
+    expect(typeof session!.createdAt).toBe("number");
+    expect(typeof session!.lastAccessed).toBe("number");
+  });
+
+  it("getSession returns null for unknown ID", async () => {
+    const store = new SessionStore(mockStateStore());
+    const session = await store.getSession("nonexistent");
+    expect(session).toBeNull();
+  });
+
+  it("getSession updates lastAccessed on each call", async () => {
+    const store = new SessionStore(mockStateStore());
+    const id = await store.createSession();
+    const first = await store.getSession(id);
+    await new Promise((r) => setTimeout(r, 5));
+    const second = await store.getSession(id);
+    expect(second!.lastAccessed).toBeGreaterThanOrEqual(first!.lastAccessed);
+  });
+
+  it("deleteSession removes the session", async () => {
+    const store = new SessionStore(mockStateStore());
+    const id = await store.createSession();
+    await store.deleteSession(id);
+    const session = await store.getSession(id);
+    expect(session).toBeNull();
+  });
+
+  it("getSession returns null after TTL expires", async () => {
+    const underlying = mockStateStore();
+    const store = new SessionStore(underlying, 1); // 1 second TTL
+    const id = await store.createSession();
+
+    // Manually expire the entry by backdating it
+    const key = `sessions:${id}`;
+    const entry = underlying._data.get(key);
+    if (entry) {
+      entry.expiresAt = Date.now() - 1;
+    }
+
+    const session = await store.getSession(id);
+    expect(session).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes the security issue where `al_session` cookie stored the raw API key directly ([#151](https://github.com/Action-Llama/action-llama/issues/151))
- Login now creates a cryptographically secure session ID (64-char hex from `crypto.randomBytes(32)`) stored server-side in the `StateStore`
- Only the opaque session ID is placed in the browser cookie — the API key never leaves the server
- Logout invalidates the session in the store, making stolen cookies non-reusable after logout
- Falls back to direct cookie-vs-API-key comparison when no `StateStore` is configured (backward compatibility for deployments without persistent state)

## Changes

- `src/gateway/session-store.ts` (new) — `SessionStore` class wrapping `StateStore` with 24-hour TTL sessions
- `src/gateway/types.ts` — added `Session` interface
- `src/gateway/auth.ts` — `authMiddleware` accepts optional `SessionStore`; validates cookie as session ID when store is present
- `src/gateway/routes/dashboard.ts` — `registerLoginRoutes` accepts optional `SessionStore`; login creates session, logout deletes it
- `src/gateway/index.ts` — creates `SessionStore` from `stateStore` when available and wires it through
- `test/gateway/routes/dashboard.test.ts` — updated + new session store integration tests
- `test/gateway/session-store.test.ts` (new) — unit tests for `SessionStore`

## Test plan

- [x] `npm run test:unit` — all 1063 tests pass
- [x] Existing auth tests unmodified (backward compat path still works)
- [x] New tests verify: session ID (not API key) in cookie, valid session ID accepted, unknown session ID rejected, raw API key rejected when store present, logout deletes session

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)