### PR TITLE
Fix Docker network IP assignment failure in E2E tests

### DIFF
--- a/.changeset/fix-e2e-docker-network.md
+++ b/.changeset/fix-e2e-docker-network.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fixed Docker network IP assignment failure in E2E tests. Containers were incorrectly connecting to the default bridge network instead of the custom `action-llama-e2e` network due to improper `NetworkMode` configuration. Moved `NetworkMode` to `HostConfig` and added explicit network connection after container start to ensure proper network attachment. Closes #309.

--- a/packages/e2e/src/harness.ts
+++ b/packages/e2e/src/harness.ts
@@ -88,6 +88,15 @@ export class E2ETestContext {
     if (!e2eNetwork) {
       throw new Error('E2E test network not found. Ensure global setup has run.');
     }
+    
+    // Verify network is properly configured
+    const network = await this.docker.getNetwork(e2eNetwork.Id).inspect();
+    console.log('E2E Network details:', {
+      id: network.Id,
+      name: network.Name,
+      driver: network.Driver,
+      ipam: network.IPAM
+    });
   }
 
   async createLocalActionLlamaContainer(): Promise<ContainerInfo> {
@@ -102,7 +111,6 @@ export class E2ETestContext {
     const container = await this.docker.createContainer({
       Image: "action-llama-local:latest",
       name: containerName,
-      NetworkMode: "action-llama-e2e",
       Env: [
         "NODE_ENV=test",
         "AL_TEST_MODE=1",
@@ -112,9 +120,18 @@ export class E2ETestContext {
       ],
       WorkingDir: "/app",
       Cmd: ["tail", "-f", "/dev/null"], // Keep container running
+      HostConfig: {
+        NetworkMode: "action-llama-e2e",
+      },
     });
 
     await container.start();
+    
+    // Connect to the custom network explicitly
+    const network = this.docker.getNetwork("action-llama-e2e");
+    await network.connect({
+      Container: container.id,
+    });
     
     // Wait for container to be fully started and connected to network
     await new Promise(resolve => setTimeout(resolve, 15000));
@@ -156,7 +173,6 @@ export class E2ETestContext {
     const container = await this.docker.createContainer({
       Image: "action-llama-vps:latest",
       name: containerName,
-      NetworkMode: "action-llama-e2e",
       Privileged: true, // Needed for Docker-in-Docker
       Env: [
         "SSH_ENABLE_ROOT=true",
@@ -166,6 +182,7 @@ export class E2ETestContext {
         Binds: [
           `${authorizedKeysPath}:/root/.ssh/authorized_keys:ro`,
         ],
+        NetworkMode: "action-llama-e2e",
       },
       ExposedPorts: {
         "22/tcp": {},
@@ -174,6 +191,12 @@ export class E2ETestContext {
     });
 
     await container.start();
+    
+    // Connect to the custom network explicitly
+    const network = this.docker.getNetwork("action-llama-e2e");
+    await network.connect({
+      Container: container.id,
+    });
     
     // Wait for container to be fully started and connected to network
     await new Promise(resolve => setTimeout(resolve, 15000));


### PR DESCRIPTION
Closes #309

## Problem

The E2E tests were failing because Docker containers created for VPS testing were not getting IP addresses assigned from the custom network. The containers were incorrectly connecting to the default bridge network instead of the custom `action-llama-e2e` network.

Error output:
```
Error: Failed to get IP address for container action-llama-e2e-vps-cd0c3340 after 10 attempts
```

## Root Cause

The containers were being created with `NetworkMode: "action-llama-e2e"` at the top level, but the Docker API expects this to be inside the `HostConfig` object for proper network attachment.

## Solution

1. **Fixed container network configuration**: Moved `NetworkMode` from the top level to `HostConfig` for both VPS and local containers
2. **Added explicit network connection**: After starting containers, explicitly connect them to the custom network to ensure proper attachment
3. **Enhanced network verification**: Added detailed logging for network configuration to help with future debugging

## Changes

- `packages/e2e/src/harness.ts`: Updated container creation in both `createVPSContainer` and `createLocalActionLlamaContainer` methods
- Added changeset documenting the fix

## Validation

- All unit tests pass ✅
- Build completes successfully ✅
- TypeScript compilation succeeds ✅
- Changes follow existing code patterns and project conventions ✅

The E2E tests cannot be run in this environment due to Docker unavailability, but the fix addresses the specific network configuration issue identified in the failure logs.