### PR TITLE
ci: enable Docker daemon for E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,6 +29,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Start Docker daemon
+        run: |
+          sudo systemctl start docker
+          sudo chmod 666 /var/run/docker.sock
+          docker --version
+          docker info
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
Closes #265

This PR fixes the E2E test failure by ensuring the Docker daemon is properly started and accessible in the GitHub Actions runner environment.

## Changes Made

- Added explicit Docker daemon startup in the E2E workflow
- Set proper permissions for Docker socket access
- Added Docker version verification steps

## Problem Solved

The E2E tests were failing because Docker daemon was not available in the GitHub Actions runner, causing the `assertDockerAvailable()` check to fail during global test setup.

## Solution

Added these steps to `.github/workflows/e2e.yml` after the Docker Buildx setup:
- Start Docker daemon with `systemctl`
- Set proper socket permissions
- Verify Docker is working with `docker --version` and `docker info`

This ensures the E2E tests can successfully create Docker containers for testing Action Llama functionality in both local and VPS scenarios.