### PR TITLE
fix: MCP server models display

### DIFF
--- a/.changeset/fix-mcp-server-models-display.md
+++ b/.changeset/fix-mcp-server-models-display.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fixed MCP server agent info display to show all configured models instead of failing with TypeScript error. The server now correctly accesses the `models` array property instead of the non-existent `model` property. Closes #196.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -244,7 +244,7 @@ export async function startMcpServer(opts: {
         if (config.description) lines.push(`Description: ${config.description}`);
         if (config.schedule) lines.push(`Schedule: ${config.schedule}`);
         if (config.webhooks?.length) lines.push(`Webhooks: ${config.webhooks.map((w) => `${w.source}:${(w.events || []).join(",")}`).join(", ")}`);
-        lines.push(`Model: ${config.model?.provider}/${config.model?.model || "default"}`);
+        lines.push(`Models: ${config.models.length > 0 ? config.models.map(m => `${m.provider}/${m.model}`).join(", ") : "none"}`);
         if (config.credentials?.length) lines.push(`Credentials: ${config.credentials.join(", ")}`);
         if (config.scale && config.scale > 1) lines.push(`Scale: ${config.scale}`);
         if (config.timeout) lines.push(`Timeout: ${config.timeout}s`);


### PR DESCRIPTION
Closes #196

This PR fixes a TypeScript error in the MCP server where the code was attempting to access `config.model` property that doesn't exist. The `AgentConfig` interface only has a `models` property (plural, array).

## Changes
- Updated `src/mcp/server.ts` line 247 to use `config.models` array instead of non-existent `config.model` property
- Changed the display from "Model:" to "Models:" to reflect that multiple models are now supported
- Added proper handling for empty models array with "none" fallback
- Added changeset documenting the fix

## Testing  
- ✅ TypeScript compilation now passes
- ✅ All existing tests continue to pass
- ✅ Build completes successfully

This resolves the CI failure that was blocking the main branch.