### PR TITLE
fix: require API key for dashboard routes (closes #155)

### DIFF
--- a/.changeset/fix-dashboard-auth-hole.md
+++ b/.changeset/fix-dashboard-auth-hole.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fixed security hole where dashboard routes could be registered without authentication. When `webUI` is enabled but no API key is configured, the gateway now logs an error and skips dashboard registration entirely. `registerDashboardRoutes` also has a defense-in-depth check that returns 503 if called without an API key. Closes #155.

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -150,8 +150,12 @@ export async function startGateway(opts: GatewayOptions): Promise<GatewayServer>
 
   // Dashboard routes (login/logout are unprotected; dashboard pages are behind authMiddleware above)
   if (webUI && statusTracker) {
-    registerDashboardRoutes(app, statusTracker, projectPath, opts.apiKey);
-    app.get("/", (c) => c.redirect("/dashboard"));
+    if (!opts.apiKey) {
+      logger.error("Dashboard UI requested but no API key configured. Dashboard will not be enabled for security.");
+    } else {
+      registerDashboardRoutes(app, statusTracker, projectPath, opts.apiKey);
+      app.get("/", (c) => c.redirect("/dashboard"));
+    }
   }
 
   // Log API routes — available regardless of webUI flag (CLI needs them)
@@ -161,7 +165,7 @@ export async function startGateway(opts: GatewayOptions): Promise<GatewayServer>
     
     // Warn if log endpoints are exposed without authentication
     if (!opts.apiKey) {
-      logger.warn("Log endpoints are exposed without authentication. Consider setting up a gateway API key for security.");
+      logger.warn("Log and dashboard endpoints are exposed without authentication. Consider setting up a gateway API key for security.");
     }
   }
 

--- a/src/gateway/routes/dashboard.ts
+++ b/src/gateway/routes/dashboard.ts
@@ -61,6 +61,13 @@ export function registerDashboardRoutes(
     );
   }
 
+  // Defense in depth: refuse to serve dashboard routes without an API key
+  if (!apiKey) {
+    app.get("/dashboard", (c) => c.text("Dashboard disabled: No API key configured", 503));
+    app.get("/dashboard/*", (c) => c.text("Dashboard disabled: No API key configured", 503));
+    return;
+  }
+
   // Main dashboard page
   app.get("/dashboard", (c) => {
     const agents = statusTracker.getAllAgents();

--- a/test/gateway/dashboard-auth.test.ts
+++ b/test/gateway/dashboard-auth.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { startGateway } from "../../src/gateway/index.js";
+
+function mockStatusTracker() {
+  return {
+    getAllAgents: () => [],
+    getSchedulerInfo: () => null,
+    getRecentLogs: () => [],
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  } as any;
+}
+
+describe("dashboard auth via startGateway", () => {
+  describe("webUI enabled without apiKey", () => {
+    let gateway: any;
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    beforeAll(async () => {
+      gateway = await startGateway({
+        port: 0,
+        logger,
+        webUI: true,
+        statusTracker: mockStatusTracker(),
+        // No apiKey
+      });
+    });
+
+    afterAll(async () => {
+      await gateway.close();
+    });
+
+    it("logs an error when dashboard requested without api key", () => {
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Dashboard UI requested but no API key configured")
+      );
+    });
+
+    it("does not serve /dashboard", async () => {
+      const addr = gateway.server.address() as any;
+      const res = await fetch(`http://localhost:${addr.port}/dashboard`);
+      expect(res.status).toBe(404);
+    });
+
+    it("does not serve /dashboard/api/status-stream", async () => {
+      const addr = gateway.server.address() as any;
+      const res = await fetch(`http://localhost:${addr.port}/dashboard/api/status-stream`);
+      expect(res.status).toBe(404);
+    });
+
+    it("does not redirect / to /dashboard", async () => {
+      const addr = gateway.server.address() as any;
+      const res = await fetch(`http://localhost:${addr.port}/`, { redirect: "manual" });
+      // No redirect registered — 404
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("webUI enabled with apiKey", () => {
+    let gateway: any;
+    const TEST_API_KEY = "test-dashboard-key-456";
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    beforeAll(async () => {
+      gateway = await startGateway({
+        port: 0,
+        logger,
+        apiKey: TEST_API_KEY,
+        webUI: true,
+        statusTracker: mockStatusTracker(),
+      });
+    });
+
+    afterAll(async () => {
+      await gateway.close();
+    });
+
+    it("redirects unauthenticated browser requests to /login", async () => {
+      const addr = gateway.server.address() as any;
+      const res = await fetch(`http://localhost:${addr.port}/dashboard`, {
+        headers: { Accept: "text/html" },
+        redirect: "manual",
+      });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/login");
+    });
+
+    it("returns 401 for unauthenticated API requests", async () => {
+      const addr = gateway.server.address() as any;
+      const res = await fetch(`http://localhost:${addr.port}/dashboard`, {
+        headers: { Accept: "application/json" },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("serves dashboard to authenticated requests", async () => {
+      const addr = gateway.server.address() as any;
+      const res = await fetch(`http://localhost:${addr.port}/dashboard`, {
+        headers: { Authorization: `Bearer ${TEST_API_KEY}` },
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("protects SSE status stream", async () => {
+      const addr = gateway.server.address() as any;
+      const res = await fetch(`http://localhost:${addr.port}/dashboard/api/status-stream`, {
+        headers: { Accept: "application/json" },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("redirects / to /dashboard", async () => {
+      const addr = gateway.server.address() as any;
+      const res = await fetch(`http://localhost:${addr.port}/`, {
+        headers: { Authorization: `Bearer ${TEST_API_KEY}` },
+        redirect: "manual",
+      });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/dashboard");
+    });
+  });
+});

--- a/test/gateway/routes/dashboard.test.ts
+++ b/test/gateway/routes/dashboard.test.ts
@@ -50,10 +50,12 @@ describe("dashboard auth", () => {
     }
   });
 
-  it("serves dashboard without auth when no apiKey provided", async () => {
+  it("returns 503 when no apiKey provided (dashboard disabled for security)", async () => {
     const app = createTestApp();
     const res = await app.request("/dashboard");
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(503);
+    const text = await res.text();
+    expect(text).toContain("Dashboard disabled");
   });
 
   it("redirects browser requests to /login when apiKey set and no auth", async () => {


### PR DESCRIPTION
## Summary

- `startGateway()` now skips dashboard route registration entirely when `webUI: true` but no `apiKey` is provided — logs an error instead
- `registerDashboardRoutes()` adds a defense-in-depth check: if called without an `apiKey`, registers 503 stub routes and returns immediately
- Updated the unauthenticated-access warning for log endpoints to also mention dashboard endpoints
- Updated existing test that expected 200 for no-apiKey dashboard access to expect 503

## Test plan

- [x] New `test/gateway/dashboard-auth.test.ts` tests via `startGateway()`: no-apiKey case returns 404 and logs error; with-apiKey case enforces auth on all dashboard routes
- [x] Updated `test/gateway/routes/dashboard.test.ts`: no-apiKey call to `registerDashboardRoutes` now returns 503 with "Dashboard disabled" message
- [x] Full unit suite passes (1060 tests)

Closes #155