### PR TITLE
fix: correct E2E Docker build context path resolution (closes #250)

### DIFF
--- a/packages/e2e/src/harness.ts
+++ b/packages/e2e/src/harness.ts
@@ -262,7 +262,8 @@ export class E2ETestContext {
     // Use ES module equivalent of __dirname to get the absolute path to the harness.ts file
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);
-    const repoRoot = path.resolve(__dirname, "../../../..");
+    // Navigate from packages/e2e/src to repo root (3 levels up)
+    const repoRoot = path.resolve(__dirname, "../../..");
     const absoluteContextPath = path.resolve(repoRoot, "packages/e2e", contextPath);
     const dockerfilePath = path.join("packages/e2e", contextPath, "Dockerfile");
     


### PR DESCRIPTION
Closes #250

This PR fixes the Docker path resolution error in the E2E test harness that was causing all tests to timeout. The issue was in the `buildImage` method in `packages/e2e/src/harness.ts` where it was incorrectly calculating the repository root path.

## Changes
- Fixed path resolution from `../../../..` (4 levels up) to `../../..` (3 levels up)
- Added comment clarifying the path navigation from `packages/e2e/src` to repo root

## Root Cause
The recent ES modules `__dirname` fix introduced a path calculation bug. From `packages/e2e/src/harness.ts`, the correct path to repo root should be 3 levels up (`../../..`), not 4 levels up (`../../../..`).

## Validation
- ✅ Unit tests pass
- ✅ TypeScript compilation succeeds
- ✅ Project builds successfully

This fix aligns with the analysis provided in the issue and should resolve the CI failures in E2E tests.