### PR TITLE
Fix Docker API usage in E2E test harness

### DIFF
--- a/packages/e2e/src/harness.ts
+++ b/packages/e2e/src/harness.ts
@@ -268,11 +268,11 @@ export class E2ETestContext {
     const dockerfilePath = path.join("packages/e2e", contextPath, "Dockerfile");
     
     const stream = await this.docker.buildImage(
+      repoRoot,
       { 
-        context: repoRoot, 
-        src: [dockerfilePath]
-      },
-      { t: `${imageName}:latest` }
+        t: `${imageName}:latest`,
+        dockerfile: dockerfilePath
+      }
     );
     
     return new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
Closes #252

Fixes the incorrect Docker API usage in the E2E test harness that was causing all E2E tests to fail.

## Problem
The Docker build was failing with "Cannot locate specified Dockerfile: Dockerfile" because the Docker API was being called incorrectly. The `src` parameter was telling Docker to look for "Dockerfile" at the root of the build context, but the actual Dockerfiles are located at specific paths.

## Solution
Replaced the incorrect Docker API call:
```typescript
const stream = await this.docker.buildImage(
  { 
    context: repoRoot, 
    src: [dockerfilePath]
  },
  { t: `${imageName}:latest` }
);
```

With the correct usage:
```typescript
const stream = await this.docker.buildImage(
  repoRoot,
  { 
    t: `${imageName}:latest`,
    dockerfile: dockerfilePath
  }
);
```

The `dockerfile` parameter correctly specifies the path to the Dockerfile relative to the build context, allowing Docker to locate and use the correct Dockerfile.

## Testing
- ✅ All unit tests pass (1314/1314)
- ✅ TypeScript compilation successful
- ✅ Build successful