### PR TITLE
Fix SSH key format error in E2E tests

### DIFF
--- a/packages/e2e/src/harness.ts
+++ b/packages/e2e/src/harness.ts
@@ -1,12 +1,11 @@
 import Docker from "dockerode";
 import { randomUUID } from "crypto";
-import { generateKeyPairSync } from "crypto";
 import tar from "tar-fs";
 import { promises as fs } from "fs";
 import path from "path";
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
-import { Client as SSHClient } from "ssh2";
+import { Client as SSHClient, utils as ssh2Utils } from "ssh2";
 import { assertDockerAvailable, isDockerAvailable } from "./docker-utils.js";
 
 export interface ContainerInfo {
@@ -71,23 +70,13 @@ export class E2ETestContext {
   }
 
   private generateSSHKeyPair() {
-    const { publicKey, privateKey } = generateKeyPairSync("rsa", {
-      modulusLength: 2048,
-      publicKeyEncoding: {
-        type: "spki",
-        format: "pem",
-      },
-      privateKeyEncoding: {
-        type: "pkcs8",
-        format: "pem",
-      },
+    const { public: publicKey, private: privateKey } = ssh2Utils.generateKeyPairSync("rsa", {
+      bits: 2048,
+      comment: "e2e-test@action-llama"
     });
 
-    // Convert to SSH format
-    const sshPublicKey = `ssh-rsa ${Buffer.from(publicKey).toString("base64")} e2e-test@action-llama`;
-    
     return {
-      publicKey: sshPublicKey,
+      publicKey,
       privateKey,
     };
   }


### PR DESCRIPTION
Closes #287

## Summary

This PR fixes the SSH key format error in the E2E test harness that was causing connection timeouts. The issue was in the `generateSSHKeyPair()` method which incorrectly converted PEM-formatted keys to SSH format by simply base64-encoding the entire PEM string.

## Changes

- Replaced manual key conversion with ssh2's native `generateKeyPairSync` function
- Updated import to include `utils` from ssh2 package  
- Simplified the key generation logic to use proper SSH key formatting

## Technical Details

The previous implementation attempted to convert a PEM public key (which includes headers and footers) to SSH format by base64-encoding the entire string. This resulted in malformed SSH keys that caused authentication failures.

The new implementation uses ssh2's built-in key generation which produces properly formatted SSH keys that are compatible with SSH authentication.

## Testing

- [x] TypeScript compilation passes
- [x] Build passes  
- [ ] E2E tests require Docker (not available in current environment)

The fix addresses the root cause identified in the issue and should resolve SSH connection timeouts in environments where Docker is available.