### PR TITLE
feat: add --headless flag to al push command

### DIFF
--- a/.changeset/add-push-headless-option.md
+++ b/.changeset/add-push-headless-option.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Added `--headless` flag to `al push` command for non-interactive mode. When used, the doctor runs in check-only mode without prompting to fix credential issues. Default behavior now runs doctor interactively to allow fixing issues during push. Closes #186.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@action-llama/action-llama",
-  "version": "0.13.3",
+  "version": "0.13.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@action-llama/action-llama",
-      "version": "0.13.3",
+      "version": "0.13.5",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/src/cli/commands/push.ts
+++ b/src/cli/commands/push.ts
@@ -15,6 +15,7 @@ export async function execute(opts: {
   filesOnly?: boolean;
   all?: boolean;
   forceInstall?: boolean;
+  headless?: boolean;
 }): Promise<void> {
   const projectPath = resolve(opts.project);
 
@@ -73,7 +74,12 @@ export async function execute(opts: {
 
   // Full push — run doctor in checkOnly mode to validate full config before pushing
   const { execute: doctorExecute } = await import("./doctor.js");
-  await doctorExecute({ project: projectPath, env: envName, checkOnly: true, silent: true });
+  await doctorExecute({ 
+    project: projectPath, 
+    env: envName, 
+    checkOnly: opts.headless ?? false,  // Run interactively by default
+    silent: true 
+  });
 
   console.log(`\n=== Push to ${serverConfig.host} (env: ${envName}) ===`);
   console.log(`Agents: ${agents.join(", ")}`);

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -180,6 +180,7 @@ program
   .argument("[agent]", "agent name — push only this agent (hot-reloaded, no restart)")
   .option("-p, --project <dir>", "project directory", ".")
   .option("-E, --env <name>", "use named environment with [server] config")
+  .option("-H, --headless", "non-interactive mode (no credential prompts, for CI/deploy environments)")
   .option("--dry-run", "show what would be synced without making changes")
   .option("--no-creds", "skip credential sync")
   .option("--creds-only", "sync only credentials (skip project files)")

--- a/test/cli/commands/push.test.ts
+++ b/test/cli/commands/push.test.ts
@@ -74,7 +74,7 @@ describe("push command", () => {
     ).rejects.toThrow("No agents found");
   });
 
-  it("runs doctor checkOnly before pushing", async () => {
+  it("runs doctor interactively by default (checkOnly: false)", async () => {
     mockResolveEnvironmentName.mockReturnValue("srv");
     mockLoadEnvironmentConfig.mockReturnValue({ server: { host: "h" } });
 
@@ -83,7 +83,33 @@ describe("push command", () => {
     expect(mockDoctorExecute).toHaveBeenCalledOnce();
     expect(mockDoctorExecute.mock.calls[0][0]).toMatchObject({
       env: "srv",
+      checkOnly: false,
+    });
+  });
+
+  it("runs doctor in check-only mode when --headless is passed", async () => {
+    mockResolveEnvironmentName.mockReturnValue("srv");
+    mockLoadEnvironmentConfig.mockReturnValue({ server: { host: "h" } });
+
+    await captureLog(() => execute({ project: ".", env: "srv", headless: true }));
+
+    expect(mockDoctorExecute).toHaveBeenCalledOnce();
+    expect(mockDoctorExecute.mock.calls[0][0]).toMatchObject({
+      env: "srv",
       checkOnly: true,
+    });
+  });
+
+  it("runs doctor interactively when --headless is explicitly false", async () => {
+    mockResolveEnvironmentName.mockReturnValue("srv");
+    mockLoadEnvironmentConfig.mockReturnValue({ server: { host: "h" } });
+
+    await captureLog(() => execute({ project: ".", env: "srv", headless: false }));
+
+    expect(mockDoctorExecute).toHaveBeenCalledOnce();
+    expect(mockDoctorExecute.mock.calls[0][0]).toMatchObject({
+      env: "srv",
+      checkOnly: false,
     });
   });
 


### PR DESCRIPTION
Closes #186

This PR adds a `--headless` flag to the `al push` command to support non-interactive mode for CI/CD environments.

## Changes

- **Added `--headless` option** to the push command definition in `main.ts`
- **Updated push command interface** to accept the headless parameter in `push.ts`
- **Modified doctor execution** to use `checkOnly: opts.headless ?? false` instead of always `true`
- **Added comprehensive test coverage** for the new headless functionality

## Behavior

- **Default (no flag)**: Doctor runs interactively, allowing users to fix credential issues during push
- **With `--headless`**: Doctor runs in check-only mode, failing fast on missing credentials without prompting

## Testing

- ✅ All existing tests pass
- ✅ New tests verify headless behavior
- ✅ Build succeeds with no TypeScript errors
- ✅ CLI help displays the new option correctly

This enables `al push` to be used reliably in automated deployment pipelines while preserving the interactive experience for local development.