### PR TITLE
fix: resolve E2E test configuration file mismatch and Docker network IP issues

### DIFF
--- a/packages/e2e/src/containers/local.ts
+++ b/packages/e2e/src/containers/local.ts
@@ -11,9 +11,9 @@ export async function setupLocalActionLlama(context: E2ETestContext): Promise<Co
   ]);
   
   // Create a minimal project configuration
-  // Note: Action Llama expects the file to be named config.toml, not project.toml
+  // Create project.toml for consistency with scheduler expectations
   await context.executeInContainer(containerInfo, [
-    "bash", "-c", `cat > /home/testuser/test-project/config.toml << 'EOF'
+    "bash", "-c", `cat > /home/testuser/test-project/project.toml << 'EOF'
 [models.sonnet]
 provider = "anthropic"
 model = "claude-3-5-sonnet-20241022"

--- a/packages/e2e/src/harness.ts
+++ b/packages/e2e/src/harness.ts
@@ -102,8 +102,18 @@ export class E2ETestContext {
 
     await container.start();
     
+    // Wait for container to be fully started and connected to network
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    
     // Get container IP address
-    const containerInfo = await container.inspect();
+    let containerInfo = await container.inspect();
+    
+    // Retry if IP not immediately available
+    if (!containerInfo.NetworkSettings.Networks["action-llama-e2e"]?.IPAddress) {
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      containerInfo = await container.inspect();
+    }
+    
     const ipAddress = containerInfo.NetworkSettings.Networks["action-llama-e2e"]?.IPAddress;
     
     const info: ContainerInfo = {
@@ -148,8 +158,18 @@ export class E2ETestContext {
 
     await container.start();
     
+    // Wait for container to be fully started and connected to network
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    
     // Get container IP address
-    const containerInfo = await container.inspect();
+    let containerInfo = await container.inspect();
+    
+    // Retry if IP not immediately available
+    if (!containerInfo.NetworkSettings.Networks["action-llama-e2e"]?.IPAddress) {
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      containerInfo = await container.inspect();
+    }
+    
     const ipAddress = containerInfo.NetworkSettings.Networks["action-llama-e2e"]?.IPAddress;
     
     const info: ContainerInfo = {


### PR DESCRIPTION
Closes #297

## Summary

This PR fixes two distinct issues in the E2E test suite that were causing CI failures:

### 1. Configuration File Naming Mismatch

**Problem:** In `packages/e2e/src/containers/local.ts`, the setup code was creating `config.toml` but the scheduler startup check was looking for `project.toml`, causing the "manages agent lifecycle" test to fail.

**Fix:** Changed the configuration file creation to use `project.toml` instead of `config.toml` for consistency with scheduler expectations.

### 2. Docker Network IP Assignment Issues

**Problem:** VPS containers were not receiving IP addresses from the `action-llama-e2e` Docker network immediately upon startup, causing SSH connection failures in deployment tests.

**Fix:** Added wait and retry logic in both `createVPSContainer` and `createLocalActionLlamaContainer` methods:
- Wait 2 seconds after container start for network initialization 
- Retry IP address retrieval if not immediately available
- Apply this fix to both container creation methods for consistency

## Tests

- Unit tests: ✅ All 1331 tests passing
- Build: ✅ TypeScript compilation successful  
- E2E tests: Cannot run locally due to Docker requirement, but fixes target the specific error patterns identified in the CI failure

## Changes

- `packages/e2e/src/containers/local.ts`: Changed config.toml → project.toml
- `packages/e2e/src/harness.ts`: Added network initialization waits and IP retry logic