### PR TITLE
feat: single-agent push with hot-reload (`al push <agent>`)

### DIFF
--- a/.changeset/push-single-agent.md
+++ b/.changeset/push-single-agent.md
@@ -1,0 +1,8 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Added single-agent push support: `al push <agent>` syncs only that agent's
+files to the remote server. The running scheduler's file watcher detects the
+change and hot-reloads the agent without restarting the service or disrupting
+other agents. Closes #169.

--- a/src/cli/commands/push.ts
+++ b/src/cli/commands/push.ts
@@ -3,10 +3,11 @@ import { loadGlobalConfig, discoverAgents } from "../../shared/config.js";
 import { resolveEnvironmentName, loadEnvironmentConfig } from "../../shared/environment.js";
 import { validateServerConfig } from "../../shared/server.js";
 import { ConfigError } from "../../shared/errors.js";
-import { pushToServer } from "../../remote/push.js";
+import { pushToServer, pushAgentToServer } from "../../remote/push.js";
 
 export async function execute(opts: {
   project: string;
+  agent?: string;
   env?: string;
   dryRun?: boolean;
   noCreds?: boolean;
@@ -43,13 +44,36 @@ export async function execute(opts: {
     throw new ConfigError("No agents found. Create agents first, then re-run al push.");
   }
 
-  // Run doctor in checkOnly mode to validate full config before pushing
-  const { execute: doctorExecute } = await import("./doctor.js");
-  await doctorExecute({ project: projectPath, env: envName, checkOnly: true, silent: true });
+  // Validate the named agent exists
+  if (opts.agent && !agents.includes(opts.agent)) {
+    throw new ConfigError(
+      `Agent "${opts.agent}" not found. Available agents: ${agents.join(", ")}`
+    );
+  }
 
   // Determine what to sync
   const syncCreds = opts.credsOnly || opts.all || (!opts.filesOnly);
   const syncFiles = opts.filesOnly || opts.all || (!opts.credsOnly);
+
+  // Single-agent push — lightweight path (no restart, hot-reloaded)
+  if (opts.agent) {
+    console.log(`\n=== Push ${opts.agent} to ${serverConfig.host} (env: ${envName}) ===`);
+
+    await pushAgentToServer({
+      projectPath,
+      serverConfig,
+      globalConfig,
+      agentName: opts.agent,
+      dryRun: opts.dryRun,
+      noCreds: !syncCreds,
+      noFiles: !syncFiles,
+    });
+    return;
+  }
+
+  // Full push — run doctor in checkOnly mode to validate full config before pushing
+  const { execute: doctorExecute } = await import("./doctor.js");
+  await doctorExecute({ project: projectPath, env: envName, checkOnly: true, silent: true });
 
   console.log(`\n=== Push to ${serverConfig.host} (env: ${envName}) ===`);
   console.log(`Agents: ${agents.join(", ")}`);

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -177,6 +177,7 @@ program
 program
   .command("push")
   .description("Deploy project to a self-hosted server via SSH")
+  .argument("[agent]", "agent name — push only this agent (hot-reloaded, no restart)")
   .option("-p, --project <dir>", "project directory", ".")
   .option("-E, --env <name>", "use named environment with [server] config")
   .option("--dry-run", "show what would be synced without making changes")
@@ -185,9 +186,9 @@ program
   .option("--files-only", "sync only project files (skip credentials)")
   .option("-a, --all", "sync project files, credentials, and restart service")
   .option("--force-install", "force npm install even if dependencies appear unchanged")
-  .action(withCommand(async (opts) => {
+  .action(withCommand(async (agent: string | undefined, opts) => {
     const { execute } = await import("./commands/push.js");
-    await execute(opts);
+    await execute({ ...opts, agent });
   }));
 
 // --- Environment management ---

--- a/src/remote/push.ts
+++ b/src/remote/push.ts
@@ -23,6 +23,16 @@ export interface PushOptions {
   forceInstall?: boolean;
 }
 
+export interface PushAgentOptions {
+  projectPath: string;
+  serverConfig: ServerConfig;
+  globalConfig: GlobalConfig;
+  agentName: string;
+  dryRun?: boolean;
+  noCreds?: boolean;
+  noFiles?: boolean;
+}
+
 /**
  * Compute a SHA-256 hash of package.json + package-lock.json contents.
  * Used to skip `npm install` when dependencies haven't changed.
@@ -99,6 +109,59 @@ export async function pushToServer(opts: PushOptions): Promise<void> {
       projectPath, serverConfig, globalConfig, dryRun, noCreds, noFiles, forceInstall,
       basePath, gatewayPort, projectName,
     });
+  } finally {
+    try { unlinkSync(controlPath); } catch {}
+  }
+}
+
+/**
+ * Push a single agent's files to the server. The running scheduler's file
+ * watcher detects the change and hot-reloads the agent — no service restart.
+ */
+export async function pushAgentToServer(opts: PushAgentOptions): Promise<void> {
+  const { projectPath, serverConfig, agentName, dryRun, noCreds, noFiles } = opts;
+  const ssh = sshOptionsFromConfig(serverConfig);
+  const basePath = serverConfig.basePath ?? "/opt/action-llama";
+
+  // Set up SSH ControlMaster for connection multiplexing
+  const hostHash = createHash("sha256").update(ssh.host).digest("hex").slice(0, 8);
+  const controlPath = `/tmp/al-ssh-${hostHash}-${process.pid}`;
+  ssh.controlPath = controlPath;
+
+  try {
+    const syncItems: string[] = [];
+    if (!noFiles) syncItems.push("agent files");
+    if (!noCreds) syncItems.push("credentials");
+
+    if (syncItems.length > 0) {
+      console.log(`\nSyncing ${syncItems.join(" and ")}...`);
+
+      if (!dryRun) {
+        await sshExec(ssh, `mkdir -p ${basePath}/project/agents/${agentName} ${basePath}/credentials`);
+      }
+
+      const rsyncFlags = dryRun ? ["--dry-run", "-v"] : [];
+      const tasks: Promise<void>[] = [];
+
+      if (!noFiles) {
+        const agentLocalPath = resolve(projectPath, "agents", agentName);
+        const agentRemotePath = `${basePath}/project/agents/${agentName}`;
+        tasks.push(rsyncTo(ssh, agentLocalPath, agentRemotePath, undefined, rsyncFlags));
+      }
+      if (!noCreds) {
+        tasks.push(rsyncTo(ssh, CREDENTIALS_DIR, `${basePath}/credentials`, undefined, rsyncFlags));
+      }
+
+      await Promise.all(tasks);
+      console.log(dryRun ? "  (dry-run) No changes made." : "  Done.");
+    }
+
+    if (dryRun) {
+      console.log("\nDry run complete — no changes were made.");
+      return;
+    }
+
+    console.log(`\nAgent "${agentName}" pushed — the scheduler will hot-reload it.`);
   } finally {
     try { unlinkSync(controlPath); } catch {}
   }

--- a/test/cli/commands/push.test.ts
+++ b/test/cli/commands/push.test.ts
@@ -29,8 +29,10 @@ vi.mock("../../../src/cli/commands/doctor.js", () => ({
 }));
 
 const mockPushToServer = vi.fn();
+const mockPushAgentToServer = vi.fn();
 vi.mock("../../../src/remote/push.js", () => ({
   pushToServer: (...args: any[]) => mockPushToServer(...args),
+  pushAgentToServer: (...args: any[]) => mockPushAgentToServer(...args),
 }));
 
 import { execute } from "../../../src/cli/commands/push.js";
@@ -42,6 +44,7 @@ describe("push command", () => {
     mockLoadGlobalConfig.mockReturnValue({});
     mockDoctorExecute.mockResolvedValue(undefined);
     mockPushToServer.mockResolvedValue(undefined);
+    mockPushAgentToServer.mockResolvedValue(undefined);
   });
 
   it("throws when no environment is specified", async () => {
@@ -144,5 +147,58 @@ describe("push command", () => {
 
     expect(mockPushToServer.mock.calls[0][0].noCreds).toBe(false);
     expect(mockPushToServer.mock.calls[0][0].noFiles).toBe(false);
+  });
+
+  // --- Single-agent push ---
+
+  it("throws when named agent does not exist", async () => {
+    mockResolveEnvironmentName.mockReturnValue("srv");
+    mockLoadEnvironmentConfig.mockReturnValue({ server: { host: "h" } });
+    mockDiscoverAgents.mockReturnValue(["dev"]);
+
+    await expect(
+      captureLog(() => execute({ project: ".", env: "srv", agent: "ghost" }))
+    ).rejects.toThrow('Agent "ghost" not found');
+  });
+
+  it("delegates to pushAgentToServer for single-agent push", async () => {
+    mockResolveEnvironmentName.mockReturnValue("srv");
+    mockLoadEnvironmentConfig.mockReturnValue({ server: { host: "h" } });
+    mockDiscoverAgents.mockReturnValue(["dev"]);
+
+    await captureLog(() => execute({ project: ".", env: "srv", agent: "dev" }));
+
+    expect(mockPushAgentToServer).toHaveBeenCalledOnce();
+    expect(mockPushAgentToServer.mock.calls[0][0]).toMatchObject({
+      agentName: "dev",
+      serverConfig: { host: "h" },
+    });
+    // Full push should NOT be called
+    expect(mockPushToServer).not.toHaveBeenCalled();
+  });
+
+  it("skips doctor for single-agent push", async () => {
+    mockResolveEnvironmentName.mockReturnValue("srv");
+    mockLoadEnvironmentConfig.mockReturnValue({ server: { host: "h" } });
+    mockDiscoverAgents.mockReturnValue(["dev"]);
+
+    await captureLog(() => execute({ project: ".", env: "srv", agent: "dev" }));
+
+    expect(mockDoctorExecute).not.toHaveBeenCalled();
+  });
+
+  it("passes sync flags through for single-agent push", async () => {
+    mockResolveEnvironmentName.mockReturnValue("srv");
+    mockLoadEnvironmentConfig.mockReturnValue({ server: { host: "h" } });
+    mockDiscoverAgents.mockReturnValue(["dev"]);
+
+    await captureLog(() => execute({ project: ".", env: "srv", agent: "dev", filesOnly: true, dryRun: true }));
+
+    expect(mockPushAgentToServer.mock.calls[0][0]).toMatchObject({
+      agentName: "dev",
+      noCreds: true,
+      noFiles: false,
+      dryRun: true,
+    });
   });
 });

--- a/test/remote/push.test.ts
+++ b/test/remote/push.test.ts
@@ -36,7 +36,7 @@ vi.mock("fs", async (importOriginal) => {
   };
 });
 
-import { buildSystemdUnit, pushToServer, computePkgHash } from "../../src/remote/push.js";
+import { buildSystemdUnit, pushToServer, pushAgentToServer, computePkgHash } from "../../src/remote/push.js";
 
 describe("buildSystemdUnit", () => {
   it("generates a valid systemd unit", () => {
@@ -444,5 +444,179 @@ describe("pushToServer", () => {
     // The SSH options object passed to bootstrapServer should have controlPath
     const sshArg = mockBootstrapServer.mock.calls[0][0];
     expect(sshArg.controlPath).toMatch(/^\/tmp\/al-ssh-/);
+  });
+});
+
+describe("pushAgentToServer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSshOptionsFromConfig.mockReturnValue({ host: "h", user: "root", port: 22 });
+    mockSshExec.mockResolvedValue("");
+    mockRsyncTo.mockResolvedValue(undefined);
+    mockUnlinkSync.mockReturnValue(undefined);
+  });
+
+  it("rsyncs only the agent directory", async () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: any[]) => logs.push(args.join(" "));
+    try {
+      await pushAgentToServer({
+        projectPath: "/tmp/project",
+        serverConfig: { host: "h" },
+        globalConfig: {},
+        agentName: "my-agent",
+      });
+    } finally {
+      console.log = origLog;
+    }
+
+    // Should rsync agent directory + credentials (2 calls)
+    expect(mockRsyncTo).toHaveBeenCalledTimes(2);
+    // First call: agent files
+    expect(mockRsyncTo.mock.calls[0][1]).toBe("/tmp/project/agents/my-agent");
+    expect(mockRsyncTo.mock.calls[0][2]).toContain("agents/my-agent");
+  });
+
+  it("skips bootstrap and systemd (no restart)", async () => {
+    const origLog = console.log;
+    console.log = () => {};
+    try {
+      await pushAgentToServer({
+        projectPath: "/tmp/project",
+        serverConfig: { host: "h" },
+        globalConfig: {},
+        agentName: "my-agent",
+      });
+    } finally {
+      console.log = origLog;
+    }
+
+    // No bootstrap
+    expect(mockBootstrapServer).not.toHaveBeenCalled();
+    // No systemd restart
+    const sshCommands = mockSshExec.mock.calls.map((c: any[]) => c[1]);
+    expect(sshCommands.some((cmd: string) => cmd.includes("systemctl restart"))).toBe(false);
+    expect(sshCommands.some((cmd: string) => cmd.includes("daemon-reload"))).toBe(false);
+    expect(sshCommands.some((cmd: string) => cmd.includes("npm install"))).toBe(false);
+  });
+
+  it("skips credential sync with noCreds", async () => {
+    const origLog = console.log;
+    console.log = () => {};
+    try {
+      await pushAgentToServer({
+        projectPath: "/tmp/project",
+        serverConfig: { host: "h" },
+        globalConfig: {},
+        agentName: "my-agent",
+        noCreds: true,
+      });
+    } finally {
+      console.log = origLog;
+    }
+
+    // Only 1 rsync call (agent files), not 2
+    expect(mockRsyncTo).toHaveBeenCalledTimes(1);
+    expect(mockRsyncTo.mock.calls[0][1]).toBe("/tmp/project/agents/my-agent");
+  });
+
+  it("skips file sync with noFiles", async () => {
+    const origLog = console.log;
+    console.log = () => {};
+    try {
+      await pushAgentToServer({
+        projectPath: "/tmp/project",
+        serverConfig: { host: "h" },
+        globalConfig: {},
+        agentName: "my-agent",
+        noFiles: true,
+      });
+    } finally {
+      console.log = origLog;
+    }
+
+    // Only 1 rsync call (credentials), not 2
+    expect(mockRsyncTo).toHaveBeenCalledTimes(1);
+    expect(mockRsyncTo.mock.calls[0][2]).toContain("credentials");
+  });
+
+  it("supports dry-run mode", async () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: any[]) => logs.push(args.join(" "));
+    try {
+      await pushAgentToServer({
+        projectPath: "/tmp/project",
+        serverConfig: { host: "h" },
+        globalConfig: {},
+        agentName: "my-agent",
+        dryRun: true,
+      });
+    } finally {
+      console.log = origLog;
+    }
+
+    expect(logs.some((l) => l.includes("Dry run complete"))).toBe(true);
+    for (const call of mockRsyncTo.mock.calls) {
+      const extraFlags = call[4] || [];
+      expect(extraFlags).toContain("--dry-run");
+    }
+  });
+
+  it("creates remote agent directory before rsync", async () => {
+    const origLog = console.log;
+    console.log = () => {};
+    try {
+      await pushAgentToServer({
+        projectPath: "/tmp/project",
+        serverConfig: { host: "h" },
+        globalConfig: {},
+        agentName: "my-agent",
+      });
+    } finally {
+      console.log = origLog;
+    }
+
+    const mkdirCall = mockSshExec.mock.calls.find(
+      (c: any[]) => typeof c[1] === "string" && c[1].includes("mkdir -p") && c[1].includes("agents/my-agent"),
+    );
+    expect(mkdirCall).toBeDefined();
+  });
+
+  it("cleans up ControlMaster socket", async () => {
+    const origLog = console.log;
+    console.log = () => {};
+    try {
+      await pushAgentToServer({
+        projectPath: "/tmp/project",
+        serverConfig: { host: "h" },
+        globalConfig: {},
+        agentName: "my-agent",
+      });
+    } finally {
+      console.log = origLog;
+    }
+
+    expect(mockUnlinkSync).toHaveBeenCalled();
+    expect(mockUnlinkSync.mock.calls[0][0]).toMatch(/^\/tmp\/al-ssh-/);
+  });
+
+  it("prints hot-reload message on success", async () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: any[]) => logs.push(args.join(" "));
+    try {
+      await pushAgentToServer({
+        projectPath: "/tmp/project",
+        serverConfig: { host: "h" },
+        globalConfig: {},
+        agentName: "my-agent",
+      });
+    } finally {
+      console.log = origLog;
+    }
+
+    expect(logs.some((l) => l.includes("hot-reload"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Adds optional `[agent]` argument to `al push` — when specified, only that agent's directory is rsynced to the remote server
- The running scheduler's file watcher detects the change and hot-reloads the agent automatically, without restarting the service or disrupting other agents
- Skips heavy full-push steps (bootstrap, npm install, systemd reconfiguration, service restart) for fast iteration

## Usage
```bash
# Push a single agent (fast, no restart)
al push my-agent --env prod

# Full project push (existing behavior, unchanged)
al push --env prod
```

Closes #169

## Test plan
- [x] New unit tests for `pushAgentToServer` (8 tests): rsync targeting, no-restart, dry-run, credential sync flags, socket cleanup
- [x] New CLI command tests (4 tests): agent validation, delegation to agent push, doctor skip, flag passthrough
- [x] All 1162 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)