### PR TITLE
fix: remove duplicate H1 headers from docs pages

### DIFF
--- a/.changeset/fix-duplicate-doc-headers.md
+++ b/.changeset/fix-duplicate-doc-headers.md
@@ -1,0 +1,8 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fixed duplicate page headers across all docs pages. Mintlify renders the
+frontmatter `title` as the page header automatically, but every MDX file also
+had an explicit `# H1` causing the title to appear twice. Also fixed `cloud.mdx`
+frontmatter title which was incorrectly set to "VPS Deployment".

--- a/docs/agent-config-reference.mdx
+++ b/docs/agent-config-reference.mdx
@@ -3,8 +3,6 @@ title: "agent-config.toml Reference"
 description: "Complete reference for agent configuration fields"
 ---
 
-# agent-config.toml Reference
-
 Each agent has an `agent-config.toml` file in its directory. The agent name is derived from the directory name and should not be included in the config.
 
 ## Full Annotated Example

--- a/docs/agents.mdx
+++ b/docs/agents.mdx
@@ -3,8 +3,6 @@ title: "Agents"
 description: "Agent structure, configuration, lifecycle, and container isolation"
 ---
 
-# Agents
-
 An agent is a directory inside your project that contains instructions and configuration for an autonomous LLM session. Each run is self-contained: the agent wakes up (on a schedule or webhook), executes its task, and shuts down.
 
 ## Structure

--- a/docs/cloud.mdx
+++ b/docs/cloud.mdx
@@ -1,9 +1,7 @@
 ---
-title: "VPS Deployment"
-description: "Deploy agents to a VPS via SSH + Docker"
+title: "Cloud Deployment"
+description: "Deploy agents to remote infrastructure"
 ---
-
-# Cloud
 
 Running `al start` on your laptop works for development, but for production you want agents running 24/7 on remote infrastructure — no laptop required and automatic restarts.
 

--- a/docs/commands.mdx
+++ b/docs/commands.mdx
@@ -3,8 +3,6 @@ title: "CLI Commands"
 description: "Complete reference for all Action Llama CLI commands"
 ---
 
-# CLI Commands
-
 ## `al new <name>`
 
 Creates a new Action Llama project. Runs interactive setup to configure credentials and LLM defaults.

--- a/docs/config-reference.mdx
+++ b/docs/config-reference.mdx
@@ -3,8 +3,6 @@ title: "config.toml Reference"
 description: "Project-level configuration reference"
 ---
 
-# config.toml Reference
-
 The project-level `config.toml` lives at the root of your Action Llama project. All sections and fields are optional — sensible defaults are used for anything you omit. If the file doesn't exist at all, an empty config is assumed.
 
 ## Full Annotated Example

--- a/docs/creating-agents.mdx
+++ b/docs/creating-agents.mdx
@@ -3,8 +3,6 @@ title: "Creating Agents"
 description: "Step-by-step guide to creating an Action Llama agent"
 ---
 
-# Creating Agents
-
 This guide walks you through creating an Action Llama agent from scratch.
 
 ## Prerequisites

--- a/docs/credentials.mdx
+++ b/docs/credentials.mdx
@@ -3,8 +3,6 @@ title: "Credentials"
 description: "Credential types, storage, and resolution"
 ---
 
-# Credentials
-
 Credentials are stored in `~/.action-llama/credentials/<type>/<instance>/<field>`. Each credential type is a directory containing one file per field. Reference them in `agent-config.toml` by type name (e.g. `"github_token"`) for the `default` instance, or use `"type:instance"` for a named instance (e.g. `"git_ssh:botty"`).
 
 ## Built-in Credentials

--- a/docs/docker.mdx
+++ b/docs/docker.mdx
@@ -3,8 +3,6 @@ title: "Docker"
 description: "Container isolation, custom images, and the Docker runtime"
 ---
 
-# Container Isolation
-
 All agents run in isolated containers for security and consistency. Container isolation is always enabled.
 
 ## How it works

--- a/docs/examples/dev/README.mdx
+++ b/docs/examples/dev/README.mdx
@@ -3,8 +3,6 @@ title: "Dev Agent"
 description: "Agent that implements GitHub issues — clones, branches, codes, tests, and opens PRs"
 ---
 
-# Dev Agent
-
 A developer agent that picks up GitHub issues and implements the requested changes. It clones the repo, creates a branch, implements the fix, runs tests, and opens a PR.
 
 ## Setup

