### PR TITLE
feat: allow multiple resource locks with deadlock detection

### DIFF
--- a/.changeset/multi-locks-deadlock.md
+++ b/.changeset/multi-locks-deadlock.md
@@ -1,0 +1,9 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Allow agents to hold multiple resource locks simultaneously and detect deadlock cycles.
+The previous one-lock-per-holder restriction has been removed. When the scheduler detects
+a cycle in the wait-for graph (e.g. agent A holds X and wants Y while agent B holds Y
+and wants X), `rlock` returns a `possible deadlock` error with the cycle path, allowing
+agents to release locks and back off without being killed. Closes #158.

--- a/agent-docs/AGENTS.md
+++ b/agent-docs/AGENTS.md
@@ -524,7 +524,7 @@ All gateway-calling shell commands (`rlock`, `runlock`, `rlock-heartbeat`, `al-c
 | Exit | Meaning | HTTP | When |
 |------|---------|------|------|
 | 0 | Success | 200 | Operation completed |
-| 1 | Conflict | 409 | Resource held by another, dispatch rejected |
+| 1 | Conflict | 409 | Resource held by another, deadlock detected, or dispatch rejected |
 | 2 | Not found | 404 | Resource or call doesn't exist |
 | 3 | Auth error | 403 | Invalid or expired secret |
 | 4 | Bad request | 400 | Server rejected the request (malformed payload) |

--- a/agent-docs/skills/resource-locks.md
+++ b/agent-docs/skills/resource-locks.md
@@ -17,7 +17,7 @@ rlock "github issue acme/app#42"
 **Responses:**
 - Acquired: `{"ok":true}` (exit 0)
 - Conflict: `{"ok":false,"holder":"<other-agent>","heldSince":...}` (exit 1) — another instance has it. Skip this resource.
-- Already holding another lock: `{"ok":false,"reason":"already holding lock on ..."}` (exit 1) — release your current lock first.
+- Possible deadlock: `{"ok":false,"reason":"possible deadlock: ...","deadlock":true,"cycle":[...]}` (exit 1) — a deadlock cycle was detected. Release your locks and back off. See [Deadlock detection](#deadlock-detection).
 
 **Exit codes:** 0=acquired, 1=conflict, 3=auth error, 9=missing arg, 6=unreachable, 7=unexpected — see [exit code table](../AGENTS.md#shell-command-exit-codes)
 
@@ -57,13 +57,50 @@ Use descriptive, unique keys that identify the exact resource:
 
 ## Rules
 
-- **One lock at a time.** You can hold at most one lock. `runlock` before acquiring a different resource.
 - **Always `rlock` before starting work** on a shared resource (issues, PRs, deployments).
 - **Always `runlock` when done.** Locks are auto-released when your container exits, but explicit unlock is cleaner.
 - **If `rlock` exits non-zero (or returns `{"ok":false,...}`), skip that resource.** Do not wait, retry, or proceed without the lock — move on to the next item.
+- **If `rlock` returns `deadlock: true`, release your locks and back off.** See [Deadlock detection](#deadlock-detection) below.
 - **Use `rlock-heartbeat` during long operations** to keep the lock alive. Each heartbeat resets the TTL.
 - **Locks expire after 30 minutes** by default (configurable via `gateway.lockTimeout` in `config.toml`). If you don't heartbeat and the lock expires, another instance can claim it.
 - When `GATEWAY_URL` is not set (single-instance mode), lock commands return `{"ok":true}` as a no-op (exit 0). When `GATEWAY_URL` is set but the gateway is unreachable, lock commands exit 6 — you must not proceed.
+
+## Multiple locks
+
+You can hold multiple locks simultaneously. This is useful when your workflow requires coordinating across several resources:
+
+```
+rlock "github issue acme/app#42"
+rlock "deploy api-prod"
+# ... work that needs both the issue and the deployment slot ...
+runlock "deploy api-prod"
+runlock "github issue acme/app#42"
+```
+
+Release each lock as soon as you no longer need it. Holding locks longer than necessary increases the chance of contention and deadlocks.
+
+## Deadlock detection
+
+When multiple agents each hold a lock the other needs, a **deadlock** can occur. The scheduler detects these cycles automatically.
+
+**Example:**
+- Agent A holds lock on `issue #1`, tries to acquire `issue #2` (held by Agent B)
+- Agent B holds lock on `issue #2`, tries to acquire `issue #1` (held by Agent A)
+- Neither can proceed — deadlock
+
+When a cycle is detected, `rlock` returns exit 1 with:
+
+```json
+{"ok":false,"reason":"possible deadlock: agent-a → issue #2 → agent-b → issue #1 → agent-a","deadlock":true,"cycle":["agent-a","issue #2","agent-b","issue #1"]}
+```
+
+**What to do when you see `deadlock: true`:**
+
+1. Release one or more of your currently held locks (`runlock`)
+2. Move on to other work, or wait briefly before retrying
+3. The other agent(s) will be able to proceed once you release
+
+The `cycle` array describes the chain: `[holderA, resourceX, holderB, resourceY, ...]`. Check the JSON output for the `deadlock` field to distinguish deadlocks from regular contention.
 
 ## Example workflow
 
@@ -71,6 +108,7 @@ Use descriptive, unique keys that identify the exact resource:
 1. List open issues labeled "agent"
 2. For each issue:
    - rlock "github issue acme/app#42"
+   - If ok is false and deadlock is true, runlock any held locks and retry later
    - If ok is false, skip — another instance is handling it
    - Clone, branch, implement, push, open PR
    - runlock "github issue acme/app#42"

--- a/src/gateway/lock-store.ts
+++ b/src/gateway/lock-store.ts
@@ -12,6 +12,8 @@ export interface AcquireResult {
   holder?: string;
   heldSince?: number;
   reason?: string;
+  deadlock?: boolean;
+  cycle?: string[];
 }
 
 export interface ReleaseResult {
@@ -30,7 +32,8 @@ const NS_HOLDERS = "lock-holders";
 
 export class LockStore {
   private locks = new Map<string, LockEntry>();
-  private holderLocks = new Map<string, string>(); // holder -> resourceKey
+  private holderLocks = new Map<string, Set<string>>(); // holder -> resourceKeys
+  private waitingFor = new Map<string, string>(); // holder -> resourceKey they failed to acquire
   private sweepTimer: ReturnType<typeof setInterval> | undefined;
   private defaultTTL: number;
   private store?: StateStore;
@@ -50,7 +53,7 @@ export class LockStore {
     for (const { value } of entries) {
       if (now < value.expiresAt) {
         this.locks.set(value.resourceKey, value);
-        this.holderLocks.set(value.holder, value.resourceKey);
+        this.addHolderLock(value.holder, value.resourceKey);
       }
     }
   }
@@ -58,39 +61,38 @@ export class LockStore {
   acquire(resourceKey: string, holder: string, ttlSeconds?: number): AcquireResult {
     const existing = this.locks.get(resourceKey);
 
-    // Check if this holder already holds a different lock
-    const existingHolderKey = this.holderLocks.get(holder);
-    if (existingHolderKey && existingHolderKey !== resourceKey) {
-      const existingHolderLock = this.locks.get(existingHolderKey);
-      if (existingHolderLock && Date.now() < existingHolderLock.expiresAt) {
-        return {
-          ok: false,
-          reason: `already holding lock on ${existingHolderLock.resourceKey} — release it first`,
-        };
-      }
-      // Expired — clean up
-      this.locks.delete(existingHolderKey);
-      this.holderLocks.delete(holder);
-      this.persistDelete(existingHolderKey, holder);
-    }
-
     if (existing) {
       if (Date.now() >= existing.expiresAt) {
         // Expired — evict
-        this.holderLocks.delete(existing.holder);
+        this.removeHolderLock(existing.holder, resourceKey);
         this.locks.delete(resourceKey);
         this.persistDelete(resourceKey, existing.holder);
       } else if (existing.holder !== holder) {
+        // Resource held by another — check for deadlock cycle
+        const cycle = this.detectCycle(holder, resourceKey);
+        if (cycle) {
+          this.waitingFor.set(holder, resourceKey);
+          return {
+            ok: false,
+            reason: `possible deadlock: ${[...cycle, cycle[0]].join(" \u2192 ")}`,
+            deadlock: true,
+            cycle,
+          };
+        }
+        this.waitingFor.set(holder, resourceKey);
         return { ok: false, holder: existing.holder, heldSince: existing.heldSince };
       }
       // Same holder re-acquiring — refresh below
     }
 
+    // Acquired — clear waiting state
+    this.waitingFor.delete(holder);
+
     const now = Date.now();
     const ttl = ttlSeconds ? ttlSeconds * 1000 : this.defaultTTL;
     const entry: LockEntry = { resourceKey, holder, heldSince: now, expiresAt: now + ttl };
     this.locks.set(resourceKey, entry);
-    this.holderLocks.set(holder, resourceKey);
+    this.addHolderLock(holder, resourceKey);
     this.persistSet(entry);
     return { ok: true };
   }
@@ -100,7 +102,7 @@ export class LockStore {
 
     if (!existing || Date.now() >= existing.expiresAt) {
       this.locks.delete(resourceKey);
-      if (this.holderLocks.get(holder) === resourceKey) this.holderLocks.delete(holder);
+      this.removeHolderLock(holder, resourceKey);
       this.persistDelete(resourceKey, holder);
       return { ok: false, reason: "lock not found" };
     }
@@ -110,7 +112,7 @@ export class LockStore {
     }
 
     this.locks.delete(resourceKey);
-    this.holderLocks.delete(holder);
+    this.removeHolderLock(holder, resourceKey);
     this.persistDelete(resourceKey, holder);
     return { ok: true };
   }
@@ -135,14 +137,17 @@ export class LockStore {
 
   releaseAll(holder: string): number {
     let count = 0;
-    for (const [rk, entry] of this.locks) {
-      if (entry.holder === holder) {
+    const holderKeys = this.holderLocks.get(holder);
+    if (holderKeys) {
+      for (const rk of holderKeys) {
         this.locks.delete(rk);
-        this.persistDelete(rk, holder);
+        this.store?.delete(NS_LOCKS, rk).catch(() => {});
         count++;
       }
     }
     this.holderLocks.delete(holder);
+    this.waitingFor.delete(holder);
+    this.store?.delete(NS_HOLDERS, holder).catch(() => {});
     return count;
   }
 
@@ -157,13 +162,70 @@ export class LockStore {
     return result;
   }
 
+  /**
+   * Detect a deadlock cycle if `holder` tries to acquire `targetResource`.
+   *
+   * Follows the wait-for graph: holder wants targetResource (held by B),
+   * B is waiting for something (held by C), ... until we reach holder again
+   * (cycle) or a dead end (no cycle).
+   *
+   * Returns the cycle path as alternating [holder, resource, holder, resource, ...]
+   * or null if no cycle exists.
+   */
+  private detectCycle(holder: string, targetResource: string): string[] | null {
+    const visited = new Set<string>([holder]);
+    const path: string[] = [holder, targetResource];
+    let currentResource = targetResource;
+
+    for (;;) {
+      const lock = this.locks.get(currentResource);
+      if (!lock || Date.now() >= lock.expiresAt) return null;
+
+      const blocker = lock.holder;
+      if (blocker === holder) return path; // cycle back to the requesting holder
+
+      if (visited.has(blocker)) return null; // cycle doesn't involve the requesting holder
+      visited.add(blocker);
+      path.push(blocker);
+
+      const waitingResource = this.waitingFor.get(blocker);
+      if (!waitingResource) return null;
+
+      path.push(waitingResource);
+      currentResource = waitingResource;
+    }
+  }
+
+  private addHolderLock(holder: string, resourceKey: string): void {
+    let keys = this.holderLocks.get(holder);
+    if (!keys) {
+      keys = new Set();
+      this.holderLocks.set(holder, keys);
+    }
+    keys.add(resourceKey);
+  }
+
+  private removeHolderLock(holder: string, resourceKey: string): void {
+    const keys = this.holderLocks.get(holder);
+    if (keys) {
+      keys.delete(resourceKey);
+      if (keys.size === 0) this.holderLocks.delete(holder);
+    }
+  }
+
   private sweep(): void {
     const now = Date.now();
     for (const [rk, entry] of this.locks) {
       if (now >= entry.expiresAt) {
-        this.holderLocks.delete(entry.holder);
+        this.removeHolderLock(entry.holder, rk);
         this.locks.delete(rk);
         this.persistDelete(rk, entry.holder);
+      }
+    }
+    // Clean up stale waiting-for entries where the holder no longer holds locks
+    for (const [holder] of this.waitingFor) {
+      if (!this.holderLocks.has(holder)) {
+        this.waitingFor.delete(holder);
       }
     }
   }
@@ -171,12 +233,28 @@ export class LockStore {
   private persistSet(entry: LockEntry): void {
     const ttlSec = Math.max(1, Math.ceil((entry.expiresAt - Date.now()) / 1000));
     this.store?.set(NS_LOCKS, entry.resourceKey, entry, { ttl: ttlSec }).catch(() => {});
-    this.store?.set(NS_HOLDERS, entry.holder, entry.resourceKey, { ttl: ttlSec }).catch(() => {});
+    this.persistHolderIndex(entry.holder);
   }
 
   private persistDelete(resourceKey: string, holder: string): void {
     this.store?.delete(NS_LOCKS, resourceKey).catch(() => {});
-    this.store?.delete(NS_HOLDERS, holder).catch(() => {});
+    this.persistHolderIndex(holder);
+  }
+
+  private persistHolderIndex(holder: string): void {
+    const keys = this.holderLocks.get(holder);
+    if (!keys || keys.size === 0) {
+      this.store?.delete(NS_HOLDERS, holder).catch(() => {});
+      return;
+    }
+    // Use the max remaining TTL across all held locks
+    let maxExpiry = 0;
+    for (const rk of keys) {
+      const lock = this.locks.get(rk);
+      if (lock) maxExpiry = Math.max(maxExpiry, lock.expiresAt);
+    }
+    const ttlSec = Math.max(1, Math.ceil((maxExpiry - Date.now()) / 1000));
+    this.store?.set(NS_HOLDERS, holder, [...keys], { ttl: ttlSec }).catch(() => {});
   }
 
   dispose(): void {
@@ -186,5 +264,6 @@ export class LockStore {
     }
     this.locks.clear();
     this.holderLocks.clear();
+    this.waitingFor.clear();
   }
 }

--- a/src/gateway/routes/locks.ts
+++ b/src/gateway/routes/locks.ts
@@ -45,11 +45,17 @@ export function registerLockRoutes(
       return c.json({ ok: true, resourceKey });
     }
 
-    // Distinguish "already holding another lock" from "someone else holds this lock"
     if (result.reason) {
-      logger.debug({ agent: reg.agentName, resourceKey }, "lock rejected: " + result.reason);
+      if (result.deadlock) {
+        logger.warn({ agent: reg.agentName, resourceKey, cycle: result.cycle }, "possible deadlock");
+      } else {
+        logger.debug({ agent: reg.agentName, resourceKey }, "lock rejected: " + result.reason);
+      }
       events?.emit("lock", { agentName: reg.agentName, instanceId: reg.instanceId, resourceKey, action: "acquire", ok: false, status: 409, reason: result.reason });
-      return c.json({ ok: false, reason: result.reason }, 409);
+      return c.json(
+        { ok: false, reason: result.reason, ...(result.deadlock ? { deadlock: true, cycle: result.cycle } : {}) },
+        409
+      );
     }
 
     logger.debug(

--- a/test/gateway/command-exit-codes.test.ts
+++ b/test/gateway/command-exit-codes.test.ts
@@ -138,14 +138,13 @@ describe("command exit codes", () => {
       expect(body.holder).toBeTruthy();
     });
 
-    it("exit 1 — already holding another lock", async () => {
+    it("exit 0 — acquiring multiple locks succeeds", async () => {
       register("sec-a", "agent-a");
       await run("rlock", ["res-1"], env("sec-a"));
       const r = await run("rlock", ["res-2"], env("sec-a"));
-      expect(r.exitCode).toBe(1);
+      expect(r.exitCode).toBe(0);
       const body = JSON.parse(r.stdout);
-      expect(body.ok).toBe(false);
-      expect(body.reason).toMatch(/already holding/);
+      expect(body.ok).toBe(true);
     });
 
     it("exit 3 — invalid secret", async () => {

--- a/test/gateway/lock-store.test.ts
+++ b/test/gateway/lock-store.test.ts
@@ -120,12 +120,12 @@ describe("LockStore", () => {
       expect(result).toEqual({ ok: true });
     });
 
-    it("rejects when holder already holds a different lock", () => {
-      store.acquire("github issue acme/app#1", "agent-a");
-      const result = store.acquire("github issue acme/app#2", "agent-a");
-      expect(result.ok).toBe(false);
-      expect(result.reason).toContain("already holding lock");
-      expect(result.reason).toContain("acme/app#1");
+    it("allows holder to acquire multiple different locks", () => {
+      const r1 = store.acquire("github issue acme/app#1", "agent-a");
+      const r2 = store.acquire("github issue acme/app#2", "agent-a");
+      expect(r1).toEqual({ ok: true });
+      expect(r2).toEqual({ ok: true });
+      expect(store.list("agent-a")).toHaveLength(2);
     });
 
     it("allows acquiring a different lock after releasing the first", () => {
@@ -145,6 +145,89 @@ describe("LockStore", () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+  });
+
+  describe("deadlock detection", () => {
+    it("detects simple deadlock cycle (A holds X, B holds Y, B→X fails, A→Y)", () => {
+      store.acquire("res-X", "agent-a");
+      store.acquire("res-Y", "agent-b");
+
+      // B tries to acquire X (held by A) — fails, records B waiting for X
+      const bResult = store.acquire("res-X", "agent-b");
+      expect(bResult.ok).toBe(false);
+      expect(bResult.holder).toBe("agent-a");
+
+      // A tries to acquire Y (held by B) — detects cycle: A→Y→B→X→A
+      const aResult = store.acquire("res-Y", "agent-a");
+      expect(aResult.ok).toBe(false);
+      expect(aResult.deadlock).toBe(true);
+      expect(aResult.reason).toContain("possible deadlock");
+      expect(aResult.cycle).toBeDefined();
+      expect(aResult.cycle).toContain("agent-a");
+      expect(aResult.cycle).toContain("agent-b");
+    });
+
+    it("detects 3-way deadlock cycle (A→B→C→A)", () => {
+      store.acquire("res-X", "agent-a");
+      store.acquire("res-Y", "agent-b");
+      store.acquire("res-Z", "agent-c");
+
+      // B tries X (held by A) → fails
+      store.acquire("res-X", "agent-b");
+      // C tries Y (held by B) → fails
+      store.acquire("res-Y", "agent-c");
+      // A tries Z (held by C) → cycle: A→Z→C→Y→B→X→A
+      const result = store.acquire("res-Z", "agent-a");
+      expect(result.ok).toBe(false);
+      expect(result.deadlock).toBe(true);
+      expect(result.cycle).toContain("agent-a");
+      expect(result.cycle).toContain("agent-b");
+      expect(result.cycle).toContain("agent-c");
+    });
+
+    it("returns regular conflict when no cycle exists", () => {
+      store.acquire("res-X", "agent-a");
+      store.acquire("res-Y", "agent-b");
+
+      // A tries Y (held by B), but B is NOT waiting for anything → no cycle
+      const result = store.acquire("res-Y", "agent-a");
+      expect(result.ok).toBe(false);
+      expect(result.deadlock).toBeUndefined();
+      expect(result.holder).toBe("agent-b");
+    });
+
+    it("clears waiting state on successful acquire", () => {
+      store.acquire("res-X", "agent-a");
+      store.acquire("res-Y", "agent-b");
+
+      // B tries X → fails (B waiting for X)
+      store.acquire("res-X", "agent-b");
+
+      // A releases X, B acquires X → clears B's waiting state
+      store.release("res-X", "agent-a");
+      expect(store.acquire("res-X", "agent-b").ok).toBe(true);
+
+      // A acquires a new lock and tries Y (held by B) — B no longer waiting, no cycle
+      store.acquire("res-Z", "agent-a");
+      const result = store.acquire("res-Y", "agent-a");
+      expect(result.ok).toBe(false);
+      expect(result.deadlock).toBeUndefined();
+      expect(result.holder).toBe("agent-b");
+    });
+
+    it("includes the full cycle path in the result", () => {
+      store.acquire("res-X", "agent-a");
+      store.acquire("res-Y", "agent-b");
+
+      store.acquire("res-X", "agent-b"); // B waits for X
+      const result = store.acquire("res-Y", "agent-a"); // A→Y→B→X→A
+
+      expect(result.cycle).toEqual(["agent-a", "res-Y", "agent-b", "res-X"]);
+      expect(result.reason).toContain("agent-a");
+      expect(result.reason).toContain("agent-b");
+      expect(result.reason).toContain("res-X");
+      expect(result.reason).toContain("res-Y");
     });
   });
 
@@ -223,11 +306,13 @@ describe("LockStore", () => {
   });
 
   describe("releaseAll", () => {
-    it("releases the lock held by an agent", () => {
+    it("releases all locks held by an agent", () => {
       store.acquire("github issue acme/app#1", "agent-a");
+      store.acquire("github issue acme/app#2", "agent-a");
       const count = store.releaseAll("agent-a");
-      expect(count).toBe(1);
+      expect(count).toBe(2);
       expect(store.acquire("github issue acme/app#1", "agent-b").ok).toBe(true);
+      expect(store.acquire("github issue acme/app#2", "agent-c").ok).toBe(true);
     });
 
     it("does not release locks held by other agents", () => {
@@ -248,6 +333,21 @@ describe("LockStore", () => {
       store.releaseAll("agent-a");
       const result = store.acquire("github issue acme/app#2", "agent-a");
       expect(result).toEqual({ ok: true });
+    });
+
+    it("clears waiting state", () => {
+      store.acquire("res-X", "agent-a");
+      store.acquire("res-Y", "agent-b");
+      store.acquire("res-X", "agent-b"); // B waits for X
+
+      store.releaseAll("agent-b");
+
+      // B's waiting state is cleared, so no deadlock when A tries something
+      store.acquire("res-Y", "agent-b"); // B re-acquires Y
+      store.acquire("res-Z", "agent-a");
+      const result = store.acquire("res-Y", "agent-a");
+      expect(result.ok).toBe(false);
+      expect(result.deadlock).toBeUndefined();
     });
   });
 
@@ -287,6 +387,14 @@ describe("LockStore", () => {
       entry.holder = "tampered";
       const [fresh] = store.list();
       expect(fresh.holder).toBe("agent-a");
+    });
+
+    it("returns multiple locks for the same holder", () => {
+      store.acquire("res-1", "agent-a");
+      store.acquire("res-2", "agent-a");
+      store.acquire("res-3", "agent-a");
+      const locks = store.list("agent-a");
+      expect(locks).toHaveLength(3);
     });
   });
 
@@ -328,6 +436,26 @@ describe("LockStore — durable persistence", () => {
     const conflict = ls2.acquire("github issue acme/app#42", "agent-b");
     expect(conflict.ok).toBe(false);
     expect(conflict.holder).toBe("agent-a");
+
+    ls2.dispose();
+  });
+
+  it("hydrates multiple locks per holder from the backing store on init", async () => {
+    const stateStore = makeStore();
+
+    const ls1 = new LockStore(300, 9999, stateStore);
+    ls1.acquire("res-1", "agent-a");
+    ls1.acquire("res-2", "agent-a");
+    ls1.dispose();
+
+    const ls2 = new LockStore(300, 9999, stateStore);
+    await ls2.init();
+
+    const locks = ls2.list("agent-a");
+    expect(locks).toHaveLength(2);
+
+    expect(ls2.acquire("res-1", "agent-b").ok).toBe(false);
+    expect(ls2.acquire("res-2", "agent-b").ok).toBe(false);
 
     ls2.dispose();
   });

--- a/test/gateway/routes/locks.test.ts
+++ b/test/gateway/routes/locks.test.ts
@@ -69,13 +69,12 @@ describe("POST /locks/acquire", () => {
     expect(body.heldSince).toBeTypeOf("number");
   });
 
-  it("returns 409 when agent already holds a different lock", async () => {
+  it("allows agent to acquire multiple different locks", async () => {
     await acquire(app, { secret: "secret-a", resourceKey: "github issue acme/app#1" });
     const res = await acquire(app, { secret: "secret-a", resourceKey: "github issue acme/app#2" });
-    expect(res.status).toBe(409);
+    expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.ok).toBe(false);
-    expect(body.reason).toContain("already holding lock");
+    expect(body.ok).toBe(true);
   });
 
   it("returns 403 for invalid secret", async () => {


### PR DESCRIPTION
## Summary

- Removes the one-lock-per-holder restriction so agents can hold multiple resource locks simultaneously
- Adds a wait-for graph that tracks contested acquisitions and detects deadlock cycles
- When a cycle is detected, `rlock` returns a `possible deadlock` error (exit 1) with the full cycle path, allowing agents to release locks and back off on their own — no need to kill agents to resolve deadlocks

## How deadlock detection works

The lock store maintains a `waitingFor` map: when an acquire fails because the resource is held by another agent, that agent is recorded as "waiting for" that resource. On subsequent acquires, a DFS follows the chain (holder → resource → blocker → resource → ...) to detect cycles.

Example: agent-a holds X, agent-b holds Y, agent-b tries X (fails), then agent-a tries Y → cycle detected: `agent-a → Y → agent-b → X → agent-a`.

The response includes the cycle path so the agent can make an informed decision about which lock to release.

## Test plan

- [x] `npm run build` passes
- [x] All 1123 unit tests pass (82 test files)
- [ ] Integration tests (Docker-based, run in CI)

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)