### PR TITLE
Add resource locks display to dashboard and instance pages

### DIFF
--- a/.changeset/add-resource-locks-display.md
+++ b/.changeset/add-resource-locks-display.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Add resource lock display to dashboard agents table and instance detail pages. Agents table now shows a "Locks" column displaying currently held resource locks, and instance detail pages include a "Resource Locks" section. Lock data is fetched from the gateway API every 2 seconds for real-time updates. Closes #204.

--- a/packages/action-llama/src/gateway/routes/dashboard.ts
+++ b/packages/action-llama/src/gateway/routes/dashboard.ts
@@ -136,6 +136,22 @@ export function registerDashboardRoutes(
     return c.redirect(`/dashboard/agents/${encodeURIComponent(name)}`);
   });
 
+  // Locks API endpoint
+  app.get("/dashboard/api/locks", async (c) => {
+    try {
+      const response = await fetch("http://127.0.0.1:" + (statusTracker.getSchedulerInfo()?.gatewayPort || 3000) + "/locks/status", {
+        headers: { "X-Internal-Request": "true" }
+      });
+      if (response.ok) {
+        const data = await response.json();
+        return c.json(data);
+      }
+    } catch {
+      // ignore fetch errors
+    }
+    return c.json({ locks: [] });
+  });
+
   // SSE: status stream
   app.get("/dashboard/api/status-stream", (c) => {
     return streamSSE(c, async (stream) => {

--- a/packages/action-llama/src/gateway/views/dashboard-page.ts
+++ b/packages/action-llama/src/gateway/views/dashboard-page.ts
@@ -57,6 +57,7 @@ function renderAgentRow(agent: AgentStatus, totalSessionTokens: number): string 
     <td class="px-3 py-2.5 text-sm text-slate-600 dark:text-slate-300">${agent.lastRunDuration != null ? formatDuration(agent.lastRunDuration) : "\u2014"}</td>
     <td class="px-3 py-2.5 text-sm text-slate-600 dark:text-slate-300">${formatTime(agent.nextRunAt)}</td>
     <td class="px-3 py-2.5" style="min-width:120px">${renderTokenBar(agent, totalSessionTokens)}</td>
+    <td class="px-3 py-2.5 text-sm text-slate-600 dark:text-slate-300">${agent.locks && agent.locks.length > 0 ? agent.locks.map(l => escapeHtml(l.resourceKey.replace(/^[^:]+:\/\//, ""))).join(", ") : "\u2014"}</td>
     <td class="px-3 py-2.5 whitespace-nowrap">
       <button class="px-2 py-1 text-xs rounded font-bold bg-green-600 hover:bg-green-700 text-white transition-colors mr-1" onclick="triggerAgent('${escapeHtml(agent.name)}')">Run</button>
       <button class="px-2 py-1 text-xs rounded font-bold bg-red-600 hover:bg-red-700 text-white transition-colors mr-1" onclick="killAgent('${escapeHtml(agent.name)}')">Kill</button>
@@ -126,11 +127,12 @@ export function renderDashboardPage(agents: AgentStatus[], schedulerInfo: Schedu
             <th class="text-left px-3 py-2 text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wider font-medium">Duration</th>
             <th class="text-left px-3 py-2 text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wider font-medium">Next Run</th>
             <th class="text-left px-3 py-2 text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wider font-medium">Tokens Used</th>
+            <th class="text-left px-3 py-2 text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wider font-medium">Locks</th>
             <th class="text-left px-3 py-2 text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wider font-medium">Actions</th>
           </tr>
         </thead>
         <tbody id="agent-table-body" class="divide-y divide-slate-100 dark:divide-slate-800">
-          ${agents.length > 0 ? agents.map((a) => renderAgentRow(a, sessionTokens)).join("\n") : '<tr><td colspan="7" class="px-3 py-8 text-center text-slate-400 italic">No agents registered</td></tr>'}
+          ${agents.length > 0 ? agents.map((a) => renderAgentRow(a, sessionTokens)).join("\n") : '<tr><td colspan="8" class="px-3 py-8 text-center text-slate-400 italic">No agents registered</td></tr>'}
         </tbody>
       </table>
     </div>
@@ -195,6 +197,7 @@ export function renderDashboardPage(agents: AgentStatus[], schedulerInfo: Schedu
         '<td class="px-3 py-2.5 text-sm text-slate-600 dark:text-slate-300">' + (a.lastRunDuration != null ? fmtDur(a.lastRunDuration) : "\\u2014") + '</td>' +
         '<td class="px-3 py-2.5 text-sm text-slate-600 dark:text-slate-300">' + fmtTime(a.nextRunAt) + '</td>' +
         '<td class="px-3 py-2.5" style="min-width:120px">' + tokenBar(a, totalTok) + '</td>' +
+        '<td class="px-3 py-2.5 text-sm text-slate-600 dark:text-slate-300">' + (a.locks && a.locks.length > 0 ? a.locks.map(function(l) { return esc(l.resourceKey.replace(/^[^:]+:\\/\\//, "")); }).join(", ") : "\\u2014") + '</td>' +
         '<td class="px-3 py-2.5 whitespace-nowrap">' +
         '<button class="px-2 py-1 text-xs rounded font-bold bg-green-600 hover:bg-green-700 text-white transition-colors mr-1" onclick="triggerAgent(\\'' + esc(a.name) + '\\')">Run</button>' +
         '<button class="px-2 py-1 text-xs rounded font-bold bg-red-600 hover:bg-red-700 text-white transition-colors mr-1" onclick="killAgent(\\'' + esc(a.name) + '\\')">Kill</button>' +
@@ -231,7 +234,7 @@ export function renderDashboardPage(agents: AgentStatus[], schedulerInfo: Schedu
         if (data.agents.length > 0) {
           tbody.innerHTML = data.agents.map(renderRow).join("");
         } else {
-          tbody.innerHTML = '<tr><td colspan="7" class="px-3 py-8 text-center text-slate-400 italic">No agents registered</td></tr>';
+          tbody.innerHTML = '<tr><td colspan="8" class="px-3 py-8 text-center text-slate-400 italic">No agents registered</td></tr>';
         }
         var cards = document.getElementById("agent-cards");
         if (data.agents.length > 0) {
@@ -258,6 +261,36 @@ export function renderDashboardPage(agents: AgentStatus[], schedulerInfo: Schedu
         }
       }
     };
+
+    // Fetch locks periodically
+    async function fetchLocks() {
+      try {
+        var res = await fetch("/dashboard/api/locks");
+        if (res.ok) {
+          var data = await res.json();
+          if (data.locks && _cachedAgents) {
+            // Group locks by agent
+            var locksByAgent = {};
+            for (var i = 0; i < data.locks.length; i++) {
+              var lock = data.locks[i];
+              if (!locksByAgent[lock.agentName]) locksByAgent[lock.agentName] = [];
+              locksByAgent[lock.agentName].push(lock);
+            }
+            // Update agent locks
+            for (var j = 0; j < _cachedAgents.length; j++) {
+              _cachedAgents[j].locks = locksByAgent[_cachedAgents[j].name] || [];
+            }
+            // Re-render table
+            var tbody = document.getElementById("agent-table-body");
+            if (_cachedAgents.length > 0) {
+              tbody.innerHTML = _cachedAgents.map(renderRow).join("");
+            }
+          }
+        }
+      } catch(e) {}
+    }
+    setInterval(fetchLocks, 2000);
+    fetchLocks(); // Initial fetch
 
     var schedulerPaused = ${schedulerInfo?.paused ? "true" : "false"};
 

--- a/packages/action-llama/src/gateway/views/instance-detail-page.ts
+++ b/packages/action-llama/src/gateway/views/instance-detail-page.ts
@@ -62,6 +62,12 @@ export function renderInstanceDetailPage(data: InstanceDetailData): string {
         </div>
       </div>
       ${notFoundContent}
+      <div id="locks-section" class="mt-6">
+        <h3 class="text-base font-semibold text-slate-900 dark:text-white mb-3">Resource Locks</h3>
+        <div id="locks-container" class="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 p-4">
+          <div class="text-sm text-slate-400 italic">Loading...</div>
+        </div>
+      </div>
       <h2 class="text-base font-semibold text-slate-900 dark:text-white mb-3 mt-8">Logs</h2>
       ${logViewerHtml(agentName, instanceId)}`;
 
@@ -110,6 +116,13 @@ export function renderInstanceDetailPage(data: InstanceDetailData): string {
         ${statRow("Cache Write", formatTokens(run.cache_write_tokens))}
         ${statRow("Total Tokens", formatTokens(run.total_tokens))}
         ${statRow("Cost", formatCost(run.cost_usd))}
+      </div>
+    </div>
+
+    <div id="locks-section" class="mt-6">
+      <h3 class="text-base font-semibold text-slate-900 dark:text-white mb-3">Resource Locks</h3>
+      <div id="locks-container" class="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 p-4">
+        <div class="text-sm text-slate-400 italic">Loading...</div>
       </div>
     </div>
 
@@ -278,6 +291,44 @@ function logViewerScript(agentName: string, instanceId: string): string {
     }
     fetchLogs(true);
     setInterval(function() { fetchLogs(false); }, 1500);
+
+    // Fetch locks for this instance
+    async function fetchInstanceLocks() {
+      try {
+        var res = await fetch("/dashboard/api/locks");
+        if (res.ok) {
+          var data = await res.json();
+          var instanceLocks = [];
+          if (data.locks) {
+            for (var i = 0; i < data.locks.length; i++) {
+              var lock = data.locks[i];
+              // Check if holder matches this instance
+              if (lock.holder && lock.holder.includes(instanceId)) {
+                instanceLocks.push(lock);
+              }
+            }
+          }
+          // Update locks display
+          var container = document.getElementById("locks-container");
+          if (instanceLocks.length > 0) {
+            var html = "<div class='space-y-2'>";
+            for (var j = 0; j < instanceLocks.length; j++) {
+              var l = instanceLocks[j];
+              var since = new Date(l.heldSince).toLocaleString();
+              html += "<div class='flex justify-between py-2 border-b border-slate-100 dark:border-slate-800'>" +
+                      "<span class='text-sm font-mono text-slate-700 dark:text-slate-300'>" + esc(l.resourceKey) + "</span>" +
+                      "<span class='text-xs text-slate-500'>Since " + since + "</span></div>";
+            }
+            html += "</div>";
+            container.innerHTML = html;
+          } else {
+            container.innerHTML = "<div class='text-sm text-slate-400 italic'>No locks held</div>";
+          }
+        }
+      } catch(e) {}
+    }
+    setInterval(fetchInstanceLocks, 2000);
+    fetchInstanceLocks(); // Initial fetch
 
     // Scroll up to load older logs
     var loadingOlder = false;

--- a/packages/action-llama/src/tui/status-tracker.ts
+++ b/packages/action-llama/src/tui/status-tracker.ts
@@ -20,6 +20,7 @@ export interface AgentStatus {
   runReason: string | null; // why the agent is running (e.g. "schedule", "webhook", "rerun 2/10")
   lastRunUsage: TokenUsage | null;
   cumulativeUsage: TokenUsage | null;  // accumulated across all runs in this session
+  locks?: Array<{ resourceKey: string; heldSince: number; }>; // resource locks held by this agent
 }
 
 export interface SchedulerInfo {
@@ -67,6 +68,7 @@ export class StatusTracker extends EventEmitter {
       runReason: null,
       lastRunUsage: null,
       cumulativeUsage: null,
+      locks: [],
     });
     this.emit("update");
   }


### PR DESCRIPTION
Closes #204

This PR adds resource lock information to both the agents table on the dashboard and to individual instance detail pages.

## Changes Made

### Dashboard Agents Table
- Added new "Locks" column after "Tokens Used" 
- Shows currently held resource locks for each agent
- Displays lock resource keys with URI scheme stripped for brevity
- Shows "—" when no locks are held

### Instance Detail Page
- Added "Resource Locks" section after token usage grid
- Shows locks held by the specific instance
- Displays lock resource key and "held since" timestamp
- Real-time updates every 2 seconds

### API Endpoint
- Added new `/dashboard/api/locks` endpoint in gateway
- Fetches lock data from internal locks service
- Returns empty locks array on fetch errors for graceful degradation

### Implementation Details
- Added `locks` field to `AgentStatus` interface
- Lock data fetched independently from main status stream 
- All data access goes through gateway API endpoints as required
- Maintains existing project patterns and conventions

The implementation follows the detailed plan from the planner agent and has been tested with the full unit test suite.