### PR TITLE
fix: scheduler pause doesn't block webhook and other triggers

### DIFF
--- a/.changeset/fix-scheduler-pause.md
+++ b/.changeset/fix-scheduler-pause.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fixed scheduler pause not blocking webhook triggers, queued work, and manual triggers. When the scheduler is paused, all trigger sources (webhooks, cron, manual control API, inter-agent calls) now reject incoming work rather than queuing it. Closes #162.

--- a/src/scheduler/execution.ts
+++ b/src/scheduler/execution.ts
@@ -10,6 +10,7 @@ import type { WebhookContext } from "../webhooks/types.js";
 import type { createLogger } from "../shared/logger.js";
 import type { SchedulerEventBus } from "./events.js";
 import type { CallStore } from "../gateway/call-store.js";
+import type { StatusTracker } from "../tui/status-tracker.js";
 
 export const DEFAULT_MAX_RERUNS = 10;
 export const DEFAULT_MAX_TRIGGER_DEPTH = 3;
@@ -41,6 +42,8 @@ export interface SchedulerContext {
   events?: SchedulerEventBus;
   /** Optional call store for updating al-call lifecycle status. */
   callStore?: CallStore;
+  /** Optional status tracker — used to check pause state. */
+  statusTracker?: StatusTracker;
 }
 
 // Prompt helpers: when images have baked-in static files, only pass the dynamic suffix.
