### PR TITLE
feat: add expose option to [server] config for al push

### DIFF
--- a/.changeset/server-expose-option.md
+++ b/.changeset/server-expose-option.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Added `expose` field to `[server]` config for `al push` deployments. Set `expose = false` to bind the gateway to localhost only instead of `0.0.0.0`, which is useful when running behind a reverse proxy. Defaults to `true` for backward compatibility. Closes #152.

--- a/docs/vps-deployment.mdx
+++ b/docs/vps-deployment.mdx
@@ -214,6 +214,27 @@ sudo ufw allow https
 sudo ufw enable
 ```
 
+## SSH Push Deploy (`al push`)
+
+`al push` deploys your project to a server over SSH and manages the scheduler as a systemd service. It requires a `[server]` section in your environment file.
+
+In your environment file (`~/.action-llama/environments/<name>.toml`):
+
+```toml
+[server]
+host = "5.6.7.8"
+user = "root"          # default: "root"
+port = 22              # default: 22
+keyPath = "~/.ssh/id_rsa"  # default: ssh-agent
+basePath = "/opt/action-llama"  # default: "/opt/action-llama"
+expose = true          # bind gateway to 0.0.0.0 (default: true)
+```
+
+The `expose` field controls whether the gateway binds to `0.0.0.0` (all interfaces) or `127.0.0.1` (localhost only):
+
+- `expose = true` (default) — gateway listens on all interfaces, reachable from outside the server. Required for incoming webhooks.
+- `expose = false` — gateway listens on localhost only. Use this when a reverse proxy (Caddy, nginx) handles public traffic, or when you don't need external webhook access.
+
 ## Security Considerations
 
 - **Use TLS in production** — Don't expose port 8080 directly without HTTPS
@@ -221,6 +242,7 @@ sudo ufw enable
 - **Credentials isolation** — Each agent runs in a Docker container with only its required credentials
 - **User separation** — Run Action Llama as a non-root user
 - **SSH key security** — The VPS cloud provider uses your SSH key for all operations. Protect it with a passphrase and restrict access.
+- **`expose = false` for reverse proxy setups** — When using Caddy or nginx in front of the gateway, set `expose = false` in your `[server]` config to prevent the gateway port from being directly reachable.
 
 ## Monitoring
 

--- a/src/remote/push.ts
+++ b/src/remote/push.ts
@@ -48,6 +48,7 @@ export function buildSystemdUnit(
   basePath: string,
   binPaths?: BootstrapResult,
   gatewayPort?: number,
+  expose?: boolean,
 ): string {
   // al is installed as a project dependency — use the local binary
   const alExec = `${basePath}/project/node_modules/.bin/al`;
@@ -57,6 +58,8 @@ export function buildSystemdUnit(
   const pathEnv = extraDirs.size > 0
     ? `\nEnvironment=PATH=${[...extraDirs].join(":")}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`
     : "";
+  // Default to true for backward compatibility — existing server deployments expect public exposure
+  const exposeFlag = expose === false ? "" : " -e";
 
   return `[Unit]
 Description=Action Llama scheduler (${projectName})
@@ -66,7 +69,7 @@ Requires=docker.service
 [Service]
 Type=simple
 WorkingDirectory=${basePath}/project
-ExecStart=${alExec} start --headless -w -e${gatewayPort ? ` --port ${gatewayPort}` : ""}
+ExecStart=${alExec} start --headless -w${exposeFlag}${gatewayPort ? ` --port ${gatewayPort}` : ""}
 Restart=on-failure
 RestartSec=5
 Environment=NODE_ENV=production${pathEnv}
@@ -173,7 +176,7 @@ async function pushToServerInner(ssh: SshOptions, opts: InnerOpts): Promise<void
     phaseB.push(setupNginx(ssh, basePath, serverConfig.cloudflareHostname, gatewayPort));
   }
   phaseB.push(writeEnvAndSymlink(ssh, basePath, gatewayPort, globalConfig));
-  const unitContent = buildSystemdUnit(projectName, basePath, binPaths, gatewayPort);
+  const unitContent = buildSystemdUnit(projectName, basePath, binPaths, gatewayPort, serverConfig.expose);
   phaseB.push(installSystemdUnit(ssh, unitContent));
 
   const results = await Promise.all(phaseB);

