### PR TITLE
fix: correct E2E Docker build context paths

### DIFF
--- a/.changeset/fix-e2e-docker-paths.md
+++ b/.changeset/fix-e2e-docker-paths.md
@@ -1,0 +1,9 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fixed E2E test Docker build context paths. Corrected relative paths in harness.ts
+from `./packages/e2e/docker/local` and `./packages/e2e/docker/vps` to `./docker/local`
+and `./docker/vps` to resolve correctly when vitest runs from the packages/e2e directory.
+Fixes CI failures where E2E tests were timing out due to missing Dockerfiles.
+Closes #242.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pr-repo",
+  "name": "repo",
   "version": "0.13.7",
   "lockfileVersion": 3,
   "requires": true,

--- a/packages/e2e/src/harness.ts
+++ b/packages/e2e/src/harness.ts
@@ -91,7 +91,7 @@ export class E2ETestContext {
 
   async createLocalActionLlamaContainer(): Promise<ContainerInfo> {
     // Build the local Action Llama container
-    await this.buildImage("action-llama-local", "./packages/e2e/docker/local");
+    await this.buildImage("action-llama-local", "./docker/local");
     
     const containerName = `action-llama-e2e-local-${this.runId}`;
     
@@ -126,7 +126,7 @@ export class E2ETestContext {
 
   async createVPSContainer(): Promise<ContainerInfo> {
     // Build the VPS container with SSH and Docker
-    await this.buildImage("action-llama-vps", "./packages/e2e/docker/vps");
+    await this.buildImage("action-llama-vps", "./docker/vps");
     
     const containerName = `action-llama-e2e-vps-${this.runId}`;
     


### PR DESCRIPTION
Closes #242

Fixed E2E test Docker build context paths in harness.ts. When vitest runs E2E tests from the packages/e2e/ directory, the relative paths "./packages/e2e/docker/local" and "./packages/e2e/docker/vps" resolve incorrectly to non-existent nested paths.

Changes:
- Updated `createLocalActionLlamaContainer()` to use "./docker/local" instead of "./packages/e2e/docker/local"
- Updated `createVPSContainer()` to use "./docker/vps" instead of "./packages/e2e/docker/vps"

This fixes the CI failures where E2E tests were timing out due to Docker build failures caused by missing Dockerfile paths.