### PR TITLE
Fix E2E Docker build context path resolution failure

### DIFF
--- a/packages/e2e/src/harness.ts
+++ b/packages/e2e/src/harness.ts
@@ -257,10 +257,10 @@ export class E2ETestContext {
   }
 
   private async buildImage(imageName: string, contextPath: string) {
-    // Use the repository root as the build context so Docker can access
-    // all the files referenced in the Dockerfile
-    const repoRoot = path.resolve(process.cwd(), "../..");
-    const dockerfilePath = path.relative(repoRoot, path.resolve(contextPath, "Dockerfile"));
+    // Use __dirname to get the absolute path to the harness.ts file, then navigate to repo root
+    const repoRoot = path.resolve(__dirname, "../../../..");
+    const absoluteContextPath = path.resolve(repoRoot, "packages/e2e", contextPath);
+    const dockerfilePath = path.join("packages/e2e", contextPath, "Dockerfile");
     
     const stream = await this.docker.buildImage(
       { 

--- a/packages/e2e/tsconfig.json
+++ b/packages/e2e/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "skipLibCheck": true,
+    "noImplicitAny": false,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Closes #246

This PR fixes the CI failure in E2E tests where Docker cannot locate the Dockerfile during the build process.

## Changes Made

1. **Fixed buildImage method path resolution**: Replaced `process.cwd()` based path resolution with `__dirname` based resolution to ensure consistent path calculation regardless of working directory.

2. **Added proper tsconfig.json for e2e package**: Added TypeScript configuration to resolve module import issues.

## Root Cause

The issue was in the `packages/e2e/src/harness.ts` file where the `buildImage` method used `process.cwd()` for path resolution, which was unreliable when tests were run from different working directories.

## Solution

The fix uses `__dirname` to get the absolute path to the harness.ts file and then navigates to the repo root, ensuring consistent behavior regardless of the current working directory:

```typescript
// Before
const repoRoot = path.resolve(process.cwd(), "../..");
const dockerfilePath = path.relative(repoRoot, path.resolve(contextPath, "Dockerfile"));

// After  
const repoRoot = path.resolve(__dirname, "../../../..");
const dockerfilePath = path.join("packages/e2e", contextPath, "Dockerfile");
```

This ensures that Docker can reliably locate the Dockerfile and access the required built packages at `packages/action-llama/dist` and `packages/shared/dist`.