### PR TITLE
fix: correct agent runner count display in Web UI

### DIFF
--- a/.changeset/fix-agent-runner-count-display.md
+++ b/.changeset/fix-agent-runner-count-display.md
@@ -1,0 +1,9 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fix agent runners showing wrong running count in the Web UI dashboard.
+
+When a project-wide `scale` cap throttled individual agent pools, the status tracker still showed the original uncapped scale — causing displays like "3/4" when all runners were active. The tracker is now synced with actual pool sizes after runner pool creation.
+
+Additionally, hot-reload scale changes now use `updateAgentScale` instead of re-registering the agent (which reset the running count to zero), and the "idle" state is no longer set unconditionally at the end of a hot reload when runners are still active. The `startRun` running-count clamp at `scale` has also been removed so the count reflects reality during scale transitions. Closes #331.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "action-llama",
+  "name": "repo",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -12139,7 +12139,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.17.7",
+      "version": "0.18.1",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
@@ -12185,7 +12185,7 @@
     },
     "packages/e2e": {
       "name": "@action-llama/e2e",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
         "@action-llama/action-llama": "*",
         "@action-llama/shared": "*",

--- a/packages/action-llama/src/execution/runner-setup.ts
+++ b/packages/action-llama/src/execution/runner-setup.ts
@@ -16,6 +16,8 @@ import { RunnerPool, type PoolRunner } from "./runner-pool.js";
 export interface RunnerSetupResult {
   runnerPools: Record<string, RunnerPool>;
   createRunner: (agentConfig: AgentConfig, image: string) => PoolRunner;
+  /** Actual pool sizes after project-wide scale cap is applied. */
+  actualScales: Record<string, number>;
 }
 
 export interface RunnerSetupOpts {
@@ -114,6 +116,7 @@ export async function createRunnerPools(opts: RunnerSetupOpts): Promise<RunnerSe
   }
 
   const runnerPools: Record<string, RunnerPool> = {};
+  const actualScales: Record<string, number> = {};
 
   for (const agentConfig of adjustedConfigs) {
     const scale = agentConfig.scale ?? defaultScale;
@@ -124,8 +127,9 @@ export async function createRunnerPools(opts: RunnerSetupOpts): Promise<RunnerSe
     }
 
     runnerPools[agentConfig.name] = new RunnerPool(runners);
+    actualScales[agentConfig.name] = scale;
     logger.info({ agent: agentConfig.name, scale }, "Created runner pool");
   }
 
-  return { runnerPools, createRunner };
+  return { runnerPools, createRunner, actualScales };
 }

--- a/packages/action-llama/src/scheduler/index.ts
+++ b/packages/action-llama/src/scheduler/index.ts
@@ -154,11 +154,23 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
   setChatRuntime(runtime, agentImages);
 
   // Create runner pools
-  const { runnerPools, createRunner } = await createRunnerPools({
+  const { runnerPools, createRunner, actualScales } = await createRunnerPools({
     globalConfig, agentConfigs, runtime, agentRuntimeOverrides,
     agentImages, baseImage, gatewayPort, registerContainer, unregisterContainer,
     statusTracker, mkLogger, projectPath, logger,
   });
+
+  // Sync status tracker with actual pool sizes (may differ from configured scale
+  // when a project-wide scale cap throttles individual agents)
+  if (statusTracker) {
+    for (const [agentName, actualScale] of Object.entries(actualScales)) {
+      const registeredScale = statusTracker.getAgentScale(agentName);
+      if (registeredScale !== actualScale) {
+        statusTracker.updateAgentScale(agentName, actualScale);
+        logger.info({ agent: agentName, registeredScale, actualScale }, "synced status tracker scale with actual pool size");
+      }
+    }
+  }
 
   // Populate late-binding state
   Object.assign(state.runnerPools, runnerPools);

--- a/packages/action-llama/src/scheduler/watcher.ts
+++ b/packages/action-llama/src/scheduler/watcher.ts
@@ -341,10 +341,10 @@ export function watchAgents(ctx: HotReloadContext): WatcherHandle {
         for (let i = oldScale; i < newScale; i++) {
           pool.addRunner(ctx.createRunner(newConfig, image));
         }
-        ctx.statusTracker?.registerAgent(agentName, newScale);
+        ctx.statusTracker?.updateAgentScale(agentName, newScale);
       } else if (newScale < oldScale) {
         pool.shrinkTo(newScale);
-        ctx.statusTracker?.registerAgent(agentName, newScale);
+        ctx.statusTracker?.updateAgentScale(agentName, newScale);
       }
     }
 
@@ -387,7 +387,13 @@ export function watchAgents(ctx: HotReloadContext): WatcherHandle {
       }
     }
 
