### PR TITLE
Fix E2E test Docker network connection conflict

### DIFF
--- a/packages/e2e/src/harness.ts
+++ b/packages/e2e/src/harness.ts
@@ -127,12 +127,6 @@ export class E2ETestContext {
 
     await container.start();
     
-    // Connect to the custom network explicitly
-    const network = this.docker.getNetwork("action-llama-e2e");
-    await network.connect({
-      Container: container.id,
-    });
-    
     // Wait for container to be fully started and connected to network
     await new Promise(resolve => setTimeout(resolve, 15000));
     
@@ -191,12 +185,6 @@ export class E2ETestContext {
     });
 
     await container.start();
-    
-    // Connect to the custom network explicitly
-    const vpsNetwork = this.docker.getNetwork("action-llama-e2e");
-    await vpsNetwork.connect({
-      Container: container.id,
-    });
     
     // Wait for container to be fully started and connected to network
     await new Promise(resolve => setTimeout(resolve, 15000));


### PR DESCRIPTION
Closes #315

This PR fixes the CI failure in E2E tests where containers were being double-connected to the action-llama-e2e Docker network.

## Problem

The recent commit c5a9d945 added explicit `network.connect()` calls to ensure containers were connected to the custom network. However, containers were already being connected via the `NetworkMode: "action-llama-e2e"` parameter during creation, causing duplicate connection attempts and the error:

```
Error: (HTTP code 403) unexpected - endpoint with name action-llama-e2e-local-[ID] already exists in network action-llama-e2e
```

## Solution

Removed the redundant `network.connect()` calls in `packages/e2e/src/harness.ts` from both:
- `createLocalActionLlamaContainer()`
- `createVPSContainer()`

Since containers are automatically connected to the network when created with `NetworkMode`, the explicit connection calls are unnecessary and cause conflicts.

## Validation

- ✅ Build passes
- ✅ Unit tests pass (1331 passed)
- ✅ No breaking changes to existing functionality

The fix removes exactly the redundant code that was causing the CI failures.