@@ -125,6 +128,7 @@ export function dispatchTriggers(
 /** Drain all agents' work queues — fires runs without blocking. */
 export async function drainQueues(ctx: SchedulerContext): Promise<void> {
   if (ctx.shuttingDown) return;
+  if (ctx.statusTracker?.isPaused()) return;
   for (const agentConfig of ctx.agentConfigs) {
     const pool = ctx.runnerPools[agentConfig.name];
     if (!pool || ctx.workQueue.size(agentConfig.name) === 0) continue;

--- a/src/scheduler/index.ts
+++ b/src/scheduler/index.ts
@@ -185,6 +185,7 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
         logger.info("Scheduler resumed via control API");
       },
       triggerAgent: async (name: string) => {
+        if (statusTracker?.isPaused()) return false;
         const pool = runnerPools[name];
         if (!pool) return false;
         const runner = pool.getAvailableRunner();
@@ -345,11 +346,14 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
   await workQueue.init();
   const skills: PromptSkills = { locking: true };
   const callStore = gateway?.callStore;
-  const schedulerCtx: SchedulerContext = { runnerPools, agentConfigs, maxReruns, maxTriggerDepth, logger, workQueue, shuttingDown: false, skills, useBakedImages: true, events, callStore };
+  const schedulerCtx: SchedulerContext = { runnerPools, agentConfigs, maxReruns, maxTriggerDepth, logger, workQueue, shuttingDown: false, skills, useBakedImages: true, events, callStore, statusTracker };
 
   // Wire up the call dispatcher so al-call works from inside containers
   if (gateway) {
     gateway.setCallDispatcher((entry) => {
+      if (statusTracker?.isPaused()) {
+        return { ok: false, reason: "scheduler is paused" };
+      }
       if (entry.callerAgent === entry.targetAgent) {
         return { ok: false, reason: "agent cannot call itself" };
       }
@@ -418,6 +422,10 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
           filter,
           trigger: (context: WebhookContext) => {
             if (statusTracker && !statusTracker.isAgentEnabled(agentConfig.name)) return false;
+            if (statusTracker?.isPaused()) {
+              logger.info({ agent: agentConfig.name, event: context.event }, "scheduler paused, webhook rejected");
+              return false;
+            }
 
             const runner = pool.getAvailableRunner();
             if (!runner) {
@@ -449,6 +457,11 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
     const pool = runnerPools[agentConfig.name];
 
     const job = new Cron(agentConfig.schedule, { timezone }, async () => {
+      // Skip if scheduler is paused
+      if (statusTracker?.isPaused()) {
+        logger.info({ agent: agentConfig.name }, "scheduler paused, skipping scheduled run");
+        return;
+      }
       // Skip if agent is disabled
       if (statusTracker && !statusTracker.isAgentEnabled(agentConfig.name)) {
         logger.info({ agent: agentConfig.name }, "agent is disabled, skipping scheduled run");

--- a/test/scheduler/execution.test.ts
+++ b/test/scheduler/execution.test.ts
@@ -231,6 +231,23 @@ describe("drainQueues", () => {
     expect(runner.run).not.toHaveBeenCalled();
   });
 
+  it("stops when scheduler is paused", async () => {
+    const runner = makeRunner({ instanceId: "a" });
+    const ctx = makeCtx({
+      agentConfigs: [makeAgentConfig("a")],
+      runnerPools: { a: new RunnerPool([runner]) },
+      statusTracker: { isPaused: () => true } as any,
+    });
+    ctx.workQueue.enqueue("a", {
+      type: "webhook",
+      context: { event: "push", action: "", payload: {}, headers: {}, source: "github" } as any,
+    });
+
+    await drainQueues(ctx);
+
+    expect(runner.run).not.toHaveBeenCalled();
+  });
+
   it("stops when shuttingDown is true", async () => {
     const runner = makeRunner({ instanceId: "a" });
     const ctx = makeCtx({

--- a/test/scheduler/index.test.ts
+++ b/test/scheduler/index.test.ts
@@ -74,10 +74,14 @@ vi.mock("../../src/agents/container-runner.js", () => ({
 
 // Mock croner — capture the callbacks
 const mockCronStop = vi.fn();
+const mockCronPause = vi.fn();
+const mockCronResume = vi.fn();
 const cronCallbacks: Function[] = [];
 vi.mock("croner", () => ({
   Cron: class {
     stop = mockCronStop;
+    pause = mockCronPause;
+    resume = mockCronResume;
     nextRun = () => new Date(Date.now() + 300000);
     constructor(_schedule: string, _opts: any, callback: Function) {
       cronCallbacks.push(callback);
@@ -394,6 +398,57 @@ describe("startScheduler", () => {
       // Should not throw — scale=0 skips schedule/webhook validation
       const { runnerPools } = await startScheduler(tmpDir);
       expect(runnerPools["disabled-agent"].size).toBe(0);
+    });
+  });
+
+  describe("scheduler pause", () => {
+    function makeStatusTracker(paused: boolean) {
+      return {
+        isPaused: vi.fn().mockReturnValue(paused),
+        isAgentEnabled: vi.fn().mockReturnValue(true),
+        registerAgent: vi.fn(),
+        setPaused: vi.fn(),
+        setNextRunAt: vi.fn(),
+        on: vi.fn(),
+        enableAgent: vi.fn(),
+        disableAgent: vi.fn(),
+      } as any;
+    }
+
+    it("cron callback does not run agent when paused", async () => {
+      const tracker = makeStatusTracker(true);
+      await startScheduler(tmpDir, undefined, tracker);
+      vi.clearAllMocks();
+
+      await cronCallbacks[0]();
+
+      expect(mockRun).not.toHaveBeenCalled();
+    });
+
+    it("cron callback does not queue work when paused", async () => {
+      const tracker = makeStatusTracker(true);
+      mockIsRunning = true;
+      await startScheduler(tmpDir, undefined, tracker);
+      vi.clearAllMocks();
+
+      await cronCallbacks[0]();
+
+      // No run, no "queued" log — work is rejected
+      expect(mockRun).not.toHaveBeenCalled();
+      expect(mockLoggerInfo).not.toHaveBeenCalledWith(
+        expect.objectContaining({ agent: "dev" }),
+        "all runners busy, scheduled run queued"
+      );
+    });
+
+    it("cron callback runs agent when not paused", async () => {
+      const tracker = makeStatusTracker(false);
+      await startScheduler(tmpDir, undefined, tracker);
+      vi.clearAllMocks();
+
+      await cronCallbacks[0]();
+
+      expect(mockRun).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Summary

- When the scheduler is paused, webhooks now return `false` (rejected) instead of queuing work
- Cron jobs skip without queuing when paused
- Manual trigger via control API returns `false` when paused
- Inter-agent call dispatcher rejects with `"scheduler is paused"` when paused
- `drainQueues` short-circuits early when paused so previously-queued items are not processed

## How it works

Added `statusTracker` to `SchedulerContext` so `drainQueues` (in `execution.ts`) can check the pause state. All four trigger entry points check `statusTracker?.isPaused()` and reject without queuing.

## Tests

- `drainQueues` stops when paused (execution.test.ts)
- Cron callback doesn't run or queue when paused (index.test.ts)
- Cron callback runs normally when not paused (index.test.ts)

Closes #162