### PR TITLE
fix: cleanup orphan locks for dead containers

### DIFF
--- a/packages/action-llama/src/execution/container-registry.ts
+++ b/packages/action-llama/src/execution/container-registry.ts
@@ -44,6 +44,30 @@ export class ContainerRegistry {
     await this.store?.delete(NS, secret);
   }
 
+  /**
+   * Check if a container with the given instanceId is currently registered.
+   * Used by the lock store to detect orphan locks held by dead containers.
+   */
+  hasInstance(instanceId: string): boolean {
+    for (const reg of this.cache.values()) {
+      if (reg.instanceId === instanceId) return true;
+    }
+    return false;
+  }
+
+  /** Return all current registrations as an array (used during startup cleanup). */
+  listAll(): ContainerRegistration[] {
+    return Array.from(this.cache.values());
+  }
+
+  /** Remove all registrations from both the cache and the persistent store. */
+  async clear(): Promise<void> {
+    for (const key of this.cache.keys()) {
+      await this.store?.delete(NS, key);
+    }
+    this.cache.clear();
+  }
+
   /** Number of registered containers. */
   get size(): number {
     return this.cache.size;

--- a/packages/action-llama/src/execution/lock-store.ts
+++ b/packages/action-llama/src/execution/lock-store.ts
@@ -37,10 +37,17 @@ export class LockStore {
   private sweepTimer: ReturnType<typeof setInterval> | undefined;
   private defaultTTL: number;
   private store?: StateStore;
+  private isHolderAlive?: (holder: string) => boolean;
 
-  constructor(defaultTTLSeconds = 1800, sweepIntervalSeconds = 30, store?: StateStore) {
+  constructor(
+    defaultTTLSeconds = 1800,
+    sweepIntervalSeconds = 30,
+    store?: StateStore,
+    opts?: { isHolderAlive?: (holder: string) => boolean },
+  ) {
     this.defaultTTL = defaultTTLSeconds * 1000;
     this.store = store;
+    this.isHolderAlive = opts?.isHolderAlive;
     this.sweepTimer = setInterval(() => this.sweep(), sweepIntervalSeconds * 1000);
     if (this.sweepTimer.unref) this.sweepTimer.unref();
   }
@@ -74,19 +81,27 @@ export class LockStore {
         this.locks.delete(resourceKey);
         this.persistDelete(resourceKey, existing.holder);
       } else if (existing.holder !== holder) {
-        // Resource held by another — check for deadlock cycle
-        const cycle = this.detectCycle(holder, resourceKey);
-        if (cycle) {
+        // Check if the holder is still alive — evict orphan locks immediately
+        if (this.isHolderAlive && !this.isHolderAlive(existing.holder)) {
+          this.removeHolderLock(existing.holder, resourceKey);
+          this.locks.delete(resourceKey);
+          this.persistDelete(resourceKey, existing.holder);
+          // Fall through to acquire below
+        } else {
+          // Resource held by another — check for deadlock cycle
+          const cycle = this.detectCycle(holder, resourceKey);
+          if (cycle) {
+            this.waitingFor.set(holder, resourceKey);
+            return {
+              ok: false,
+              reason: `possible deadlock: ${[...cycle, cycle[0]].join(" \u2192 ")}`,
+              deadlock: true,
+              cycle,
+            };
+          }
           this.waitingFor.set(holder, resourceKey);
-          return {
-            ok: false,
-            reason: `possible deadlock: ${[...cycle, cycle[0]].join(" \u2192 ")}`,
-            deadlock: true,
-            cycle,
-          };
+          return { ok: false, holder: existing.holder, heldSince: existing.heldSince };
         }
-        this.waitingFor.set(holder, resourceKey);
-        return { ok: false, holder: existing.holder, heldSince: existing.heldSince };
       }
       // Same holder re-acquiring — refresh below
     }
@@ -258,6 +273,11 @@ export class LockStore {
     const now = Date.now();
     for (const [rk, entry] of this.locks) {
       if (now >= entry.expiresAt) {
+        this.removeHolderLock(entry.holder, rk);
+        this.locks.delete(rk);
+        this.persistDelete(rk, entry.holder);
+      } else if (this.isHolderAlive && !this.isHolderAlive(entry.holder)) {
+        // Proactively evict locks held by dead containers
         this.removeHolderLock(entry.holder, rk);
         this.locks.delete(rk);
         this.persistDelete(rk, entry.holder);

--- a/packages/action-llama/src/gateway/index.ts
+++ b/packages/action-llama/src/gateway/index.ts
@@ -122,7 +122,9 @@ export async function startGateway(opts: GatewayOptions): Promise<GatewayServer>
 
   // Create stores backed by the persistent StateStore (if provided).
   const containerRegistry = new ContainerRegistry(stateStore);
-  const lockStore = new LockStore(lockTimeout, undefined, stateStore);
+  const lockStore = new LockStore(lockTimeout, undefined, stateStore, {
+    isHolderAlive: (holder) => containerRegistry.hasInstance(holder),
+  });
   const callStore = new CallStore(undefined, stateStore);
   let callDispatcher: CallDispatcher | undefined;
 

--- a/packages/action-llama/src/scheduler/index.ts
+++ b/packages/action-llama/src/scheduler/index.ts
@@ -141,6 +141,27 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
     logger.debug({ err }, "orphan detection skipped (runtime does not support listing)");
   }
 
+  // Clean up stale container registry entries and their locks.
+  // At this point all containers from the previous run are dead (either exited
+  // normally or just killed above). No new containers have been launched yet,
+  // so every registry entry is stale.
+  try {
+    const staleEntries = gateway.containerRegistry.listAll();
+    if (staleEntries.length > 0) {
+      let releasedLocks = 0;
+      for (const entry of staleEntries) {
+        releasedLocks += gateway.lockStore.releaseAll(entry.instanceId);
+      }
+      await gateway.containerRegistry.clear();
+      logger.info(
+        { releasedLocks, staleRegistrations: staleEntries.length },
+        "cleaned up orphan locks and stale container registrations",
+      );
+    }
+  } catch (err) {
+    logger.warn({ err }, "failed to clean up stale container registrations");
+  }
+
   // Build base + per-agent images
   const buildSkills: PromptSkills = { locking: true };
   const buildResult = await buildAgentImages({

--- a/packages/action-llama/test/execution/lock-store.test.ts
+++ b/packages/action-llama/test/execution/lock-store.test.ts
@@ -572,3 +572,89 @@ describe("LockStore — URI validation", () => {
     });
   });
 });
+
+describe("LockStore — orphan lock cleanup", () => {
+  it("evicts orphan lock on acquire when holder is dead", () => {
+    const aliveHolders = new Set(["agent-a", "agent-b"]);
+    const store = new LockStore(300, 9999, undefined, {
+      isHolderAlive: (h) => aliveHolders.has(h),
+    });
+    // agent-b acquires a lock
+    store.acquire("github://acme/app/issues/42", "agent-b");
+    // agent-b dies (remove from alive set)
+    aliveHolders.delete("agent-b");
+    // agent-a tries to acquire — should succeed because agent-b is dead
+    const result = store.acquire("github://acme/app/issues/42", "agent-a");
+    expect(result).toEqual({ ok: true });
+    // Verify agent-a now holds the lock
+    const locks = store.list("agent-a");
+    expect(locks).toHaveLength(1);
+    expect(locks[0].resourceKey).toBe("github://acme/app/issues/42");
+    store.dispose();
+  });
+
+  it("does not evict lock when holder is alive", () => {
+    const aliveHolders = new Set(["agent-a", "agent-b"]);
+    const store = new LockStore(300, 9999, undefined, {
+      isHolderAlive: (h) => aliveHolders.has(h),
+    });
+    store.acquire("github://acme/app/issues/42", "agent-a");
+    const result = store.acquire("github://acme/app/issues/42", "agent-b");
+    expect(result.ok).toBe(false);
+    expect(result.holder).toBe("agent-a");
+    store.dispose();
+  });
+
+  it("evicts orphan lock on acquire and cleans up holder index", () => {
+    const aliveHolders = new Set(["agent-a", "agent-b"]);
+    const store = new LockStore(300, 9999, undefined, {
+      isHolderAlive: (h) => aliveHolders.has(h),
+    });
+    store.acquire("github://acme/app/issues/1", "agent-b");
+    store.acquire("github://acme/app/issues/2", "agent-b");
+    // agent-b dies
+    aliveHolders.delete("agent-b");
+    // agent-a acquires issue/1 — evicts orphan lock held by dead agent-b
+    const r1 = store.acquire("github://acme/app/issues/1", "agent-a");
+    expect(r1).toEqual({ ok: true });
+    // agent-a acquires issue/2 as well
+    const r2 = store.acquire("github://acme/app/issues/2", "agent-a");
+    expect(r2).toEqual({ ok: true });
+    store.dispose();
+  });
+
+  it("works without isHolderAlive callback (backwards compatible)", () => {
+    const store = new LockStore(300, 9999);
+    store.acquire("github://acme/app/issues/42", "agent-a");
+    const result = store.acquire("github://acme/app/issues/42", "agent-b");
+    expect(result.ok).toBe(false);
+    expect(result.holder).toBe("agent-a");
+    store.dispose();
+  });
+
+  it("sweep evicts locks held by dead containers", () => {
+    vi.useFakeTimers();
+    try {
+      const aliveHolders = new Set(["agent-a", "agent-b"]);
+      // Use a short sweep interval (100ms) so we can trigger it with fake timers
+      const store = new LockStore(300, 0.1, undefined, {
+        isHolderAlive: (h) => aliveHolders.has(h),
+      });
+      store.acquire("github://acme/app/issues/1", "agent-a");
+      store.acquire("github://acme/app/issues/2", "agent-b");
+      // agent-b dies
+      aliveHolders.delete("agent-b");
+      // Advance time to trigger the sweep
+      vi.advanceTimersByTime(200);
+      // agent-b's lock should have been swept; agent-c can now acquire it
+      const result = store.acquire("github://acme/app/issues/2", "agent-c");
+      expect(result).toEqual({ ok: true });
+      // agent-a's lock should still be present
+      const aLocks = store.list("agent-a");
+      expect(aLocks).toHaveLength(1);
+      store.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
Closes #339

## Summary

When a container dies without properly calling `unregisterContainer` (e.g., due to a crash), its locks persisted in the registry until TTL expiry (up to 30 minutes). This PR implements immediate orphan lock eviction.

## Changes

### `ContainerRegistry` (new methods)
- `hasInstance(instanceId)` — checks if any registered container has the given instanceId (used for liveness checks)
- `listAll()` — returns all registrations as an array (used for startup cleanup)
- `clear()` — removes all registrations from cache and persistent store

### `LockStore` (orphan eviction)
- Added optional `isHolderAlive` callback in constructor (4th `opts` parameter, backwards-compatible)
- `acquire()`: if the existing lock holder is dead (isHolderAlive returns false), the orphan lock is immediately evicted and the new holder acquires it
- `sweep()`: proactively evicts locks held by dead containers every 30 seconds (even without an acquire request)

### Gateway wiring
- `LockStore` is now created with `isHolderAlive: (holder) => containerRegistry.hasInstance(holder)`, so any lock held by an unregistered container is treated as orphaned

### Scheduler startup cleanup
- After killing orphan Docker containers from the previous run, we now also purge stale `ContainerRegistry` entries and release their locks, ensuring a clean slate on restart

## Tests
- Added 5 new unit tests covering orphan lock eviction on acquire, liveness check, sweep-based eviction, and backwards compatibility without `isHolderAlive`

## Pre-existing test failures
The 3 failures in `dashboard-auth.test.ts` / `auth-logs.test.ts` pre-exist this PR (frontend not built in test env) and are unrelated to these changes.