### PR TITLE
feat: durable Queue abstraction backed by SQLite (closes #157)

### DIFF
--- a/.changeset/durable-queue-sqlite.md
+++ b/.changeset/durable-queue-sqlite.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Added a durable `Queue<T>` abstraction backed by SQLite. The generic `Queue` interface (`enqueue`, `dequeue`, `peek`, `size`) is designed to be swappable — a `MemoryQueue` is provided for tests and single-process use, and `SqliteQueue` persists items across restarts with atomic FIFO dequeue. Use `createQueue({ type: "sqlite", path, name })` to create a named queue within the project's existing state database. Closes #157.

--- a/src/shared/queue-memory.ts
+++ b/src/shared/queue-memory.ts
@@ -1,0 +1,34 @@
+import { randomUUID } from "crypto";
+import type { Queue, QueueItem } from "./queue.js";
+
+/**
+ * In-memory Queue implementation.
+ *
+ * Suitable for tests and single-process local use where durability
+ * is not required. State is lost when the process exits.
+ */
+export class MemoryQueue<T> implements Queue<T> {
+  private items: QueueItem<T>[] = [];
+
+  async enqueue(payload: T): Promise<string> {
+    const id = randomUUID();
+    this.items.push({ id, payload, enqueuedAt: Date.now() });
+    return id;
+  }
+
+  async dequeue(limit = 1): Promise<QueueItem<T>[]> {
+    return this.items.splice(0, limit);
+  }
+
+  async peek(limit = 1): Promise<QueueItem<T>[]> {
+    return this.items.slice(0, limit);
+  }
+
+  async size(): Promise<number> {
+    return this.items.length;
+  }
+
+  async close(): Promise<void> {
+    this.items = [];
+  }
+}

--- a/src/shared/queue-sqlite.ts
+++ b/src/shared/queue-sqlite.ts
@@ -1,0 +1,116 @@
+import Database from "better-sqlite3";
+import { mkdirSync } from "fs";
+import { dirname } from "path";
+import { randomUUID } from "crypto";
+import type { Queue, QueueItem } from "./queue.js";
+
+/**
+ * SQLite-backed Queue.
+ *
+ * All queue instances sharing a file use a single `queue` table,
+ * differentiated by a `name` column — the same pattern SqliteStateStore
+ * uses for namespaces.
+ *
+ * Uses better-sqlite3 for fast, synchronous, embedded storage.
+ * The async interface is preserved for compatibility with future
+ * remote-backed implementations (e.g., PostgreSQL).
+ *
+ * Dequeue is atomic: a transaction selects and deletes the head rows
+ * so concurrent readers (if any) cannot claim the same items.
+ */
+export class SqliteQueue<T> implements Queue<T> {
+  private db: InstanceType<typeof Database>;
+  // better-sqlite3 generic Statement types don't compose with ReturnType<>;
+  // the public Queue interface provides the type safety boundary.
+  private stmts: any;
+  private readonly name: string;
+  private _dequeueTransaction: (name: string, limit: number) => Array<{
+    id: string;
+    payload: string;
+    enqueued_at: number;
+  }>;
+
+  constructor(dbPath: string, name: string) {
+    this.name = name;
+    mkdirSync(dirname(dbPath), { recursive: true });
+    this.db = new Database(dbPath);
+    this.db.pragma("journal_mode = WAL");
+
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS queue (
+        id          TEXT NOT NULL,
+        name        TEXT NOT NULL,
+        payload     TEXT NOT NULL,
+        enqueued_at INTEGER NOT NULL,
+        PRIMARY KEY (name, id)
+      )
+    `);
+    this.db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_queue_name ON queue(name)"
+    );
+
+    // Prepare statements once for performance.
+    this.stmts = {
+      enqueue: this.db.prepare(
+        "INSERT INTO queue (id, name, payload, enqueued_at) VALUES (?, ?, ?, ?)"
+      ),
+      peek: this.db.prepare(
+        "SELECT id, payload, enqueued_at FROM queue WHERE name = ? ORDER BY rowid ASC LIMIT ?"
+      ),
+      delete: this.db.prepare("DELETE FROM queue WHERE name = ? AND id = ?"),
+      size: this.db.prepare("SELECT COUNT(*) AS n FROM queue WHERE name = ?"),
+    };
+
+    // Pre-compiled transaction for atomic dequeue (select + delete in one shot).
+    this._dequeueTransaction = this.db.transaction(
+      (name: string, limit: number) => {
+        const rows = this.stmts.peek.all(name, limit) as Array<{
+          id: string;
+          payload: string;
+          enqueued_at: number;
+        }>;
+        for (const row of rows) {
+          this.stmts.delete.run(name, row.id);
+        }
+        return rows;
+      }
+    );
+  }
+
+  async enqueue(payload: T): Promise<string> {
+    const id = randomUUID();
+    this.stmts.enqueue.run(id, this.name, JSON.stringify(payload), Date.now());
+    return id;
+  }
+
+  async dequeue(limit = 1): Promise<QueueItem<T>[]> {
+    const rows = this._dequeueTransaction(this.name, limit);
+    return rows.map((r) => ({
+      id: r.id,
+      payload: JSON.parse(r.payload) as T,
+      enqueuedAt: r.enqueued_at,
+    }));
+  }
+
+  async peek(limit = 1): Promise<QueueItem<T>[]> {
+    const rows = this.stmts.peek.all(this.name, limit) as Array<{
+      id: string;
+      payload: string;
+      enqueued_at: number;
+    }>;
+    return rows.map((r) => ({
+      id: r.id,
+      payload: JSON.parse(r.payload) as T,
+      enqueuedAt: r.enqueued_at,
+    }));
+  }
+
+  async size(): Promise<number> {
+    const row = this.stmts.size.get(this.name) as { n: number };
+    return row.n;
+  }
+
+  async close(): Promise<void> {
+    this.db.close();
+  }
+}

--- a/src/shared/queue.ts
+++ b/src/shared/queue.ts
@@ -1,0 +1,73 @@
+/**
+ * Queue — durable ordered FIFO queue with a swappable backend.
+ *
+ * Items are dequeued in insertion order (FIFO).
+ * The interface is intentionally minimal so it can be backed by
+ * SQLite (local), PostgreSQL (cloud), or an in-memory store (tests).
+ */
+
+export interface QueueItem<T = unknown> {
+  /** Opaque unique identifier assigned at enqueue time. */
+  id: string;
+  /** The enqueued value. */
+  payload: T;
+  /** Unix milliseconds when the item was enqueued. */
+  enqueuedAt: number;
+}
+
+export interface Queue<T = unknown> {
+  /**
+   * Append a payload to the tail of the queue.
+   * Returns the assigned item ID.
+   */
+  enqueue(payload: T): Promise<string>;
+
+  /**
+   * Remove and return up to `limit` items from the head (FIFO order).
+   * Defaults to 1. Returns an empty array when the queue is empty.
+   */
+  dequeue(limit?: number): Promise<QueueItem<T>[]>;
+
+  /**
+   * Return up to `limit` items from the head without removing them.
+   * Defaults to 1. Returns an empty array when the queue is empty.
+   */
+  peek(limit?: number): Promise<QueueItem<T>[]>;
+
+  /** Return the number of items currently in the queue. */
+  size(): Promise<number>;
+
+  /** Release resources (close DB connection, clear timers, etc.). */
+  close(): Promise<void>;
+}
+
+// --- Factory ---
+
+export interface SqliteQueueOpts {
+  type: "sqlite";
+  /** Path to the .db file (created if missing). */
+  path: string;
+  /** Queue name — allows multiple queues in one SQLite file. */
+  name: string;
+}
+
+export interface MemoryQueueOpts {
+  type: "memory";
+}
+
+export type QueueOpts = SqliteQueueOpts | MemoryQueueOpts;
+
+/**
+ * Create a Queue from configuration.
+ *
+ * Uses dynamic imports so native modules (better-sqlite3) are only
+ * loaded when actually needed.
+ */
+export async function createQueue<T>(opts: QueueOpts): Promise<Queue<T>> {
+  if (opts.type === "sqlite") {
+    const { SqliteQueue } = await import("./queue-sqlite.js");
+    return new SqliteQueue<T>(opts.path, opts.name);
+  }
+  const { MemoryQueue } = await import("./queue-memory.js");
+  return new MemoryQueue<T>();
+}

--- a/test/shared/queue.test.ts
+++ b/test/shared/queue.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { createQueue, type Queue } from "../../src/shared/queue.js";
+import { MemoryQueue } from "../../src/shared/queue-memory.js";
+import { SqliteQueue } from "../../src/shared/queue-sqlite.js";
+
+/**
+ * Contract tests: every Queue implementation must pass these.
+ */
+function queueContract(label: string, factory: () => Promise<Queue<string>>) {
+  describe(label, () => {
+    it("enqueue returns a unique id", async () => {
+      const q = await factory();
+      const id1 = await q.enqueue("a");
+      const id2 = await q.enqueue("b");
+      expect(typeof id1).toBe("string");
+      expect(id1).not.toBe(id2);
+      await q.close();
+    });
+
+    it("size reflects enqueue and dequeue", async () => {
+      const q = await factory();
+      expect(await q.size()).toBe(0);
+      await q.enqueue("x");
+      await q.enqueue("y");
+      expect(await q.size()).toBe(2);
+      await q.dequeue();
+      expect(await q.size()).toBe(1);
+      await q.close();
+    });
+
+    it("dequeue returns items in FIFO order", async () => {
+      const q = await factory();
+      await q.enqueue("first");
+      await q.enqueue("second");
+      await q.enqueue("third");
+      const [item] = await q.dequeue();
+      expect(item.payload).toBe("first");
+      const [item2] = await q.dequeue();
+      expect(item2.payload).toBe("second");
+      await q.close();
+    });
+
+    it("dequeue removes items from the queue", async () => {
+      const q = await factory();
+      await q.enqueue("item");
+      await q.dequeue();
+      expect(await q.size()).toBe(0);
+      await q.close();
+    });
+
+    it("dequeue with limit returns multiple items in order", async () => {
+      const q = await factory();
+      await q.enqueue("a");
+      await q.enqueue("b");
+      await q.enqueue("c");
+      const items = await q.dequeue(2);
+      expect(items).toHaveLength(2);
+      expect(items[0].payload).toBe("a");
+      expect(items[1].payload).toBe("b");
+      expect(await q.size()).toBe(1);
+      await q.close();
+    });
+
+    it("dequeue on empty queue returns empty array", async () => {
+      const q = await factory();
+      const items = await q.dequeue();
+      expect(items).toEqual([]);
+      await q.close();
+    });
+
+    it("dequeue limit larger than queue size returns all items", async () => {
+      const q = await factory();
+      await q.enqueue("only");
+      const items = await q.dequeue(10);
+      expect(items).toHaveLength(1);
+      expect(items[0].payload).toBe("only");
+      await q.close();
+    });
+
+    it("peek returns items without removing them", async () => {
+      const q = await factory();
+      await q.enqueue("peek-me");
+      const [item] = await q.peek();
+      expect(item.payload).toBe("peek-me");
+      expect(await q.size()).toBe(1);
+      await q.close();
+    });
+
+    it("peek with limit returns multiple items in order without removing them", async () => {
+      const q = await factory();
+      await q.enqueue("a");
+      await q.enqueue("b");
+      const items = await q.peek(2);
+      expect(items).toHaveLength(2);
+      expect(items[0].payload).toBe("a");
+      expect(items[1].payload).toBe("b");
+      expect(await q.size()).toBe(2);
+      await q.close();
+    });
+
+    it("item has correct id and enqueuedAt", async () => {
+      const q = await factory();
+      const before = Date.now();
+      const id = await q.enqueue("timestamped");
+      const [item] = await q.dequeue();
+      expect(item.id).toBe(id);
+      expect(item.enqueuedAt).toBeGreaterThanOrEqual(before);
+      expect(item.enqueuedAt).toBeLessThanOrEqual(Date.now());
+      await q.close();
+    });
+
+    it("round-trips complex JSON payloads", async () => {
+      const q = await factory() as unknown as Queue<{ n: number; arr: string[] }>;
+      const payload = { n: 42, arr: ["x", "y"] };
+      await q.enqueue(payload);
+      const [item] = await q.dequeue();
+      expect(item.payload).toEqual(payload);
+      await q.close();
+    });
+  });
+}
+
+describe("Queue", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    dirs.length = 0;
+  });
+
+  function sqliteFactory(name = "default"): () => Promise<Queue<string>> {
+    return async () => {
+      const dir = mkdtempSync(join(tmpdir(), "al-queue-"));
+      dirs.push(dir);
+      return new SqliteQueue<string>(join(dir, "queue.db"), name);
+    };
+  }
+
+  queueContract("MemoryQueue", async () => new MemoryQueue<string>());
+  queueContract("SqliteQueue", sqliteFactory());
+
+  describe("SqliteQueue — multiple queues in one db file", () => {
+    it("isolates items by queue name", async () => {
+      const dir = mkdtempSync(join(tmpdir(), "al-queue-"));
+      dirs.push(dir);
+      const path = join(dir, "multi.db");
+      const q1 = new SqliteQueue<string>(path, "alpha");
+      const q2 = new SqliteQueue<string>(path, "beta");
+      await q1.enqueue("from-alpha");
+      await q2.enqueue("from-beta");
+      const [item1] = await q1.dequeue();
+      expect(item1.payload).toBe("from-alpha");
+      expect(await q1.size()).toBe(0);
+      expect(await q2.size()).toBe(1);
+      const [item2] = await q2.dequeue();
+      expect(item2.payload).toBe("from-beta");
+      await q1.close();
+      await q2.close();
+    });
+
+    it("dequeue is atomic — concurrent reads don't double-claim", async () => {
+      const dir = mkdtempSync(join(tmpdir(), "al-queue-"));
+      dirs.push(dir);
+      const path = join(dir, "atomic.db");
+      // Two handles to the same queue name
+      const q1 = new SqliteQueue<string>(path, "shared");
+      const q2 = new SqliteQueue<string>(path, "shared");
+      await q1.enqueue("item-1");
+      await q1.enqueue("item-2");
+      // Each reader claims one item
+      const [a] = await q1.dequeue();
+      const [b] = await q2.dequeue();
+      expect(a.payload).not.toBe(b.payload);
+      expect(await q1.size()).toBe(0);
+      await q1.close();
+      await q2.close();
+    });
+  });
+
+  describe("createQueue factory", () => {
+    it("creates memory queue", async () => {
+      const q = await createQueue<number>({ type: "memory" });
+      await q.enqueue(42);
+      const [item] = await q.dequeue();
+      expect(item.payload).toBe(42);
+      await q.close();
+    });
+
+    it("creates sqlite queue", async () => {
+      const dir = mkdtempSync(join(tmpdir(), "al-queue-"));
+      dirs.push(dir);
+      const q = await createQueue<string>({
+        type: "sqlite",
+        path: join(dir, "q.db"),
+        name: "test",
+      });
+      await q.enqueue("hello");
+      const [item] = await q.dequeue();
+      expect(item.payload).toBe("hello");
+      await q.close();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- New `Queue<T>` interface in `src/shared/queue.ts` — `enqueue`, `dequeue`, `peek`, `size`, `close`
- `SqliteQueue<T>` in `src/shared/queue-sqlite.ts` — persists items in a `queue` table using WAL mode; atomic FIFO dequeue via SQLite transaction; orders by `rowid` for guaranteed insertion order across same-millisecond enqueues; multiple named queues can coexist in one `.db` file
- `MemoryQueue<T>` in `src/shared/queue-memory.ts` — in-memory fallback for tests and single-process local use
- `createQueue(opts)` factory with `{ type: "sqlite", path, name }` and `{ type: "memory" }` options — dynamically imports the SQLite backend so `better-sqlite3` is only loaded when needed

The interface is intentionally backend-agnostic. Swapping in a PostgreSQL implementation later only requires a new class that satisfies `Queue<T>` and a new branch in `createQueue`.

## Test plan

- [x] Contract test suite (`queueContract`) runs against both `MemoryQueue` and `SqliteQueue` — 26 tests total
- [x] Additional SQLite-specific tests: multi-queue isolation in one file, atomic dequeue (two connections can't claim the same item)
- [x] Full unit suite passes (1105 tests)

Closes #157