### PR TITLE
Move kill button to Session Instances section and rename to 'Kill all'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,10 @@
 {
-  "name": "pr-repo",
+  "name": "repo",
   "version": "0.13.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pr-repo",
       "workspaces": [
         "packages/*"
       ],

--- a/packages/action-llama/src/gateway/views/agent-detail-page.ts
+++ b/packages/action-llama/src/gateway/views/agent-detail-page.ts
@@ -82,7 +82,6 @@ export function renderAgentDetailPage(data: AgentDetailData): string {
       </div>
       <div class="flex items-center gap-2">
         <button class="px-3 py-1.5 text-sm rounded-md font-bold bg-green-600 hover:bg-green-700 text-white transition-colors" onclick="triggerAgent('${escapeHtml(agentName)}')">Run</button>
-        <button id="agent-kill-btn" class="px-3 py-1.5 text-sm rounded-md font-bold bg-red-600 hover:bg-red-700 text-white transition-colors ${runningInstances.length > 0 ? "" : "opacity-50 cursor-not-allowed"}" onclick="killAgent()" ${runningInstances.length > 0 ? "" : "disabled"}>Kill</button>
         <button id="toggle-btn" class="px-3 py-1.5 text-sm rounded-md font-bold border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 hover:bg-slate-50 dark:hover:bg-slate-700 text-slate-700 dark:text-slate-200 transition-colors" onclick="toggleEnabled()">${agent?.enabled !== false ? "Disable" : "Enable"}</button>
       </div>
     </div>
@@ -98,7 +97,10 @@ export function renderAgentDetailPage(data: AgentDetailData): string {
 
     <!-- Session instances -->
     <div id="running-section" class="${runningInstances.length > 0 ? "" : "hidden"} mb-6">
-      <h2 class="text-base font-semibold text-slate-900 dark:text-white mb-3">Session Instances</h2>
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="text-base font-semibold text-slate-900 dark:text-white">Session Instances</h2>
+        <button id="agent-kill-btn" class="px-3 py-1.5 text-sm rounded-md font-bold bg-red-600 hover:bg-red-700 text-white transition-colors ${runningInstances.length > 0 ? "" : "opacity-50 cursor-not-allowed"}" onclick="killAgent()" ${runningInstances.length > 0 ? "" : "disabled"}>Kill all</button>
+      </div>
       <div id="running-instances" class="space-y-2">
         ${runningInstances.map((inst) => renderInstanceCard(inst, agentName)).join("\n")}
       </div>


### PR DESCRIPTION
Closes #201

## Changes Made

- **Removed** the Kill button from the agent detail page header button group  
- **Added** a new "Kill all" button next to the "Session Instances" heading
- **Updated** the button text from "Kill" to "Kill all" to be more descriptive

## Implementation Details

The button retains all existing functionality:
- Only enabled when there are running instances
- Shows confirmation dialog before killing instances  
- Dynamically updates enabled/disabled state as instances start/stop
- Hidden when the Session Instances section is hidden (no running instances)

The button uses the same ID (`agent-kill-btn`) to preserve all JavaScript functionality.