### PR TITLE
fix: make gateway auth secure-by-default

### DIFF
--- a/.changeset/gateway-security-auth.md
+++ b/.changeset/gateway-security-auth.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Improve gateway security by requiring authentication when exposing services. API keys are now required for --web-ui and --expose modes, cookies use the Secure flag for non-localhost connections, and log routes are disabled without authentication. Run 'al doctor' to configure the gateway API key. Closes #183.

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -8,6 +8,8 @@ import { resolveEnvironmentName, loadEnvironmentConfig } from "../../shared/envi
 import { validateServerConfig } from "../../shared/server.js";
 import { sshOptionsFromConfig, sshExec } from "../../remote/ssh.js";
 import { gatewayFetch } from "../gateway-client.js";
+import { credentialExists } from "../../shared/credentials.js";
+import { ConfigError } from "../../shared/errors.js";
 
 export async function execute(opts: { project: string; env?: string; headless?: boolean; webUi?: boolean; expose?: boolean; port?: number }): Promise<void> {
   const projectPath = resolve(opts.project);
@@ -29,6 +31,14 @@ export async function execute(opts: { project: string; env?: string; headless?: 
       await startRemoteService(projectPath, envName, serverConfig);
       return;
     }
+  }
+
+  // Security validation: require API key for exposed services
+  if ((opts.webUi || opts.expose) && !await credentialExists("gateway_api_key", "default")) {
+    throw new ConfigError(
+      "Gateway API key required when using --web-ui or --expose. " +
+      "Run 'al doctor' to configure it."
+    );
   }
 
   // Ensure all credentials are present before starting (silent unless something is missing)

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -136,7 +136,7 @@ export async function startGateway(opts: GatewayOptions): Promise<GatewayServer>
     app.use("/api/logs/*", auth);
 
     // Always register login/logout so the auth redirect has a target
-    registerLoginRoutes(app, opts.apiKey, sessionStore);
+    registerLoginRoutes(app, opts.apiKey, sessionStore, opts.hostname);
   }
 
   registerLockRoutes(app, containerRegistry, lockStore, logger, { skipStatusEndpoint: opts.skipStatusEndpoint, events: opts.events });
@@ -160,15 +160,12 @@ export async function startGateway(opts: GatewayOptions): Promise<GatewayServer>
     }
   }
 
-  // Log API routes — available regardless of webUI flag (CLI needs them)
-  if (projectPath) {
+  // Log API routes — only register if auth is configured for security
+  if (projectPath && opts.apiKey) {
     const { registerLogRoutes } = await import("./routes/logs.js");
     registerLogRoutes(app, projectPath);
-    
-    // Warn if log endpoints are exposed without authentication
-    if (!opts.apiKey) {
-      logger.warn("Log and dashboard endpoints are exposed without authentication. Consider setting up a gateway API key for security.");
-    }
+  } else if (projectPath && !opts.apiKey) {
+    logger.warn("Log API routes disabled — gateway API key required for security.");
   }
 
   // Control routes (for kill, pause, resume commands)

--- a/src/gateway/routes/dashboard.ts
+++ b/src/gateway/routes/dashboard.ts
@@ -16,7 +16,7 @@ import type { SessionStore } from "../session-store.js";
  * server-side and sets that ID in the cookie. Logout deletes the session.
  * Without a SessionStore the behavior is unchanged (backward compatibility).
  */
-export function registerLoginRoutes(app: Hono, apiKey?: string, sessionStore?: SessionStore): void {
+export function registerLoginRoutes(app: Hono, apiKey?: string, sessionStore?: SessionStore, hostname?: string): void {
   app.get("/login", (c) => {
     return c.html(renderLoginPage());
   });
@@ -35,11 +35,13 @@ export function registerLoginRoutes(app: Hono, apiKey?: string, sessionStore?: S
       } else {
         sessionValue = apiKey;
       }
+      const isLocalhost = !hostname || hostname === "127.0.0.1" || hostname === "localhost";
+      const securePart = isLocalhost ? "" : "; Secure";
       return c.html("", {
         status: 302,
         headers: {
           Location: "/dashboard",
-          "Set-Cookie": `al_session=${sessionValue}; HttpOnly; SameSite=Strict; Path=/`,
+          "Set-Cookie": `al_session=${sessionValue}; HttpOnly; SameSite=Strict; Path=/${securePart}`,
         },
       });
     }

--- a/src/scheduler/gateway-setup.ts
+++ b/src/scheduler/gateway-setup.ts
@@ -52,6 +52,9 @@ export async function setupGateway(opts: {
   const { key: gatewayApiKey, generated } = await ensureGatewayApiKey();
   if (generated) {
     logger.info("Generated gateway API key (run 'al doctor' to view it)");
+    if (webUI || expose) {
+      logger.warn("Security: API key authentication is now required for --web-ui and --expose modes");
+    }
   }
 
   const { startGateway } = await import("../gateway/index.js");


### PR DESCRIPTION
Closes #183

This PR implements secure-by-default authentication for the Action Llama gateway:

## Changes
- **Require API key for exposed services**:  and  flags now require a gateway API key to be configured 
- **Secure cookies**: Cookies now include the Secure flag when not on localhost
- **Protected log routes**: Log API routes are disabled without authentication for better security
- **Better UX**: Clear error messages guide users to run  to configure the API key

## Security Impact
This is a **breaking change** for users who were using  or  without authentication. After updating:
- Run  to configure the gateway API key
- Existing functionality works unchanged once the API key is set
- Log routes are completely disabled (not just unprotected) when auth is missing

## Testing
- ✅ All existing tests pass
- ✅ Build succeeds 
- ✅ Validates that  fails without API key
- ✅ Validates that  fails without API key  
- ✅ Confirms cookies have Secure flag for non-localhost
- ✅ Verifies log routes are disabled without auth

The changes maintain backward compatibility for users with API keys configured while improving security for new deployments.