### PR TITLE
Filter Session Instances to show only running instances

### DIFF
--- a/.changeset/filter-running-instances.md
+++ b/.changeset/filter-running-instances.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Filter Session Instances section on agent detail page to only show running instances. Changed section title from "Session Instances" to "Running Instances" to clarify the filtering. Completed instances remain visible in the Instance History table below.

--- a/packages/action-llama/src/gateway/routes/dashboard.ts
+++ b/packages/action-llama/src/gateway/routes/dashboard.ts
@@ -115,7 +115,7 @@ export function registerDashboardRoutes(
     const agents = statusTracker.getAllAgents();
     const agent = agents.find((a) => a.name === name) || null;
     const summary = statsStore ? (statsStore.queryAgentSummary({ agent: name })[0] || null) : null;
-    const instances = statusTracker.getInstances().filter((i) => i.agentName === name);
+    const instances = statusTracker.getInstances().filter((i) => i.agentName === name && i.status === "running");
     const totalHistorical = statsStore ? statsStore.countRunsByAgent(name) : 0;
     const html = renderAgentDetailPage({ agentName: name, agent, summary, runningInstances: instances, totalHistorical });
     return c.html(html);

--- a/packages/action-llama/src/gateway/views/agent-detail-page.ts
+++ b/packages/action-llama/src/gateway/views/agent-detail-page.ts
@@ -98,7 +98,7 @@ export function renderAgentDetailPage(data: AgentDetailData): string {
     <!-- Session instances -->
     <div id="running-section" class="${runningInstances.length > 0 ? "" : "hidden"} mb-6">
       <div class="flex items-center justify-between mb-3">
-        <h2 class="text-base font-semibold text-slate-900 dark:text-white">Session Instances</h2>
+        <h2 class="text-base font-semibold text-slate-900 dark:text-white">Running Instances</h2>
         <button id="agent-kill-btn" class="px-3 py-1.5 text-sm rounded-md font-bold bg-red-600 hover:bg-red-700 text-white transition-colors ${runningInstances.length > 0 ? "" : "opacity-50 cursor-not-allowed"}" onclick="killAgent()" ${runningInstances.length > 0 ? "" : "disabled"}>Kill all</button>
       </div>
       <div id="running-instances" class="space-y-2">


### PR DESCRIPTION
Closes #207

Filters the Session Instances section on the agent detail page to only show running instances and updates the section title to 'Running Instances' for clarity. Completed instances remain visible in the Instance History table below.

## Changes

- **Backend**: Modified dashboard.ts to filter instances by status === 'running'
- **Frontend**: Updated section title from 'Session Instances' to 'Running Instances' in agent-detail-page.ts

## Testing

- ✅ All unit tests pass
- ✅ Build passes
- ✅ No linting issues
