### PR TITLE
fix: pin croner to ^10.0.1 instead of latest

### DIFF
--- a/.changeset/fix-croner-version.md
+++ b/.changeset/fix-croner-version.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Pinned the `croner` dependency to `^10.0.1` instead of `"latest"` to ensure reproducible installs. Closes #154.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@opentelemetry/semantic-conventions": "^1.28.0",
         "better-sqlite3": "^12.8.0",
         "commander": "^14.0.3",
-        "croner": "latest",
+        "croner": "^10.0.1",
         "hono": "^4.12.5",
         "ink": "^6.8.0",
         "pino": "^10.3.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@opentelemetry/semantic-conventions": "^1.28.0",
     "better-sqlite3": "^12.8.0",
     "commander": "^14.0.3",
-    "croner": "latest",
+    "croner": "^10.0.1",
     "hono": "^4.12.5",
     "ink": "^6.8.0",
     "pino": "^10.3.1",


### PR DESCRIPTION
## Summary

- Changed `"croner": "latest"` to `"croner": "^10.0.1"` in `package.json`
- Regenerated `package-lock.json` (resolved version unchanged: 10.0.1)
- Consistent with all other dependencies in the project which use caret ranges

Closes #154

## Test plan

- [x] `npm install` completes successfully, lock file still resolves to 10.0.1
- [x] No behavior change — same version as before, just pinned