### PR TITLE
feat: navigate to instance page after triggering agent from web UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "action-llama",
+  "name": "repo",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -12139,7 +12139,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.17.7",
+      "version": "0.18.1",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
@@ -12185,7 +12185,7 @@
     },
     "packages/e2e": {
       "name": "@action-llama/e2e",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
         "@action-llama/action-llama": "*",
         "@action-llama/shared": "*",

--- a/packages/action-llama/src/agents/container-runner.ts
+++ b/packages/action-llama/src/agents/container-runner.ts
@@ -136,7 +136,7 @@ export class ContainerAgentRunner {
     }
   }
 
-  async run(prompt: string, triggerInfo?: { type: 'schedule' | 'manual' | 'webhook' | 'agent'; source?: string }): Promise<RunOutcome> {
+  async run(prompt: string, triggerInfo?: { type: 'schedule' | 'manual' | 'webhook' | 'agent'; source?: string }, instanceId?: string): Promise<RunOutcome> {
     if (this._running) {
       this.logger.warn(`${this.agentConfig.name} is already running, skipping`);
       return { result: "error", triggers: [] };
@@ -145,9 +145,8 @@ export class ContainerAgentRunner {
     this._running = true;
     this._aborting = false;
 
-    // Generate a unique instance ID for this run
-    const runId = randomBytes(4).toString("hex");
-    this.instanceId = `${this.agentConfig.name}-${runId}`;
+    // Generate a unique instance ID for this run (or use the pre-generated one)
+    this.instanceId = instanceId ?? `${this.agentConfig.name}-${randomBytes(4).toString("hex")}`;
     this.logger = this.baseLogger.child({ instance: this.instanceId });
 
     return await withSpan(

--- a/packages/action-llama/src/agents/runner.ts
+++ b/packages/action-llama/src/agents/runner.ts
@@ -70,7 +70,7 @@ export class AgentRunner {
     this.abortController.abort();
   }
 
-  async run(prompt: string, triggerInfo?: { type: 'schedule' | 'manual' | 'webhook' | 'agent'; source?: string }): Promise<RunOutcome> {
+  async run(prompt: string, triggerInfo?: { type: 'schedule' | 'manual' | 'webhook' | 'agent'; source?: string }, instanceId?: string): Promise<RunOutcome> {
     if (this.running) {
       this.logger.warn(`${this.agentConfig.name} is already running, skipping`);
       return { result: "error", triggers: [] };
@@ -78,9 +78,8 @@ export class AgentRunner {
 
     this.running = true;
 
-    // Generate a unique instance ID for this run
-    const runId = randomBytes(4).toString("hex");
-    this.instanceId = `${this.agentConfig.name}-${runId}`;
+    // Generate a unique instance ID for this run (or use the pre-generated one)
+    this.instanceId = instanceId ?? `${this.agentConfig.name}-${randomBytes(4).toString("hex")}`;
     this.logger = this.baseLogger.child({ instance: this.instanceId });
 
     const runReason = triggerInfo

--- a/packages/action-llama/src/control/routes/control.ts
+++ b/packages/action-llama/src/control/routes/control.ts
@@ -8,7 +8,7 @@ export interface ControlRoutesDeps {
   killAgent: (name: string) => Promise<{ killed: number } | null>;
   pauseScheduler: () => Promise<void>;
   resumeScheduler: () => Promise<void>;
-  triggerAgent?: (name: string, prompt?: string) => Promise<true | string>;
+  triggerAgent?: (name: string, prompt?: string) => Promise<{ instanceId: string } | string>;
   enableAgent?: (name: string) => Promise<boolean>;
   disableAgent?: (name: string) => Promise<boolean>;
   stopScheduler?: () => Promise<void>;
@@ -107,12 +107,14 @@ export function registerControlRoutes(app: Hono, deps: ControlRoutesDeps) {
     }
     try {
       const result = await deps.triggerAgent(name, prompt);
-      if (result === true) {
-        return c.json({ success: true, message: `Agent ${name} triggered` });
-      } else {
+      if (typeof result === "object" && result.instanceId) {
+        return c.json({ success: true, message: `Agent ${name} triggered`, instanceId: result.instanceId });
+      } else if (typeof result === "string") {
         logger?.warn({ agent: name, reason: result }, "control: trigger rejected");
         const status = result.includes("not found") ? 404 : 409;
         return c.json({ error: result }, status);
+      } else {
+        return c.json({ success: true, message: `Agent ${name} triggered` });
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/packages/action-llama/src/execution/execution.ts
+++ b/packages/action-llama/src/execution/execution.ts
@@ -80,7 +80,8 @@ export async function executeRun(
   runner: PoolRunner, prompt: string,
   triggerInfo: { type: 'schedule' | 'manual' | 'webhook' | 'agent'; source?: string; receiptId?: string },
   agentName: string, depth: number, ctx: SchedulerContext,
-  instanceLifecycle?: InstanceLifecycle
+  instanceLifecycle?: InstanceLifecycle,
+  instanceId?: string
 ): Promise<{ result: string; triggers: Array<{ agent: string; context: string }>; returnValue?: string }> {
   const startedAt = Date.now();
 
@@ -96,7 +97,7 @@ export async function executeRun(
   let outcome: any;
   let error: string | undefined;
   try {
-    outcome = await runner.run(prompt, triggerInfo);
+    outcome = await runner.run(prompt, triggerInfo, instanceId);
     error = outcome.exitReason;
   } catch (err) {
     error = err instanceof Error ? err.message : String(err);
@@ -315,7 +316,7 @@ function fireQueuedItem(
 }
 
 export async function runWithReruns(
-  runner: PoolRunner, agentConfig: AgentConfig, depth: number, ctx: SchedulerContext, prompt?: string
+  runner: PoolRunner, agentConfig: AgentConfig, depth: number, ctx: SchedulerContext, prompt?: string, instanceId?: string
 ): Promise<void> {
   const isManual = prompt !== undefined;
   const triggerType = isManual ? 'manual' as const : 'schedule' as const;
@@ -331,7 +332,7 @@ export async function runWithReruns(
     : makeScheduledPrompt(agentConfig, ctx);
 
   let { result } = await executeRun(
-    runner, initialPrompt, { type: triggerType, source: prompt ? 'user-prompt' : undefined }, agentConfig.name, depth, ctx, instanceLifecycle
+    runner, initialPrompt, { type: triggerType, source: prompt ? 'user-prompt' : undefined }, agentConfig.name, depth, ctx, instanceLifecycle, instanceId
   );
 
   let reruns = 0;

--- a/packages/action-llama/src/execution/runner-pool.ts
+++ b/packages/action-llama/src/execution/runner-pool.ts
@@ -7,7 +7,7 @@ export interface PoolRunner {
   isRunning: boolean;
   instanceId: string;
   abort?(): void;
-  run(prompt: string, triggerInfo?: { type: 'schedule' | 'manual' | 'webhook' | 'agent'; source?: string }): Promise<any>;
+  run(prompt: string, triggerInfo?: { type: 'schedule' | 'manual' | 'webhook' | 'agent'; source?: string }, instanceId?: string): Promise<any>;
 }
 
 export class RunnerPool {

--- a/packages/action-llama/src/scheduler/gateway-setup.ts
+++ b/packages/action-llama/src/scheduler/gateway-setup.ts
@@ -19,6 +19,7 @@ import { ensureGatewayApiKey } from "../control/api-key.js";
 import type { SchedulerEventBus } from "./events.js";
 import type { SchedulerState } from "./state.js";
 import { runWithReruns } from "../execution/execution.js";
+import { randomBytes } from "node:crypto";
 import type { ContainerRuntime } from "../docker/runtime.js";
 import { ChatContainerLauncher } from "../chat/container-launcher.js";
 
@@ -131,7 +132,7 @@ export async function setupGateway(opts: {
         statusTracker?.setPaused(false);
         logger.info("Scheduler resumed via control API");
       },
-      triggerAgent: async (name: string, prompt?: string): Promise<true | string> => {
+      triggerAgent: async (name: string, prompt?: string): Promise<{ instanceId: string } | string> => {
         if (statusTracker?.isPaused()) return "Scheduler is paused";
         const pool = state.runnerPools[name];
         if (!pool) return `Agent "${name}" not found`;
@@ -140,11 +141,12 @@ export async function setupGateway(opts: {
         const config = agentConfigs.find((a) => a.name === name);
         if (!config) return `Agent "${name}" config not found`;
         if (!state.schedulerCtx) return "Scheduler is not ready";
-        logger.info({ agent: name, hasPrompt: !!prompt }, "manual trigger via control API");
-        runWithReruns(runner, config, 0, state.schedulerCtx, prompt).catch((err) => {
+        const instanceId = `${name}-${randomBytes(4).toString("hex")}`;
+        logger.info({ agent: name, hasPrompt: !!prompt, instanceId }, "manual trigger via control API");
+        runWithReruns(runner, config, 0, state.schedulerCtx, prompt, instanceId).catch((err) => {
           logger.error({ err, agent: name }, "manual trigger run failed");
         });
-        return true;
+        return { instanceId };
       },
       enableAgent: async (name: string) => {
         if (!statusTracker) return false;

--- a/packages/action-llama/test/control/routes/control.test.ts
+++ b/packages/action-llama/test/control/routes/control.test.ts
@@ -24,7 +24,7 @@ function setup(overrides?: Partial<ControlRoutesDeps>) {
     killAgent: vi.fn(async () => null),
     pauseScheduler: vi.fn(async () => {}),
     resumeScheduler: vi.fn(async () => {}),
-    triggerAgent: vi.fn(async () => "Agent not found"),
+    triggerAgent: vi.fn(async () => "Agent not found" as string),
     enableAgent: vi.fn(async () => false),
     disableAgent: vi.fn(async () => false),
     ...overrides,
@@ -165,15 +165,18 @@ describe("POST /control/stop", () => {
 
 describe("POST /control/trigger/:name", () => {
   it("triggers agent without prompt when no body", async () => {
-    const triggerAgent = vi.fn(async () => true as const);
+    const triggerAgent = vi.fn(async () => ({ instanceId: "agent-a-abc123" }));
     const { app } = setup({ triggerAgent });
     const res = await app.request("/control/trigger/agent-a", { method: "POST" });
     expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.instanceId).toBe("agent-a-abc123");
     expect(triggerAgent).toHaveBeenCalledWith("agent-a", undefined);
   });
 
   it("passes prompt from JSON body to triggerAgent", async () => {
-    const triggerAgent = vi.fn(async () => true as const);
+    const triggerAgent = vi.fn(async () => ({ instanceId: "agent-a-abc123" }));
     const { app } = setup({ triggerAgent });
     const res = await app.request("/control/trigger/agent-a", {
       method: "POST",
@@ -181,11 +184,13 @@ describe("POST /control/trigger/:name", () => {
       body: JSON.stringify({ prompt: "review PR #42" }),
     });
     expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.instanceId).toBe("agent-a-abc123");
     expect(triggerAgent).toHaveBeenCalledWith("agent-a", "review PR #42");
   });
 
   it("ignores empty/whitespace prompt", async () => {
-    const triggerAgent = vi.fn(async () => true as const);
+    const triggerAgent = vi.fn(async () => ({ instanceId: "agent-a-abc123" }));
     const { app } = setup({ triggerAgent });
     const res = await app.request("/control/trigger/agent-a", {
       method: "POST",
@@ -193,6 +198,8 @@ describe("POST /control/trigger/:name", () => {
       body: JSON.stringify({ prompt: "   " }),
     });
     expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.instanceId).toBe("agent-a-abc123");
     expect(triggerAgent).toHaveBeenCalledWith("agent-a", undefined);
   });
 });

--- a/packages/action-llama/test/execution/execution.test.ts
+++ b/packages/action-llama/test/execution/execution.test.ts
@@ -71,7 +71,7 @@ describe("executeRun", () => {
 
     expect(result).toBe("completed");
     expect(triggers).toEqual([{ agent: "b", context: "hi" }]);
-    expect(runner.run).toHaveBeenCalledWith("prompt", { type: "schedule" });
+    expect(runner.run).toHaveBeenCalledWith("prompt", { type: "schedule" }, undefined);
   });
 
   it("handles runs with no triggers", async () => {

--- a/packages/frontend/src/components/RunModal.tsx
+++ b/packages/frontend/src/components/RunModal.tsx
@@ -7,7 +7,7 @@ export function RunModal({
 }: {
   agentName: string;
   onClose: () => void;
-  onRun: (prompt?: string) => void;
+  onRun: (prompt?: string) => void | Promise<unknown>;
 }) {
   const [prompt, setPrompt] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -285,8 +285,8 @@ export function getInstanceLogs(
 
 // --- Control operations ---
 
-export function triggerAgent(name: string, prompt?: string) {
-  return ctrlPost(
+export function triggerAgent(name: string, prompt?: string): Promise<{ success: boolean; message?: string; instanceId?: string }> {
+  return ctrlPost<{ success: boolean; message?: string; instanceId?: string }>(
     `/control/trigger/${encodeURIComponent(name)}`,
     prompt ? { prompt } : undefined,
   );

--- a/packages/frontend/src/pages/AgentDetailPage.tsx
+++ b/packages/frontend/src/pages/AgentDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams, Link, useNavigate } from "react-router-dom";
 import { useStatusStream } from "../hooks/StatusStreamContext";
 import { useInvalidation } from "../hooks/useInvalidation";
 import { StatCard } from "../components/StatCard";
@@ -59,6 +59,7 @@ function formatLogEntry(entry: LogEntry): {
 
 export function AgentDetailPage() {
   const { name } = useParams<{ name: string }>();
+  const navigate = useNavigate();
   const { agents, instances } = useStatusStream();
   const [detail, setDetail] = useState<AgentDetailData | null>(null);
   const [runs, setRuns] = useState<RunRecord[]>([]);
@@ -476,9 +477,16 @@ export function AgentDetailPage() {
         <RunModal
           agentName={name}
           onClose={() => setShowRunModal(false)}
-          onRun={(prompt) =>
-            handleAction(() => triggerAgent(name, prompt))
-          }
+          onRun={async (prompt) => {
+            try {
+              const result = await triggerAgent(name, prompt);
+              if (result?.instanceId) {
+                navigate(`/dashboard/agents/${encodeURIComponent(name)}/instances/${encodeURIComponent(result.instanceId)}`);
+              }
+            } catch (err) {
+              setActionError(err instanceof Error ? err.message : "Action failed");
+            }
+          }}
         />
       )}
     </div>

--- a/packages/frontend/src/pages/DashboardPage.tsx
+++ b/packages/frontend/src/pages/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useStatusStream } from "../hooks/StatusStreamContext";
 import { useInvalidation } from "../hooks/useInvalidation";
 import { StateBadge, TriggerTypeBadge, ResultBadge } from "../components/Badge";
@@ -88,6 +88,7 @@ function ActionMenu({
 }
 
 export function DashboardPage() {
+  const navigate = useNavigate();
   const { agents, schedulerInfo } = useStatusStream();
   const [triggers, setTriggers] = useState<TriggerHistoryRow[]>([]);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -481,9 +482,17 @@ export function DashboardPage() {
         <RunModal
           agentName={runModalAgent}
           onClose={() => setRunModalAgent(null)}
-          onRun={(prompt) =>
-            handleAction(() => triggerAgent(runModalAgent, prompt))
-          }
+          onRun={async (prompt) => {
+            const agentName = runModalAgent;
+            try {
+              const result = await triggerAgent(agentName, prompt);
+              if (result?.instanceId) {
+                navigate(`/dashboard/agents/${encodeURIComponent(agentName)}/instances/${encodeURIComponent(result.instanceId)}`);
+              }
+            } catch (err) {
+              setActionError(err instanceof Error ? err.message : "Action failed");
+            }
+          }}
         />
       )}
     </div>


### PR DESCRIPTION
Closes #328

## Summary

When a user clicks "Run" in the web UI (from either the Dashboard or Agent Detail page), they are now automatically navigated to the new instance's detail page so they can watch the logs in real time.

## Changes

### Backend
- ** / **: Accept an optional pre-generated `instanceId` in `run()`. If provided, use it directly; otherwise generate one as before.
- ****: Updated `PoolRunner` interface to include the optional `instanceId` parameter.
- ****: Thread `instanceId` through `executeRun()` and `runWithReruns()` — only the first run uses the pre-generated ID; reruns generate their own.
- ****: Updated `triggerAgent` type from `Promise<true | string>` to `Promise<{ instanceId: string } | string>`. Route handler now returns `instanceId` in the JSON response.
- ****: Pre-generates the instance ID before firing the async run, then returns `{ instanceId }`.

### Frontend
- ****: Updated `triggerAgent()` return type to include `instanceId?: string`.
- ****: `onRun` prop now accepts `void | Promise<unknown>`.
- **** / ****: Navigate to `/dashboard/agents/:name/instances/:instanceId` after a successful trigger.

### Tests
- ****: Updated trigger test mocks to return `{ instanceId }` and assert `instanceId` in response body.
- ****: Updated `runner.run` call assertion to include the new `instanceId` parameter.

## Notes

- The instance page already handles the brief moment where the run hasn't fully started yet — it shows a "running" state and polls for logs.
- Only the first run in `runWithReruns` uses the pre-generated ID; reruns generate their own IDs (they are separate instances).
- Pre-existing test failures in `dashboard-auth.test.ts` and `auth-logs.test.ts` are unrelated to this change.