--- a/src/shared/server.ts
+++ b/src/shared/server.ts
@@ -6,6 +6,7 @@ export interface ServerConfig {
   port?: number;         // default: 22
   keyPath?: string;      // default: ssh-agent
   basePath?: string;     // default: "/opt/action-llama"
+  expose?: boolean;      // bind gateway to 0.0.0.0 (default: true for backward compat)
   provider?: string;        // "vultr" or "hetzner" when AL-provisioned
   vultrInstanceId?: string;
   vultrRegion?: string;
@@ -45,6 +46,10 @@ export function validateServerConfig(raw: unknown): ServerConfig {
 
   if (config.keyPath !== undefined && typeof config.keyPath !== "string") {
     throw new ConfigError("server.keyPath must be a string");
+  }
+
+  if (config.expose !== undefined && typeof config.expose !== "boolean") {
+    throw new ConfigError("server.expose must be a boolean");
   }
 
   return config as unknown as ServerConfig;

--- a/test/remote/push.test.ts
+++ b/test/remote/push.test.ts
@@ -86,6 +86,28 @@ describe("buildSystemdUnit", () => {
     const unit = buildSystemdUnit("proj", "/opt/al");
     expect(unit).not.toContain("--port");
   });
+
+  it("includes -e when expose is true", () => {
+    const unit = buildSystemdUnit("proj", "/opt/al", undefined, undefined, true);
+    expect(unit).toContain("start --headless -w -e\n");
+  });
+
+  it("omits -e when expose is false", () => {
+    const unit = buildSystemdUnit("proj", "/opt/al", undefined, undefined, false);
+    expect(unit).not.toContain(" -e");
+    expect(unit).toContain("start --headless -w\n");
+  });
+
+  it("includes -e when expose is undefined (backward compat default)", () => {
+    const unit = buildSystemdUnit("proj", "/opt/al", undefined, undefined, undefined);
+    expect(unit).toContain("start --headless -w -e\n");
+  });
+
+  it("omits -e but keeps --port when expose is false and gatewayPort is set", () => {
+    const unit = buildSystemdUnit("proj", "/opt/al", undefined, 3000, false);
+    expect(unit).not.toContain(" -e");
+    expect(unit).toContain("start --headless -w --port 3000");
+  });
 });
 
 describe("computePkgHash", () => {

--- a/test/shared/server.test.ts
+++ b/test/shared/server.test.ts
@@ -52,6 +52,20 @@ describe("validateServerConfig", () => {
     expect(() => validateServerConfig({ host: "h", keyPath: true })).toThrow("server.keyPath must be a string");
   });
 
+  it("accepts expose: true", () => {
+    const config = validateServerConfig({ host: "h", expose: true });
+    expect(config.expose).toBe(true);
+  });
+
+  it("accepts expose: false", () => {
+    const config = validateServerConfig({ host: "h", expose: false });
+    expect(config.expose).toBe(false);
+  });
+
+  it("throws on non-boolean expose", () => {
+    expect(() => validateServerConfig({ host: "h", expose: "yes" })).toThrow("server.expose must be a boolean");
+  });
+
   it("ignores unknown fields", () => {
     const config = validateServerConfig({ host: "h", gatewayPort: 9090 });
     expect(config.host).toBe("h");


### PR DESCRIPTION
## Summary

- Adds optional `expose` field to `ServerConfig` (`[server]` section in environment files)
- When `expose = false`, the systemd unit generated by `al push` omits the `-e` flag, binding the gateway to `127.0.0.1` instead of `0.0.0.0`
- Defaults to `true` for backward compatibility with existing deployments
- Adds validation for the new field and documentation in `docs/vps-deployment.mdx`

Closes #152

## Test plan

- [x] `buildSystemdUnit` with `expose: true` → includes `-e`
- [x] `buildSystemdUnit` with `expose: false` → omits `-e`
- [x] `buildSystemdUnit` with `expose: undefined` → includes `-e` (backward compat)
- [x] `buildSystemdUnit` with `expose: false` + port → omits `-e`, keeps `--port`
- [x] `validateServerConfig` accepts `expose: true/false`, rejects non-boolean
- [x] All existing tests pass unchanged