### PR TITLE
Fix Docker build context path resolution in E2E tests

### DIFF
--- a/packages/e2e/src/harness.ts
+++ b/packages/e2e/src/harness.ts
@@ -265,23 +265,23 @@ export class E2ETestContext {
     // Navigate from packages/e2e/src to repo root (3 levels up)
     const repoRoot = path.resolve(__dirname, "../../..");
     
-    // Use the specific docker context directory as the build context
+    // Use repo root as build context, but specify dockerfile location
     const normalizedContextPath = contextPath.replace(/^\.\//, "");
-    const buildContext = path.join(repoRoot, "packages/e2e", normalizedContextPath);
+    const dockerfilePath = path.join("packages/e2e", normalizedContextPath, "Dockerfile");
     
     // Verify the dockerfile exists before building
-    const dockerfilePath = path.join(buildContext, "Dockerfile");
+    const absoluteDockerfilePath = path.join(repoRoot, dockerfilePath);
     try {
-      await fs.access(dockerfilePath);
+      await fs.access(absoluteDockerfilePath);
     } catch (error) {
-      throw new Error(`Dockerfile not found: ${dockerfilePath}`);
+      throw new Error(`Dockerfile not found: ${absoluteDockerfilePath}`);
     }
     
     const stream = await this.docker.buildImage(
-      buildContext,
+      repoRoot,
       { 
         t: `${imageName}:latest`,
-        dockerfile: "Dockerfile"  // Relative to buildContext
+        dockerfile: dockerfilePath  // Relative to repoRoot
       }
     );
     


### PR DESCRIPTION
Closes #263

This PR fixes the Docker build context path resolution issue in E2E tests where the `buildImage` method was setting the build context to `packages/e2e/docker/local` but the Dockerfile COPY commands expected files relative to the repository root.

## Changes
- Modified `buildImage` method in `packages/e2e/src/harness.ts` to use repository root as build context
- Updated dockerfile path to be relative to repo root instead of build context
- This allows COPY commands in Dockerfile to find `packages/action-llama/dist` and `packages/shared/dist`

## Testing
- All unit tests pass successfully (1314 tests)
- TypeScript compilation succeeds with no errors
- The fix addresses the root cause identified in the issue

## Root Cause
The issue was that Docker was looking for files like:
- `packages/e2e/docker/local/packages/action-llama/dist` (doesn't exist)

Instead of:
- `packages/action-llama/dist` (actual location relative to repo root)

By using the repository root as the build context, the Dockerfile COPY commands can now find the required files.

Resolves the CI failure where Docker builds failed due to missing source files.