### PR TITLE
Fix E2E Docker build context paths

### DIFF
--- a/packages/e2e/docker/local/Dockerfile
+++ b/packages/e2e/docker/local/Dockerfile
@@ -7,10 +7,10 @@ RUN apk add --no-cache git bash curl openssh-client
 WORKDIR /app
 
 # Copy the built action-llama package
-COPY ../../action-llama/dist ./action-llama/dist
-COPY ../../action-llama/package.json ./action-llama/
-COPY ../../shared/dist ./shared/dist
-COPY ../../shared/package.json ./shared/
+COPY packages/action-llama/dist ./action-llama/dist
+COPY packages/action-llama/package.json ./action-llama/
+COPY packages/shared/dist ./shared/dist
+COPY packages/shared/package.json ./shared/
 
 # Install action-llama globally
 RUN cd action-llama && npm pack && npm install -g *.tgz

--- a/packages/e2e/src/harness.ts
+++ b/packages/e2e/src/harness.ts
@@ -257,8 +257,16 @@ export class E2ETestContext {
   }
 
   private async buildImage(imageName: string, contextPath: string) {
+    // Use the repository root as the build context so Docker can access
+    // all the files referenced in the Dockerfile
+    const repoRoot = path.resolve(process.cwd(), "../..");
+    const dockerfilePath = path.relative(repoRoot, path.resolve(contextPath, "Dockerfile"));
+    
     const stream = await this.docker.buildImage(
-      { context: contextPath, src: ["Dockerfile"] },
+      { 
+        context: repoRoot, 
+        src: [dockerfilePath]
+      },
       { t: `${imageName}:latest` }
     );
     


### PR DESCRIPTION
Closes #244

Fixed Docker build context issue in E2E tests by:

1. **Changed build context**: Modified `buildImage` method to use repository root as the build context instead of the docker subdirectory
2. **Updated Dockerfile paths**: Changed relative paths in `packages/e2e/docker/local/Dockerfile` from `../../` to `packages/` to match the new build context

The original issue was that the Docker build context was set to `./docker/local` but the Dockerfile was trying to copy files from `../../../` which goes outside the build context. This fix ensures Docker can access all the required source files during the build.

## Changes Made

### Modified files:
- `packages/e2e/src/harness.ts`: Updated `buildImage` method to use repo root as build context
- `packages/e2e/docker/local/Dockerfile`: Updated COPY paths to be relative to repo root

### Testing
- All unit tests continue to pass
- Build completes successfully
- The E2E test failure should now be resolved when Docker is available in the CI environment