-    ctx.statusTracker?.setAgentState(agentName, "idle");
+    // Only transition to idle if no runners are currently active. This avoids
+    // overriding the "running" state when instances are still in-flight after
+    // a hot reload.
+    const currentAgent = ctx.statusTracker?.getAllAgents?.().find(a => a.name === agentName);
+    if (!currentAgent || currentAgent.runningCount === 0) {
+      ctx.statusTracker?.setAgentState(agentName, "idle");
+    }
     ctx.statusTracker?.addLogLine(agentName, "hot-reloaded");
     ctx.logger.info({ agent: agentName }, "hot reload: agent updated");
   }

--- a/packages/action-llama/src/tui/status-tracker.ts
+++ b/packages/action-llama/src/tui/status-tracker.ts
@@ -144,7 +144,7 @@ export class StatusTracker extends EventEmitter {
     const agent = this.agents.get(name);
     if (!agent) return;
 
-    agent.runningCount = Math.min(agent.runningCount + 1, agent.scale);
+    agent.runningCount += 1;
     agent.state = "running";
     agent.statusText = null;
     agent.lastError = null;

--- a/packages/action-llama/test/execution/runner-setup.test.ts
+++ b/packages/action-llama/test/execution/runner-setup.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the container-runner dynamic import used inside createRunnerPools
+vi.mock("../../src/agents/container-runner.js", () => ({
+  ContainerAgentRunner: class MockContainerAgentRunner {
+    instanceId = "mock-runner";
+    isRunning = false;
+    async run() { return { result: "completed", triggers: [] }; }
+  },
+}));
+
+import { createRunnerPools } from "../../src/execution/runner-setup.js";
+import { StatusTracker } from "../../src/tui/status-tracker.js";
+import type { GlobalConfig, AgentConfig } from "../../src/shared/config.js";
+
+function makeLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any;
+}
+
+function makeGlobalConfig(overrides: Partial<GlobalConfig> = {}): GlobalConfig {
+  return {
+    name: "test-project",
+    models: {},
+    ...overrides,
+  } as GlobalConfig;
+}
+
+function makeAgentConfig(name: string, scale?: number): AgentConfig {
+  return {
+    name,
+    scale,
+    prompt: "test prompt",
+  } as AgentConfig;
+}
+
+function makeRuntime() {
+  return {
+    run: vi.fn(),
+    build: vi.fn(),
+    kill: vi.fn(),
+    remove: vi.fn(),
+    listRunningAgents: vi.fn().mockResolvedValue([]),
+    inspect: vi.fn(),
+  } as any;
+}
+
+describe("createRunnerPools", () => {
+  it("returns actualScales matching configured scale when no project cap", async () => {
+    const agentConfigs = [
+      makeAgentConfig("agent-a", 2),
+      makeAgentConfig("agent-b", 3),
+    ];
+
+    const { actualScales } = await createRunnerPools({
+      globalConfig: makeGlobalConfig(),
+      agentConfigs,
+      runtime: makeRuntime(),
+      agentRuntimeOverrides: {},
+      agentImages: { "agent-a": "img-a", "agent-b": "img-b" },
+      baseImage: "base:latest",
+      gatewayPort: 8080,
+      registerContainer: vi.fn(),
+      unregisterContainer: vi.fn(),
+      mkLogger: () => makeLogger() as any,
+      projectPath: "/tmp",
+      logger: makeLogger(),
+    });
+
+    expect(actualScales["agent-a"]).toBe(2);
+    expect(actualScales["agent-b"]).toBe(3);
+  });
+
+  it("returns actualScales after project-wide scale cap is applied", async () => {
+    // Project cap of 5 shared across two agents requesting 4 each (8 total)
+    const agentConfigs = [
+      makeAgentConfig("agent-a", 4),
+      makeAgentConfig("agent-b", 4),
+    ];
+
+    const { actualScales, runnerPools } = await createRunnerPools({
+      globalConfig: makeGlobalConfig({ scale: 5 }),
+      agentConfigs,
+      runtime: makeRuntime(),
+      agentRuntimeOverrides: {},
+      agentImages: {},
+      baseImage: "base:latest",
+      gatewayPort: 8080,
+      registerContainer: vi.fn(),
+      unregisterContainer: vi.fn(),
+      mkLogger: () => makeLogger() as any,
+      projectPath: "/tmp",
+      logger: makeLogger(),
+    });
+
+    // agent-a gets 4 (within remaining 5), agent-b gets capped to 1 (5-4=1)
+    expect(actualScales["agent-a"]).toBe(4);
+    expect(actualScales["agent-b"]).toBe(1);
+
+    // runnerPools should match
+    expect(runnerPools["agent-a"].size).toBe(4);
+    expect(runnerPools["agent-b"].size).toBe(1);
+  });
+
+  it("status tracker scale is updated when it differs from pool size", async () => {
+    const tracker = new StatusTracker();
+    // Register agent-a with scale=4 (as if configured before pool creation)
+    tracker.registerAgent("agent-a", 4);
+
+    const agentConfigs = [makeAgentConfig("agent-a", 4)];
+
+    const { actualScales } = await createRunnerPools({
+      globalConfig: makeGlobalConfig({ scale: 2 }),
+      agentConfigs,
+      runtime: makeRuntime(),
+      agentRuntimeOverrides: {},
+      agentImages: {},
+      baseImage: "base:latest",
+      gatewayPort: 8080,
+      registerContainer: vi.fn(),
+      unregisterContainer: vi.fn(),
+      statusTracker: tracker,
+      mkLogger: () => makeLogger() as any,
+      projectPath: "/tmp",
+      logger: makeLogger(),
+    });
+
+    // actualScales reflects the capped value
+    expect(actualScales["agent-a"]).toBe(2);
+
+    // The caller (scheduler/index.ts) is responsible for syncing the tracker
+    // using actualScales, which this test verifies the data is available for.
+    expect(actualScales["agent-a"]).not.toBe(4); // not the original configured value
+  });
+});

