### PR TITLE
Fix E2E test Docker network IP assignment and API key configuration issues

### DIFF
--- a/.changeset/fix-e2e-docker-network-api-keys.md
+++ b/.changeset/fix-e2e-docker-network-api-keys.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fix E2E test Docker network IP assignment and API key configuration issues. Increased container startup timeout from 2000ms to 5000ms to allow proper network setup and added test API keys to E2E workflow to prevent model provider initialization failures. Closes #303.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,6 +55,8 @@ jobs:
         env:
           CI: true
           DOCKER_BUILDKIT: 1
+          ANTHROPIC_API_KEY: ${{ secrets.TEST_ANTHROPIC_API_KEY || 'test-key' }}
+          OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY || 'test-key' }}
         timeout-minutes: 45
 
       - name: Upload test artifacts

--- a/packages/e2e/src/harness.ts
+++ b/packages/e2e/src/harness.ts
@@ -103,7 +103,7 @@ export class E2ETestContext {
     await container.start();
     
     // Wait for container to be fully started and connected to network
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 5000));
     
     // Get container IP address
     let containerInfo = await container.inspect();
@@ -159,7 +159,7 @@ export class E2ETestContext {
     await container.start();
     
     // Wait for container to be fully started and connected to network
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 5000));
     
     // Get container IP address with exponential backoff
     let containerInfo = await container.inspect();


### PR DESCRIPTION
Closes #303

This PR addresses two critical issues preventing E2E tests from running successfully:

## Changes Made

### 1. Docker Network IP Assignment Fix
- **Issue**: Containers were failing to get assigned IP addresses on the custom test network within the timeout period
- **Solution**: Increased the initial wait time after container creation from 2000ms to 5000ms in both `createLocalActionLlamaContainer()` and `createVPSContainer()` methods
- **Location**: `packages/e2e/src/harness.ts` lines 107 and 162
- **Rationale**: Allows more time for Docker to properly assign IP addresses to containers on the custom network

### 2. API Key Configuration Fix
- **Issue**: Missing API keys for OpenAI and Anthropic providers causing scheduler initialization failure
- **Solution**: Added environment variables for test API keys in the E2E workflow with fallback to 'test-key'
- **Location**: `.github/workflows/e2e.yml`
- **Rationale**: Prevents model extension loading failures during test execution

## Testing
- ✅ Unit tests continue to pass
- ✅ Build completes successfully
- ✅ Changes follow project conventions (conventional commits + changeset)

## Root Cause
These issues occurred because:
1. Docker network setup timing was insufficient for reliable container IP assignment
2. E2E tests required valid API key configuration but workflow lacked test credentials

The fixes address both underlying timing and configuration issues while maintaining test isolation.