### PR TITLE
Fix E2E tests Docker network connectivity regression

### DIFF
--- a/.changeset/fix-e2e-docker-network.md
+++ b/.changeset/fix-e2e-docker-network.md
@@ -2,4 +2,4 @@
 "@action-llama/action-llama": patch
 ---
 
-Fixed Docker network IP assignment failure in E2E tests. Containers were incorrectly connecting to the default bridge network instead of the custom `action-llama-e2e` network due to improper `NetworkMode` configuration. Moved `NetworkMode` to `HostConfig` and added explicit network connection after container start to ensure proper network attachment. Closes #309.
+Fix E2E tests Docker network connectivity by restoring explicit network connection calls. This resolves the regression introduced in commit 2987ecc where containers were not properly connecting to the custom network, causing SSH connection timeouts and scheduler startup failures. Closes #313.

--- a/packages/e2e/src/harness.ts
+++ b/packages/e2e/src/harness.ts
@@ -127,6 +127,12 @@ export class E2ETestContext {
 
     await container.start();
     
+    // Connect to the custom network explicitly
+    const network = this.docker.getNetwork("action-llama-e2e");
+    await network.connect({
+      Container: container.id,
+    });
+    
     // Wait for container to be fully started and connected to network
     await new Promise(resolve => setTimeout(resolve, 15000));
     
@@ -185,6 +191,12 @@ export class E2ETestContext {
     });
 
     await container.start();
+    
+    // Connect to the custom network explicitly
+    const vpsNetwork = this.docker.getNetwork("action-llama-e2e");
+    await vpsNetwork.connect({
+      Container: container.id,
+    });
     
     // Wait for container to be fully started and connected to network
     await new Promise(resolve => setTimeout(resolve, 15000));


### PR DESCRIPTION
Closes #313

## Summary

This PR fixes the E2E tests Docker network connectivity regression that was introduced in commit 2987ecc. The issue was causing SSH connection timeouts and scheduler startup failures in the E2E test suite.

## Root Cause

The problem occurred when explicit `network.connect()` calls were removed from the E2E test harness, assuming that setting `NetworkMode: "action-llama-e2e"` in the container's HostConfig would be sufficient. However, this change broke network connectivity for containers.

## Solution

Restored the explicit network connection calls in both:
- `createLocalActionLlamaContainer()` method 
- `createVPSContainer()` method

The fix ensures that containers are properly connected to the custom network after starting, which allows SSH connections and proper IP assignment to work correctly.

## Testing

- ✅ Build passes
- ✅ Unit tests pass (1331 tests)
- ✅ TypeScript compilation successful

This change specifically addresses the Docker networking issues mentioned in the CI failure report and should resolve the E2E test failures.