--- a/packages/action-llama/test/scheduler/index.test.ts
+++ b/packages/action-llama/test/scheduler/index.test.ts
@@ -452,6 +452,8 @@ describe("startScheduler", () => {
         on: vi.fn(),
         enableAgent: vi.fn(),
         disableAgent: vi.fn(),
+        getAgentScale: vi.fn().mockReturnValue(1),
+        updateAgentScale: vi.fn(),
       } as any;
     }
 

--- a/packages/action-llama/test/scheduler/watcher.test.ts
+++ b/packages/action-llama/test/scheduler/watcher.test.ts
@@ -110,12 +110,14 @@ function makeContext(overrides: Partial<HotReloadContext> = {}): HotReloadContex
     statusTracker: {
       registerAgent: vi.fn(),
       unregisterAgent: vi.fn(),
+      updateAgentScale: vi.fn(),
       setAgentState: vi.fn(),
       setAgentStatusText: vi.fn(),
       setAgentError: vi.fn(),
       setNextRunAt: vi.fn(),
       addLogLine: vi.fn(),
       isAgentEnabled: vi.fn(() => true),
+      getAllAgents: vi.fn(() => []),
     } as any,
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any,
     skills: { locking: true },
@@ -370,5 +372,80 @@ describe("watchAgents handler (via _handleAgentChange)", () => {
     // New cron job should have been created (schedule changed from "0 * * * *" to "*/10 * * * *")
     expect(ctx.cronJobs.length).toBeGreaterThan(0);
     expect(ctx.statusTracker!.setNextRunAt).toHaveBeenCalled();
+  });
+
+  it("hot reload scale change uses updateAgentScale (not registerAgent) to preserve running state", async () => {
+    const runner = makeMockRunner("agent-a");
+    const pool = new RunnerPool([runner]);
+    const ctx = makeContext({ runnerPools: { "agent-a": pool } });
+
+    // Scale increases from 1 to 2
+    const scaledConfig = makeAgentConfig("agent-a", { scale: 2 });
+    mockedDiscoverAgents.mockReturnValue(["agent-a"]);
+    mockedLoadAgentConfig.mockReturnValue(scaledConfig);
+
+    const handle = watchAgents(ctx);
+    await handle._handleAgentChange("agent-a");
+
+    // updateAgentScale should be called — NOT registerAgent — to preserve runningCount
+    expect(ctx.statusTracker!.updateAgentScale).toHaveBeenCalledWith("agent-a", 2);
+    expect(ctx.statusTracker!.registerAgent).not.toHaveBeenCalled();
+  });
+
+  it("hot reload scale decrease uses updateAgentScale (not registerAgent)", async () => {
+    const runner1 = makeMockRunner("agent-a-00000001");
+    const runner2 = makeMockRunner("agent-a-00000002");
+    const runner3 = makeMockRunner("agent-a-00000003");
+    const pool = new RunnerPool([runner1, runner2, runner3]);
+    const ctx = makeContext({
+      agentConfigs: [makeAgentConfig("agent-a", { scale: 3 })],
+      runnerPools: { "agent-a": pool },
+    });
+
+    const shrunkConfig = makeAgentConfig("agent-a", { scale: 1 });
+    mockedDiscoverAgents.mockReturnValue(["agent-a"]);
+    mockedLoadAgentConfig.mockReturnValue(shrunkConfig);
+
+    const handle = watchAgents(ctx);
+    await handle._handleAgentChange("agent-a");
+
+    expect(ctx.statusTracker!.updateAgentScale).toHaveBeenCalledWith("agent-a", 1);
+    expect(ctx.statusTracker!.registerAgent).not.toHaveBeenCalled();
+  });
+
+  it("hot reload preserves running state when runners are active after rebuild", async () => {
+    const runner = makeMockRunner("agent-a");
+    const pool = new RunnerPool([runner]);
+
+    // Simulate a running agent: getAllAgents reports runningCount = 1
+    const statusTracker = {
+      registerAgent: vi.fn(),
+      unregisterAgent: vi.fn(),
+      updateAgentScale: vi.fn(),
+      setAgentState: vi.fn(),
+      setAgentStatusText: vi.fn(),
+      setAgentError: vi.fn(),
+      setNextRunAt: vi.fn(),
+      addLogLine: vi.fn(),
+      isAgentEnabled: vi.fn(() => true),
+      getAllAgents: vi.fn(() => [{ name: "agent-a", runningCount: 1, state: "running" }]),
+    };
+
+    const ctx = makeContext({ runnerPools: { "agent-a": pool }, statusTracker: statusTracker as any });
+
+    mockedDiscoverAgents.mockReturnValue(["agent-a"]);
+    mockedLoadAgentConfig.mockReturnValue(makeAgentConfig("agent-a"));
+
+    const handle = watchAgents(ctx);
+    await handle._handleAgentChange("agent-a");
+
+    // setAgentState("idle") should NOT have been called — a runner is still active
+    const idleCalls = statusTracker.setAgentState.mock.calls.filter(
+      ([_name, state]: [string, string]) => state === "idle"
+    );
+    expect(idleCalls).toHaveLength(0);
+
+    // But building state should have been set
+    expect(statusTracker.setAgentState).toHaveBeenCalledWith("agent-a", "building");
   });
 });

