### PR TITLE
Fix Docker API buildImage EISDIR error in E2E tests

### DIFF
--- a/packages/e2e/src/harness.ts
+++ b/packages/e2e/src/harness.ts
@@ -271,7 +271,7 @@ export class E2ETestContext {
       repoRoot,
       { 
         t: `${imageName}:latest`,
-        dockerfile: path.resolve(repoRoot, dockerfilePath)
+        dockerfile: dockerfilePath
       }
     );
     


### PR DESCRIPTION
Closes #256

Fixed the "EISDIR: illegal operation on a directory, read" error in E2E tests by using a relative dockerfile path instead of an absolute path in the Docker API buildImage call.

## Problem
The E2E tests were failing with "EISDIR: illegal operation on a directory, read" error during Docker image build operations. This occurred because the Docker API was receiving an absolute path for the dockerfile parameter when using a directory as the build context.

## Solution
Changed `path.resolve(repoRoot, dockerfilePath)` to just `dockerfilePath` in the buildImage call. The dockerfile path should be relative to the build context (repoRoot), not an absolute path.

## Testing
- Build passes without TypeScript compilation errors
- Unit tests pass successfully
- Fix follows Docker API requirements for dockerode library