### PR TITLE
fix: block all triggers when scheduler is paused

### DIFF
--- a/.changeset/fix-scheduler-pause-webhooks.md
+++ b/.changeset/fix-scheduler-pause-webhooks.md
@@ -1,0 +1,8 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fixed scheduler pause not blocking webhook triggers. When the scheduler was paused
+via `al pause`, webhooks could still trigger agent runs and queue work. Now all
+trigger paths (webhooks, agent-to-agent calls, manual triggers, and queue draining)
+respect the paused state and reject new work. Closes #162.

--- a/src/scheduler/execution.ts
+++ b/src/scheduler/execution.ts
@@ -35,6 +35,8 @@ export interface SchedulerContext {
   shuttingDown: boolean;
   skills?: PromptSkills;
   useBakedImages: boolean;
+  /** Returns true when the scheduler is paused — all new work should be rejected. */
+  isPaused?: () => boolean;
   /** Optional hook called after every agent run completes. Used for test instrumentation. */
   onRunComplete?: (event: RunCompleteEvent) => void;
   /** Optional event bus for lifecycle instrumentation (used by integration tests). */
@@ -124,7 +126,7 @@ export function dispatchTriggers(
 
 /** Drain all agents' work queues — fires runs without blocking. */
 export async function drainQueues(ctx: SchedulerContext): Promise<void> {
-  if (ctx.shuttingDown) return;
+  if (ctx.shuttingDown || ctx.isPaused?.()) return;
   for (const agentConfig of ctx.agentConfigs) {
     const pool = ctx.runnerPools[agentConfig.name];
     if (!pool || ctx.workQueue.size(agentConfig.name) === 0) continue;

--- a/src/scheduler/index.ts
+++ b/src/scheduler/index.ts
@@ -185,6 +185,7 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
         logger.info("Scheduler resumed via control API");
       },
       triggerAgent: async (name: string) => {
+        if (statusTracker?.isPaused()) return false;
         const pool = runnerPools[name];
         if (!pool) return false;
         const runner = pool.getAvailableRunner();
@@ -342,11 +343,14 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
   await workQueue.init();
   const skills: PromptSkills = { locking: true };
   const callStore = gateway?.callStore;
-  const schedulerCtx: SchedulerContext = { runnerPools, agentConfigs, maxReruns, maxTriggerDepth, logger, workQueue, shuttingDown: false, skills, useBakedImages: true, events, callStore };
+  const schedulerCtx: SchedulerContext = { runnerPools, agentConfigs, maxReruns, maxTriggerDepth, logger, workQueue, shuttingDown: false, skills, useBakedImages: true, isPaused: () => statusTracker?.isPaused() ?? false, events, callStore };
 
   // Wire up the call dispatcher so al-call works from inside containers
   if (gateway) {
     gateway.setCallDispatcher((entry) => {
+      if (statusTracker?.isPaused()) {
+        return { ok: false, reason: "scheduler is paused" };
+      }
       if (entry.callerAgent === entry.targetAgent) {
         return { ok: false, reason: "agent cannot call itself" };
       }
@@ -414,6 +418,10 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
           type: providerType,
           filter,
           trigger: (context: WebhookContext) => {
+            if (statusTracker?.isPaused()) {
+              logger.info({ agent: agentConfig.name, event: context.event }, "scheduler paused, webhook rejected");
+              return false;
+            }
             if (statusTracker && !statusTracker.isAgentEnabled(agentConfig.name)) return false;
 
             const runner = pool.getAvailableRunner();

--- a/test/scheduler/execution.test.ts
+++ b/test/scheduler/execution.test.ts
@@ -231,6 +231,25 @@ describe("drainQueues", () => {
     expect(runner.run).not.toHaveBeenCalled();
   });
 
+  it("stops when isPaused returns true", async () => {
+    const runner = makeRunner({ instanceId: "a" });
+    const ctx = makeCtx({
+      agentConfigs: [makeAgentConfig("a")],
+      runnerPools: { a: new RunnerPool([runner]) },
+      isPaused: () => true,
+    });
+    ctx.workQueue.enqueue("a", {
+      type: "webhook",
+      context: { event: "push", action: "", payload: {}, headers: {}, source: "github" } as any,
+    });
+
+    await drainQueues(ctx);
+
+    expect(runner.run).not.toHaveBeenCalled();
+    // Items remain in the queue (not lost)
+    expect(ctx.workQueue.size("a")).toBe(1);
+  });
+
   it("stops when shuttingDown is true", async () => {
     const runner = makeRunner({ instanceId: "a" });
     const ctx = makeCtx({

--- a/test/scheduler/webhooks.test.ts
+++ b/test/scheduler/webhooks.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createHmac } from "crypto";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
 import { join, resolve } from "path";
 import { tmpdir } from "os";
@@ -135,6 +136,7 @@ vi.mock("../../src/shared/logger.js", () => ({
 }));
 
 import { startScheduler } from "../../src/scheduler/index.js";
+import { StatusTracker } from "../../src/tui/status-tracker.js";
 
 const model = { provider: "anthropic", model: "claude-sonnet-4-20250514", thinkingLevel: "medium", authType: "api_key" };
 
@@ -259,5 +261,168 @@ describe("scheduler webhook support", () => {
     // so we verify the queue behavior through the WorkQueue unit tests
     // and the scheduler integration via the rerun+drain test below
     expect(mockRun).not.toHaveBeenCalled();
+  });
+});
+
+function signPayload(body: string, secret: string): string {
+  return "sha256=" + createHmac("sha256", secret).update(body).digest("hex");
+}
+
+describe("scheduler pause blocks webhooks", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cronCallbacks.length = 0;
+    mockIsRunning = false;
+    tmpDir = mkdtempSync(join(tmpdir(), "al-sched-pause-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rejects webhook triggers when scheduler is paused", async () => {
+    setupProjectWithWebhooks(tmpDir);
+    const statusTracker = new StatusTracker();
+    statusTracker.setSchedulerInfo({
+      mode: "docker",
+      runtime: "local",
+      gatewayPort: 8080,
+      cronJobCount: 0,
+      webhooksActive: true,
+      webhookUrls: [],
+      startedAt: new Date(),
+      paused: false,
+    });
+
+    const { webhookRegistry, schedulerCtx } = await startScheduler(tmpDir, undefined, statusTracker);
+
+    // Verify initially not paused
+    expect(schedulerCtx.isPaused?.()).toBe(false);
+
+    // Pause the scheduler
+    statusTracker.setPaused(true);
+    expect(schedulerCtx.isPaused?.()).toBe(true);
+
+    // Dispatch a webhook — should be rejected (skipped) because scheduler is paused
+    const payload = JSON.stringify({
+      action: "labeled",
+      issue: { number: 1, title: "Test", body: "test body", labels: [{ name: "agent" }], html_url: "https://github.com/test/test/issues/1" },
+      repository: { full_name: "test/repo" },
+      sender: { login: "user1" },
+      label: { name: "agent" },
+    });
+    const signature = signPayload(payload, "fake-token");
+
+    const result = webhookRegistry!.dispatch("github", {
+      "x-hub-signature-256": signature,
+      "x-github-event": "issues",
+      "content-type": "application/json",
+    }, payload, { MyOrg: "fake-token" });
+
+    expect(result.ok).toBe(true);
+    expect(result.matched).toBe(0);
+    expect(result.skipped).toBe(1); // trigger returned false
+    expect(mockRun).not.toHaveBeenCalled();
+  });
+
+  it("accepts webhook triggers when scheduler is not paused", async () => {
+    setupProjectWithWebhooks(tmpDir);
+    const statusTracker = new StatusTracker();
+    statusTracker.setSchedulerInfo({
+      mode: "docker",
+      runtime: "local",
+      gatewayPort: 8080,
+      cronJobCount: 0,
+      webhooksActive: true,
+      webhookUrls: [],
+      startedAt: new Date(),
+      paused: false,
+    });
+
+    const { webhookRegistry } = await startScheduler(tmpDir, undefined, statusTracker);
+
+    const payload = JSON.stringify({
+      action: "labeled",
+      issue: { number: 1, title: "Test", body: "test body", labels: [{ name: "agent" }], html_url: "https://github.com/test/test/issues/1" },
+      repository: { full_name: "test/repo" },
+      sender: { login: "user1" },
+      label: { name: "agent" },
+    });
+    const signature = signPayload(payload, "fake-token");
+
+    const result = webhookRegistry!.dispatch("github", {
+      "x-hub-signature-256": signature,
+      "x-github-event": "issues",
+      "content-type": "application/json",
+    }, payload, { MyOrg: "fake-token" });
+
+    expect(result.ok).toBe(true);
+    expect(result.matched).toBe(1);
+    expect(result.skipped).toBe(0);
+  });
+
+  it("does not queue webhook events when paused", async () => {
+    setupProjectWithWebhooks(tmpDir);
+    const statusTracker = new StatusTracker();
+    statusTracker.setSchedulerInfo({
+      mode: "docker",
+      runtime: "local",
+      gatewayPort: 8080,
+      cronJobCount: 0,
+      webhooksActive: true,
+      webhookUrls: [],
+      startedAt: new Date(),
+      paused: false,
+    });
+
+    const { webhookRegistry, schedulerCtx } = await startScheduler(tmpDir, undefined, statusTracker);
+
+    // Pause the scheduler
+    statusTracker.setPaused(true);
+
+    const payload = JSON.stringify({
+      action: "labeled",
+      issue: { number: 1, title: "Test", body: "test body", labels: [{ name: "agent" }], html_url: "https://github.com/test/test/issues/1" },
+      repository: { full_name: "test/repo" },
+      sender: { login: "user1" },
+      label: { name: "agent" },
+    });
+    const signature = signPayload(payload, "fake-token");
+
+    webhookRegistry!.dispatch("github", {
+      "x-hub-signature-256": signature,
+      "x-github-event": "issues",
+      "content-type": "application/json",
+    }, payload, { MyOrg: "fake-token" });
+
+    // Work queue should be empty — paused scheduler rejects, not queues
+    expect(schedulerCtx.workQueue.size("webhook-dev")).toBe(0);
+  });
+
+  it("wires isPaused into schedulerCtx from statusTracker", async () => {
+    setupProjectWithWebhooks(tmpDir);
+    const statusTracker = new StatusTracker();
+    statusTracker.setSchedulerInfo({
+      mode: "docker",
+      runtime: "local",
+      gatewayPort: 8080,
+      cronJobCount: 0,
+      webhooksActive: true,
+      webhookUrls: [],
+      startedAt: new Date(),
+      paused: false,
+    });
+
+    const { schedulerCtx } = await startScheduler(tmpDir, undefined, statusTracker);
+
+    expect(schedulerCtx.isPaused?.()).toBe(false);
+
+    statusTracker.setPaused(true);
+    expect(schedulerCtx.isPaused?.()).toBe(true);
+
+    statusTracker.setPaused(false);
+    expect(schedulerCtx.isPaused?.()).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- When the scheduler was paused via `al pause`, only cron jobs were stopped — webhooks, agent-to-agent calls (`al-call`), manual triggers, and queue draining all continued to fire
- Added `isPaused` check to the webhook trigger callback, call dispatcher, manual trigger handler, and `drainQueues` so all trigger paths respect the paused state
- Work is rejected (not queued) when paused, matching the expected behavior described in #162

Closes #162

## Test plan

- [x] New unit test: `drainQueues` skips work when `isPaused` returns true (execution.test.ts)
- [x] New unit test: webhook triggers are rejected when scheduler is paused (webhooks.test.ts)
- [x] New unit test: webhook triggers are accepted when scheduler is not paused (webhooks.test.ts)
- [x] New unit test: webhook events are not queued when paused (webhooks.test.ts)
- [x] New unit test: `isPaused` is properly wired from StatusTracker to SchedulerContext (webhooks.test.ts)
- [x] All 1084 existing unit tests pass