### PR TITLE
fix: remove redundant Docker network connections in E2E tests

### DIFF
--- a/packages/e2e/src/harness.ts
+++ b/packages/e2e/src/harness.ts
@@ -127,12 +127,6 @@ export class E2ETestContext {
 
     await container.start();
     
-    // Connect to the custom network explicitly
-    const network = this.docker.getNetwork("action-llama-e2e");
-    await network.connect({
-      Container: container.id,
-    });
-    
     // Wait for container to be fully started and connected to network
     await new Promise(resolve => setTimeout(resolve, 15000));
     
@@ -191,12 +185,6 @@ export class E2ETestContext {
     });
 
     await container.start();
-    
-    // Connect to the custom network explicitly
-    const network = this.docker.getNetwork("action-llama-e2e");
-    await network.connect({
-      Container: container.id,
-    });
     
     // Wait for container to be fully started and connected to network
     await new Promise(resolve => setTimeout(resolve, 15000));


### PR DESCRIPTION
Closes #311

This PR fixes the E2E test failures caused by attempting to connect Docker containers to networks twice:

- Containers were already being connected via `NetworkMode: "action-llama-e2e"` in their HostConfig
- The code was also explicitly calling `network.connect()` after container startup
- Docker automatically connects containers to networks specified in NetworkMode when they start
- The explicit connect() calls were causing "endpoint already exists in network" errors

## Changes

- Removed redundant `network.connect()` calls from both `createLocalActionLlamaContainer()` and `createVPSContainer()` methods in `packages/e2e/src/harness.ts`

The containers will continue to be properly connected to the `action-llama-e2e` network via the NetworkMode configuration, but without the duplicate connection attempts that were causing the CI failures.