### PR TITLE
Docs: rename configuration page titles

### DIFF
--- a/packages/docs/reference/agent-config.mdx
+++ b/packages/docs/reference/agent-config.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Agent Configuration Reference"
+title: "Agent Configuration"
 description: "Complete reference for agent configuration: SKILL.md (portable metadata) and config.toml (runtime config)"
 ---
 

--- a/packages/docs/reference/project-config.mdx
+++ b/packages/docs/reference/project-config.mdx
@@ -1,5 +1,5 @@
 ---
-title: "config.toml Reference"
+title: "Project Configuration"
 description: "Project-level configuration reference — all fields and sections"
 ---
 


### PR DESCRIPTION
Closes #332

## Changes

- Renamed project config page title from "config.toml Reference" to "Project Configuration" in `reference/project-config.mdx`
- Renamed agent config page title from "Agent Configuration Reference" to "Agent Configuration" in `reference/agent-config.mdx`