--- a/docs/examples/index.mdx
+++ b/docs/examples/index.mdx
@@ -3,8 +3,6 @@ title: "Example Agents"
 description: "Ready-to-use agent configurations for common workflows"
 ---
 
-# Example Agents
-
 Ready-to-use agent configurations. Each directory contains everything you need to add the agent to your project:
 
 - `agent-config.toml` — drop into `agents/<name>/`

--- a/docs/examples/planner/README.mdx
+++ b/docs/examples/planner/README.mdx
@@ -3,8 +3,6 @@ title: "Planner Agent"
 description: "Agent that triages GitHub issues and writes implementation plans"
 ---
 
-# Planner Agent
-
 A triage agent that reads new GitHub issues, assesses whether they have enough detail, asks clarifying questions, and writes detailed implementation plans for the dev agent to follow.
 
 ## Setup

--- a/docs/examples/reddit-moderator/README.mdx
+++ b/docs/examples/reddit-moderator/README.mdx
@@ -3,8 +3,6 @@ title: "Reddit Moderator Agent"
 description: "Agent that moderates Reddit posts and comments, removes violations, and posts content"
 ---
 
-# Reddit Moderator Agent
-
 A moderator agent that helps manage a Reddit community by monitoring posts, removing inappropriate comments, and posting scheduled content.
 
 ## Features

--- a/docs/examples/reviewer/README.mdx
+++ b/docs/examples/reviewer/README.mdx
@@ -3,8 +3,6 @@ title: "Reviewer Agent"
 description: "Agent that reviews pull requests, runs checks, and auto-merges"
 ---
 
-# Reviewer Agent
-
 A code review agent that automatically reviews open pull requests, runs checks, fixes failures, and merges approved PRs.
 
 ## Setup

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -3,8 +3,6 @@ title: "Action Llama"
 description: "Run agents like scripts — triggered by cron or webhooks"
 ---
 
-# Action Llama
-
 Run agents like scripts: triggered by cron or webhooks.
 
 <CardGroup cols={2}>

--- a/docs/models.mdx
+++ b/docs/models.mdx
@@ -3,8 +3,6 @@ title: "Models"
 description: "Supported LLM providers, model IDs, and configuration"
 ---
 
-# Models
-
 Action Llama supports 8 LLM providers. Each agent can use a different provider and model — configure a project-wide default in `config.toml` under `[model]`, and override per agent in `agent-config.toml`.
 
 ## `[model]` Fields

--- a/docs/vps-deployment.mdx
+++ b/docs/vps-deployment.mdx
@@ -3,8 +3,6 @@ title: "VPS Deployment"
 description: "Deploy to a VPS with SSH push"
 ---
 
-# VPS Deployment
-
 Deploy Action Llama on any VPS (DigitalOcean, Vultr, Hetzner, etc.) for cost-effective remote hosting.
 
 There are two approaches:

--- a/docs/web-dashboard.mdx
+++ b/docs/web-dashboard.mdx
@@ -3,8 +3,6 @@ title: "Web Dashboard"
 description: "Browser-based dashboard for monitoring agents"
 ---
 
-# Web Dashboard
-
 Action Llama includes an optional web-based dashboard for monitoring agents in your browser. It provides a live view of agent statuses and streaming logs — similar to the terminal TUI, but accessible from any browser.
 
 ## Enabling the Dashboard

--- a/docs/webhooks.mdx
+++ b/docs/webhooks.mdx
@@ -3,8 +3,6 @@ title: "Webhooks"
 description: "Webhook setup, providers, and filter configuration"
 ---
 
-# Webhooks
-
 Action Llama agents can be triggered by webhooks in addition to (or instead of) cron schedules.
 
 ## Defining Webhook Sources


### PR DESCRIPTION
## Summary
- Mintlify automatically renders the frontmatter `title` as the page header, but every MDX file also had an explicit `# H1` — causing all doc pages to show the title twice
- Removed the duplicate `# H1` lines from all 18 MDX files
- Fixed `cloud.mdx` frontmatter title from "VPS Deployment" to "Cloud Deployment" (was a copy-paste error from `vps-deployment.mdx`)

## Test plan
- [ ] Verify docs pages on Mintlify preview — each page should show a single header

🤖 Generated with [Claude Code](https://claude.com/claude-code)