--- a/packages/action-llama/test/tui/status-tracker.test.ts
+++ b/packages/action-llama/test/tui/status-tracker.test.ts
@@ -397,6 +397,53 @@ describe("StatusTracker", () => {
     expect(agents[0].state).toBe("running");
   });
 
+  it("startRun allows runningCount to exceed scale (no clamping)", () => {
+    // During scale transitions or race conditions, runningCount should reflect
+    // the actual number of running instances — not be capped at scale.
+    const tracker = new StatusTracker();
+    tracker.registerAgent("dev", 2);
+
+    tracker.startRun("dev");
+    tracker.startRun("dev");
+    tracker.startRun("dev"); // third run on a scale=2 agent
+
+    const agent = tracker.getAllAgents()[0];
+    expect(agent.runningCount).toBe(3);
+  });
+
+  it("updateAgentScale preserves runningCount", () => {
+    const tracker = new StatusTracker();
+    tracker.registerAgent("dev", 2);
+
+    tracker.startRun("dev");
+    tracker.startRun("dev");
+
+    tracker.updateAgentScale("dev", 3);
+
+    const agent = tracker.getAllAgents()[0];
+    expect(agent.runningCount).toBe(2); // unchanged
+    expect(agent.scale).toBe(3);
+    expect(agent.state).toBe("running");
+  });
+
+  it("registerAgent resets runningCount (documents behavior)", () => {
+    // registerAgent() completely replaces the agent status object, resetting
+    // runningCount to 0. This is why watcher.ts uses updateAgentScale for
+    // scale changes instead of re-registering, to avoid losing running state.
+    const tracker = new StatusTracker();
+    tracker.registerAgent("dev", 2);
+
+    tracker.startRun("dev");
+    tracker.startRun("dev");
+
+    // Re-registering resets everything
+    tracker.registerAgent("dev", 3);
+
+    const agent = tracker.getAllAgents()[0];
+    expect(agent.runningCount).toBe(0);
+    expect(agent.scale).toBe(3);
+  });
+
   it("two concurrent instances with scale=2 shows correct count", () => {
     const tracker = new StatusTracker();
     tracker.registerAgent("dev", 2);


### PR DESCRIPTION
Closes #331

## Summary

Fixes the agent table in the Web UI dashboard showing incorrect `runningCount/scale` when 4 agents are running but only 3/4 are shown.

## Root Causes Fixed

**Bug 1 (primary): Project-wide scale cap mismatch**

`createRunnerPools` applies a project-wide scale cap that can reduce individual agent pool sizes below their configured values. However, the status tracker was registered with the *uncapped* scale beforehand and never updated — causing a display like `3/4` when the actual pool only has 3 runners.

Fix: `createRunnerPools` now returns `actualScales` (the real post-cap sizes), and `scheduler/index.ts` syncs the status tracker immediately after pool creation.

**Bug 2: Hot reload re-registers agent (resets runningCount to 0)**

When an agent's scale changed during hot reload, `registerAgent()` was called — which completely replaces the agent status object, resetting `runningCount` to 0. Any actively running instances were "forgotten".

Fix: `watcher.ts` now calls `updateAgentScale()` for scale changes, which updates only the scale field and preserves all running state.

**Bug 3: Hot reload unconditionally sets state to idle**

At the end of `handleChangedAgent`, `setAgentState(agentName, "idle")` was called unconditionally — even if runners were still active after the rebuild.

Fix: The state is only set to idle if `runningCount === 0`.

**Bug 4: Math.min clamp suppressed actual running count**

`startRun` clamped `runningCount` at `scale`, which masked the true count during scale transitions and when scale was wrong due to Bug 1.

Fix: Removed the clamp — the pool enforces runner limits, the tracker should count truthfully.

## Files Changed

- `packages/action-llama/src/execution/runner-setup.ts` — add `actualScales` to result
- `packages/action-llama/src/scheduler/index.ts` — sync tracker with actual pool sizes
- `packages/action-llama/src/tui/status-tracker.ts` — remove Math.min clamp in startRun
- `packages/action-llama/src/scheduler/watcher.ts` — use updateAgentScale; respect running state
- `packages/action-llama/test/tui/status-tracker.test.ts` — new tests for fixed behaviors
- `packages/action-llama/test/scheduler/watcher.test.ts` — new tests for hot-reload fixes
- `packages/action-llama/test/execution/runner-setup.test.ts` — new tests for actualScales
- `packages/action-llama/test/scheduler/index.test.ts` — update mock with new methods

## Test Results

All new tests pass. 3 pre-existing failures in `dashboard-auth.test.ts` / `auth-logs.test.ts` are unrelated to this change (present on main branch).