### PR TITLE
Fix Docker image build failure detection in E2E tests

### DIFF
--- a/.changeset/fix-docker-build-logging.md
+++ b/.changeset/fix-docker-build-logging.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fix Docker image build failure detection in E2E tests. Added proper error logging and verification of required build artifacts before building Docker images. This prevents silent failures when build dependencies are missing and provides clear error messages when Docker builds fail. Closes #307.

--- a/packages/e2e/src/harness.ts
+++ b/packages/e2e/src/harness.ts
@@ -313,6 +313,27 @@ export class E2ETestContext {
       throw new Error(`Dockerfile not found: ${absoluteDockerfilePath}`);
     }
     
+    // Verify required build artifacts exist for local image
+    if (imageName === "action-llama-local") {
+      const requiredPaths = [
+        'packages/action-llama/dist',
+        'packages/action-llama/package.json',
+        'packages/shared/dist',
+        'packages/shared/package.json'
+      ];
+      
+      for (const requiredPath of requiredPaths) {
+        const absolutePath = path.join(repoRoot, requiredPath);
+        try {
+          await fs.access(absolutePath);
+        } catch (error) {
+          throw new Error(`Required build artifact not found: ${requiredPath}. Run 'npm run build' first.`);
+        }
+      }
+    }
+    
+    console.log(`Building Docker image ${imageName}:latest from ${dockerfilePath}...`);
+    
     const tarStream = tar.pack(repoRoot);
     const stream = await this.docker.buildImage(
       tarStream,
@@ -323,9 +344,24 @@ export class E2ETestContext {
     );
     
     return new Promise<void>((resolve, reject) => {
-      this.docker.modem.followProgress(stream, (err) => {
-        if (err) reject(err);
-        else resolve();
+      this.docker.modem.followProgress(stream, (err, output) => {
+        if (output) {
+          output.forEach((event: any) => {
+            if (event.stream) {
+              console.log(`[${imageName}] ${event.stream.trim()}`);
+            }
+            if (event.error) {
+              console.error(`[${imageName}] Docker build error:`, event.error);
+            }
+          });
+        }
+        if (err) {
+          console.error(`[${imageName}] Docker build failed:`, err);
+          reject(err);
+        } else {
+          console.log(`[${imageName}] Docker image built successfully`);
+          resolve();
+        }
       });
     });
   }


### PR DESCRIPTION
Closes #307

This PR improves Docker image build error detection in the E2E test harness by:

1. **Adding proper error logging** to the `buildImage()` method to capture Docker build output and errors that were previously swallowed
2. **Verifying required build artifacts exist** before building Docker images (specifically checking for `packages/action-llama/dist` and `packages/shared/dist`)
3. **Adding console logging** to track build progress and make debugging easier

## Problem
The E2E tests were failing with "Docker image 'action-llama-local:latest' not found" errors because Docker builds were failing silently. The error handler in `buildImage()` was not capturing the actual build output or errors, making it impossible to diagnose why builds were failing.

## Solution
Enhanced the `buildImage()` method in `packages/e2e/src/harness.ts` to:
- Capture and log Docker build output streams
- Log any Docker build errors
- Verify that required build artifacts exist before attempting to build
- Provide clear error messages when dependencies are missing

## Testing
- ✅ Unit tests pass
- ✅ Build artifacts verified to exist
- ✅ Enhanced error logging will help identify future build issues

This should resolve the CI failures and provide better debugging information for future Docker build issues in the E2E test suite.