### PR TITLE
fix: persistent chat sessions with clear/shutdown and lock release

### DIFF
--- a/packages/action-llama/src/chat/container-launcher.ts
+++ b/packages/action-llama/src/chat/container-launcher.ts
@@ -8,7 +8,7 @@
  */
 
 import { randomUUID } from "crypto";
-import type { ContainerRuntime } from "../docker/runtime.js";
+import type { ContainerRuntime, RuntimeCredentials } from "../docker/runtime.js";
 import type { AgentConfig, GlobalConfig } from "../shared/config.js";
 import type { Logger } from "../shared/logger.js";
 import type { ChatSessionManager } from "./session-manager.js";
@@ -21,6 +21,9 @@ export class ChatContainerLauncher {
   private logger: Logger;
   private sessionManager: ChatSessionManager;
   private images: Map<string, string>;
+  private registerContainer: (secret: string, reg: any) => Promise<void>;
+  private unregisterContainer: (secret: string) => Promise<void>;
+  private sessionCredentials = new Map<string, RuntimeCredentials>();
 
   constructor(opts: {
     runtime: ContainerRuntime;
@@ -30,6 +33,8 @@ export class ChatContainerLauncher {
     logger: Logger;
     sessionManager: ChatSessionManager;
     images: Map<string, string>;
+    registerContainer?: (secret: string, reg: any) => Promise<void>;
+    unregisterContainer?: (secret: string) => Promise<void>;
   }) {
     this.runtime = opts.runtime;
     this.globalConfig = opts.globalConfig;
@@ -38,6 +43,8 @@ export class ChatContainerLauncher {
     this.logger = opts.logger;
     this.sessionManager = opts.sessionManager;
     this.images = opts.images;
+    this.registerContainer = opts.registerContainer ?? (() => Promise.resolve());
+    this.unregisterContainer = opts.unregisterContainer ?? (() => Promise.resolve());
   }
 
   async launchChatContainer(agentName: string, sessionId: string): Promise<string> {
@@ -63,15 +70,20 @@ export class ChatContainerLauncher {
 
     const credentials = await this.runtime.prepareCredentials(credRefs);
 
+    // Generate shutdown secret for gateway registration (enables lock release on stop)
+    const shutdownSecret = randomUUID();
+    const instanceId = `${agentName}-chat-${sessionId.slice(0, 8)}`;
+
     const env: Record<string, string> = {
       AL_CHAT_MODE: "1",
       AL_CHAT_SESSION_ID: sessionId,
       GATEWAY_URL: this.gatewayUrl,
+      SHUTDOWN_SECRET: shutdownSecret,
     };
 
     const containerName = await this.runtime.launch({
       image,
-      agentName: `${agentName}-chat-${sessionId.slice(0, 8)}`,
+      agentName: instanceId,
       env,
       credentials,
       memory: this.globalConfig.local?.memory,
@@ -79,6 +91,20 @@ export class ChatContainerLauncher {
     });
 
     this.sessionManager.setContainerName(sessionId, containerName);
+
+    // Register with gateway so locks are released when container stops
+    try {
+      await this.registerContainer(shutdownSecret, {
+        containerName,
+        agentName,
+        instanceId,
+      });
+      this.sessionManager.setShutdownSecret(sessionId, shutdownSecret);
+      this.sessionCredentials.set(sessionId, credentials);
+    } catch (err: any) {
+      this.logger.warn({ sessionId, err: err.message }, "failed to register chat container with gateway");
+    }
+
     this.logger.info({ agentName, sessionId, containerName }, "chat container launched");
 
     return containerName;
@@ -87,6 +113,22 @@ export class ChatContainerLauncher {
   async stopChatContainer(sessionId: string): Promise<void> {
     const session = this.sessionManager.getSession(sessionId);
     if (!session?.containerName) return;
+
+    // Release locks via gateway unregister (calls lockStore.releaseAll)
+    if (session.shutdownSecret) {
+      try {
+        await this.unregisterContainer(session.shutdownSecret);
+      } catch (err: any) {
+        this.logger.warn({ sessionId, err: err.message }, "failed to unregister chat container");
+      }
+    }
+
+    // Clean up credentials
+    const creds = this.sessionCredentials.get(sessionId);
+    if (creds) {
+      this.runtime.cleanupCredentials(creds);
+      this.sessionCredentials.delete(sessionId);
+    }
 
     try {
       await this.runtime.kill(session.containerName);

--- a/packages/action-llama/src/chat/routes.ts
+++ b/packages/action-llama/src/chat/routes.ts
@@ -16,12 +16,19 @@ export function registerChatApiRoutes(
   stopCallback: StopChatCallback,
   logger?: Logger,
 ): void {
-  // Create a new chat session and launch a container
+  // Create a new chat session and launch a container (idempotent per agent)
   app.post("/api/chat/sessions", async (c) => {
     const body = await c.req.json().catch(() => ({}));
     const agentName = body.agentName;
     if (!agentName || typeof agentName !== "string") {
       return c.json({ error: "agentName is required" }, 400);
+    }
+
+    // Return existing session for this agent if one exists (idempotent)
+    const existing = sessionManager.getSessionByAgent(agentName);
+    if (existing) {
+      logger?.info({ sessionId: existing.sessionId, agentName }, "returning existing chat session");
+      return c.json({ sessionId: existing.sessionId, created: false });
     }
 
     if (!sessionManager.canCreateSession()) {
@@ -38,7 +45,41 @@ export function registerChatApiRoutes(
         sessionManager.removeSession(session.sessionId);
       });
 
-      return c.json({ sessionId: session.sessionId });
+      return c.json({ sessionId: session.sessionId, created: true });
+    } catch (err: any) {
+      return c.json({ error: err.message }, 500);
+    }
+  });
+
+  // Clear chat context: stop old container (releases locks), create new session and container
+  app.post("/api/chat/sessions/:sessionId/clear", async (c) => {
+    const sessionId = c.req.param("sessionId");
+    const session = sessionManager.getSession(sessionId);
+    if (!session) {
+      return c.json({ error: "Session not found" }, 404);
+    }
+
+    const agentName = session.agentName;
+
+    // Stop old container (this releases locks via unregisterContainer)
+    try {
+      await stopCallback(sessionId);
+    } catch (err: any) {
+      logger?.warn({ sessionId, err: err.message }, "error stopping chat container during clear");
+    }
+    sessionManager.removeSession(sessionId);
+
+    // Create new session for the same agent
+    try {
+      const newSession = sessionManager.createSession(agentName);
+      logger?.info({ oldSessionId: sessionId, newSessionId: newSession.sessionId, agentName }, "chat context cleared");
+
+      launchCallback(agentName, newSession.sessionId).catch((err) => {
+        logger?.error({ sessionId: newSession.sessionId, err: err.message }, "failed to launch chat container after clear");
+        sessionManager.removeSession(newSession.sessionId);
+      });
+
+      return c.json({ sessionId: newSession.sessionId });
     } catch (err: any) {
       return c.json({ error: err.message }, 500);
     }

--- a/packages/action-llama/src/chat/session-manager.ts
+++ b/packages/action-llama/src/chat/session-manager.ts
@@ -55,6 +55,20 @@ export class ChatSessionManager {
     }
   }
 
+  setShutdownSecret(sessionId: string, secret: string): void {
+    const session = this.sessions.get(sessionId);
+    if (session) {
+      session.shutdownSecret = secret;
+    }
+  }
+
+  getSessionByAgent(agentName: string): ChatSession | undefined {
+    for (const session of this.sessions.values()) {
+      if (session.agentName === agentName) return session;
+    }
+    return undefined;
+  }
+
   /** Returns sessions that have been idle longer than the given timeout. */
   getIdleSessions(timeoutMs: number): ChatSession[] {
     const cutoff = Date.now() - timeoutMs;

--- a/packages/action-llama/src/chat/types.ts
+++ b/packages/action-llama/src/chat/types.ts
@@ -66,6 +66,7 @@ export interface ChatSession {
   sessionId: string;
   agentName: string;
   containerName?: string;
+  shutdownSecret?: string;
   createdAt: Date;
   lastActivityAt: Date;
 }

--- a/packages/action-llama/src/chat/ws-handler.ts
+++ b/packages/action-llama/src/chat/ws-handler.ts
@@ -48,9 +48,6 @@ export function attachChatWebSocket(
   // Container-facing WS server
   const containerWss = new WebSocketServer({ noServer: true });
 
-  // Disconnection grace periods: track when browser disconnected
-  const browserDisconnectTimers = new Map<string, ReturnType<typeof setTimeout>>();
-
   server.on("upgrade", async (req: IncomingMessage, socket, head) => {
     const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
     const pathname = url.pathname;
@@ -103,13 +100,6 @@ export function attachChatWebSocket(
   function handleBrowserConnection(ws: WebSocket, sessionId: string) {
     logger?.debug({ sessionId }, "browser WebSocket connected");
 
-    // Clear any grace-period timer from a prior disconnect
-    const timer = browserDisconnectTimers.get(sessionId);
-    if (timer) {
-      clearTimeout(timer);
-      browserDisconnectTimers.delete(sessionId);
-    }
-
     const conn: BrowserConnection = { ws, rateLimiter: new RateLimiter() };
     browserConnections.set(sessionId, conn);
 
@@ -140,14 +130,7 @@ export function attachChatWebSocket(
     ws.on("close", () => {
       logger?.debug({ sessionId }, "browser WebSocket disconnected");
       browserConnections.delete(sessionId);
-
-      // Grace period: wait 60s before shutting down the container
-      const gracePeriod = setTimeout(() => {
-        browserDisconnectTimers.delete(sessionId);
-        logger?.info({ sessionId }, "browser grace period expired, shutting down container");
-        shutdownSession(sessionId);
-      }, 60_000);
-      browserDisconnectTimers.set(sessionId, gracePeriod);
+      // No auto-shutdown — session persists until explicit user action (Clear/Shutdown) or idle timeout
     });
 
     ws.on("error", (err) => {

--- a/packages/action-llama/src/scheduler/gateway-setup.ts
+++ b/packages/action-llama/src/scheduler/gateway-setup.ts
@@ -226,6 +226,8 @@ export async function setupGateway(opts: {
       logger,
       sessionManager: gateway.chatSessionManager,
       images: liveImages,
+      registerContainer,
+      unregisterContainer,
     });
   };
 

--- a/packages/action-llama/test/chat/container-launcher.test.ts
+++ b/packages/action-llama/test/chat/container-launcher.test.ts
@@ -48,12 +48,16 @@ describe("ChatContainerLauncher", () => {
   let runtime: ContainerRuntime;
   let sessionManager: ChatSessionManager;
   let launcher: ChatContainerLauncher;
+  let registerContainer: ReturnType<typeof vi.fn>;
+  let unregisterContainer: ReturnType<typeof vi.fn>;
   const logger = makeMockLogger();
 
   beforeEach(() => {
     vi.clearAllMocks();
     runtime = createMockRuntime();
     sessionManager = new ChatSessionManager(5);
+    registerContainer = vi.fn().mockResolvedValue(undefined);
+    unregisterContainer = vi.fn().mockResolvedValue(undefined);
     launcher = new ChatContainerLauncher({
       runtime,
       globalConfig: {} as GlobalConfig,
@@ -62,6 +66,8 @@ describe("ChatContainerLauncher", () => {
       logger,
       sessionManager,
       images: new Map([["test-agent", "test-image:latest"]]),
+      registerContainer: registerContainer as any,
+      unregisterContainer: unregisterContainer as any,
     });
   });
 
@@ -95,6 +101,37 @@ describe("ChatContainerLauncher", () => {
 
       expect(runtime.prepareCredentials).toHaveBeenCalledWith(
         expect.arrayContaining(["github_token", "anthropic_key"]),
+      );
+    });
+
+    it("calls registerContainer with a shutdown secret", async () => {
+      const session = sessionManager.createSession("test-agent");
+      await launcher.launchChatContainer("test-agent", session.sessionId);
+
+      expect(registerContainer).toHaveBeenCalledTimes(1);
+      const [secret, reg] = registerContainer.mock.calls[0];
+      expect(typeof secret).toBe("string");
+      expect(secret.length).toBeGreaterThan(0);
+      expect(reg).toMatchObject({ agentName: "test-agent" });
+    });
+
+    it("stores shutdown secret on the session", async () => {
+      const session = sessionManager.createSession("test-agent");
+      await launcher.launchChatContainer("test-agent", session.sessionId);
+
+      expect(session.shutdownSecret).toBeTruthy();
+    });
+
+    it("passes SHUTDOWN_SECRET in container env vars", async () => {
+      const session = sessionManager.createSession("test-agent");
+      await launcher.launchChatContainer("test-agent", session.sessionId);
+
+      expect(runtime.launch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          env: expect.objectContaining({
+            SHUTDOWN_SECRET: expect.any(String),
+          }),
+        }),
       );
     });
 
@@ -155,6 +192,35 @@ describe("ChatContainerLauncher", () => {
       // Should not throw
       await launcher.stopChatContainer(session.sessionId);
       expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it("calls unregisterContainer with the stored shutdown secret", async () => {
+      const session = sessionManager.createSession("test-agent");
+      await launcher.launchChatContainer("test-agent", session.sessionId);
+
+      const shutdownSecret = session.shutdownSecret;
+      await launcher.stopChatContainer(session.sessionId);
+
+      expect(unregisterContainer).toHaveBeenCalledWith(shutdownSecret);
+    });
+
+    it("calls runtime.cleanupCredentials on stop", async () => {
+      const session = sessionManager.createSession("test-agent");
+      await launcher.launchChatContainer("test-agent", session.sessionId);
+      await launcher.stopChatContainer(session.sessionId);
+
+      expect(runtime.cleanupCredentials).toHaveBeenCalled();
+    });
+
+    it("does not call unregisterContainer when session has no shutdown secret", async () => {
+      const session = sessionManager.createSession("test-agent");
+      // Launch without registering (simulated by not setting shutdownSecret)
+      registerContainer.mockRejectedValueOnce(new Error("registration failed"));
+      await launcher.launchChatContainer("test-agent", session.sessionId);
+      unregisterContainer.mockClear();
+
+      await launcher.stopChatContainer(session.sessionId);
+      expect(unregisterContainer).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/action-llama/test/chat/routes.test.ts
+++ b/packages/action-llama/test/chat/routes.test.ts
@@ -37,6 +37,55 @@ describe("Chat API routes", () => {
       expect(typeof body.sessionId).toBe("string");
     });
 
+    it("returns created: true for a new session", async () => {
+      const res = await app.request("/api/chat/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentName: "new-agent" }),
+      });
+      const body = await res.json();
+      expect(body.created).toBe(true);
+    });
+
+    it("returns existing session with created: false when one already exists for agent", async () => {
+      // Create initial session
+      const firstRes = await app.request("/api/chat/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentName: "existing-agent" }),
+      });
+      const { sessionId: firstId } = await firstRes.json();
+
+      // Request again for same agent
+      const secondRes = await app.request("/api/chat/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentName: "existing-agent" }),
+      });
+      expect(secondRes.status).toBe(200);
+      const body = await secondRes.json();
+      expect(body.sessionId).toBe(firstId);
+      expect(body.created).toBe(false);
+    });
+
+    it("does not call launchCallback for existing session", async () => {
+      await app.request("/api/chat/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentName: "existing-agent" }),
+      });
+      await new Promise((r) => setTimeout(r, 10));
+      const firstCallCount = launchCallback.mock.calls.length;
+
+      await app.request("/api/chat/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentName: "existing-agent" }),
+      });
+      await new Promise((r) => setTimeout(r, 10));
+      expect(launchCallback.mock.calls.length).toBe(firstCallCount);
+    });
+
     it("calls launchCallback with agentName and sessionId", async () => {
       const res = await app.request("/api/chat/sessions", {
         method: "POST",
@@ -86,6 +135,81 @@ describe("Chat API routes", () => {
         body: "not json",
       });
       expect(res.status).toBe(400);
+    });
+  });
+
+  describe("POST /api/chat/sessions/:sessionId/clear", () => {
+    it("stops the old container and returns a new sessionId", async () => {
+      const createRes = await app.request("/api/chat/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentName: "test-agent" }),
+      });
+      const { sessionId } = await createRes.json();
+
+      const clearRes = await app.request(`/api/chat/sessions/${sessionId}/clear`, {
+        method: "POST",
+      });
+      expect(clearRes.status).toBe(200);
+      const body = await clearRes.json();
+      expect(body.sessionId).toBeTruthy();
+      expect(body.sessionId).not.toBe(sessionId);
+    });
+
+    it("calls stopCallback with old sessionId", async () => {
+      const createRes = await app.request("/api/chat/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentName: "test-agent" }),
+      });
+      const { sessionId } = await createRes.json();
+
+      await app.request(`/api/chat/sessions/${sessionId}/clear`, {
+        method: "POST",
+      });
+
+      expect(stopCallback).toHaveBeenCalledWith(sessionId);
+    });
+
+    it("calls launchCallback for the new session", async () => {
+      const createRes = await app.request("/api/chat/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentName: "test-agent" }),
+      });
+      const { sessionId: oldId } = await createRes.json();
+
+      const clearRes = await app.request(`/api/chat/sessions/${oldId}/clear`, {
+        method: "POST",
+      });
+      const { sessionId: newId } = await clearRes.json();
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(launchCallback).toHaveBeenCalledWith("test-agent", newId);
+    });
+
+    it("returns 404 for unknown session", async () => {
+      const res = await app.request("/api/chat/sessions/nonexistent/clear", {
+        method: "POST",
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("removes old session and creates a new one", async () => {
+      const createRes = await app.request("/api/chat/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentName: "test-agent" }),
+      });
+      const { sessionId: oldId } = await createRes.json();
+
+      const clearRes = await app.request(`/api/chat/sessions/${oldId}/clear`, {
+        method: "POST",
+      });
+      const { sessionId: newId } = await clearRes.json();
+
+      expect(sessionManager.getSession(oldId)).toBeUndefined();
+      expect(sessionManager.getSession(newId)).toBeDefined();
     });
   });
 

--- a/packages/action-llama/test/chat/session-manager.test.ts
+++ b/packages/action-llama/test/chat/session-manager.test.ts
@@ -172,4 +172,42 @@ describe("ChatSessionManager", () => {
       expect(() => defaultManager.createSession("overflow")).toThrow("session limit reached");
     });
   });
+
+  describe("getSessionByAgent", () => {
+    it("returns session matching agent name", () => {
+      const session = manager.createSession("target-agent");
+      const found = manager.getSessionByAgent("target-agent");
+      expect(found).toBe(session);
+    });
+
+    it("returns undefined when no session exists for agent", () => {
+      expect(manager.getSessionByAgent("nonexistent-agent")).toBeUndefined();
+    });
+
+    it("returns undefined when sessions exist but for different agents", () => {
+      manager.createSession("agent-a");
+      manager.createSession("agent-b");
+      expect(manager.getSessionByAgent("agent-c")).toBeUndefined();
+    });
+
+    it("returns the correct session when multiple sessions exist", () => {
+      manager.createSession("agent-a");
+      const target = manager.createSession("agent-b");
+      const found = manager.getSessionByAgent("agent-b");
+      expect(found).toBe(target);
+    });
+  });
+
+  describe("setShutdownSecret", () => {
+    it("stores the secret on the session", () => {
+      const session = manager.createSession("agent-x");
+      manager.setShutdownSecret(session.sessionId, "my-secret-123");
+      expect(session.shutdownSecret).toBe("my-secret-123");
+    });
+
+    it("does nothing for unknown session", () => {
+      // Should not throw
+      manager.setShutdownSecret("nonexistent", "my-secret");
+    });
+  });
 });

--- a/packages/frontend/src/hooks/useChatSocket.ts
+++ b/packages/frontend/src/hooks/useChatSocket.ts
@@ -146,5 +146,10 @@ export function useChatSocket(sessionId: string | null) {
     wsRef.current.send(JSON.stringify({ type: "cancel" }));
   }, []);
 
-  return { messages, connected, containerReady, sendMessage, cancel };
+  const resetMessages = useCallback(() => {
+    setMessages([]);
+    streamingRef.current = false;
+  }, []);
+
+  return { messages, connected, containerReady, sendMessage, cancel, resetMessages };
 }

--- a/packages/frontend/src/lib/chat-api.ts
+++ b/packages/frontend/src/lib/chat-api.ts
@@ -24,11 +24,17 @@ export interface ChatSessionInfo {
   lastActivityAt: string;
 }
 
-export function createChatSession(agentName: string): Promise<{ sessionId: string }> {
+export function createChatSession(agentName: string): Promise<{ sessionId: string; created: boolean }> {
   return fetchJSON("/api/chat/sessions", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ agentName }),
+  });
+}
+
+export function clearChatSession(sessionId: string): Promise<{ sessionId: string }> {
+  return fetchJSON(`/api/chat/sessions/${encodeURIComponent(sessionId)}/clear`, {
+    method: "POST",
   });
 }
 

--- a/packages/frontend/src/pages/ChatPage.tsx
+++ b/packages/frontend/src/pages/ChatPage.tsx
@@ -1,21 +1,22 @@
 import { useEffect, useState, useRef, useCallback } from "react";
-import { useParams, Link } from "react-router-dom";
-import { createChatSession, deleteChatSession } from "../lib/chat-api";
+import { useParams, Link, useNavigate } from "react-router-dom";
+import { createChatSession, deleteChatSession, clearChatSession } from "../lib/chat-api";
 import { useChatSocket, type ChatMessage as ChatMessageType } from "../hooks/useChatSocket";
 import { ChatMessage } from "../components/ChatMessage";
 import { ToolBlock } from "../components/ToolBlock";
 
 export function ChatPage() {
   const { agent } = useParams<{ agent: string }>();
+  const navigate = useNavigate();
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [input, setInput] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const { messages, connected, containerReady, sendMessage, cancel } = useChatSocket(sessionId);
+  const { messages, connected, containerReady, sendMessage, cancel, resetMessages } = useChatSocket(sessionId);
 
-  // Create session on mount
+  // Create or reconnect to existing session on mount (idempotent per agent)
   useEffect(() => {
     if (!agent) return;
     let cancelled = false;
@@ -32,15 +33,6 @@ export function ChatPage() {
       cancelled = true;
     };
   }, [agent]);
-
-  // Cleanup session on unmount
-  useEffect(() => {
-    return () => {
-      if (sessionId) {
-        deleteChatSession(sessionId).catch(() => {});
-      }
-    };
-  }, [sessionId]);
 
   // Auto-scroll to bottom
   useEffect(() => {
@@ -71,6 +63,27 @@ export function ChatPage() {
     },
     [handleSend],
   );
+
+  const handleClear = useCallback(async () => {
+    if (!sessionId) return;
+    try {
+      const { sessionId: newId } = await clearChatSession(sessionId);
+      resetMessages();
+      setSessionId(newId);
+    } catch (err: any) {
+      setError(err.message);
+    }
+  }, [sessionId, resetMessages]);
+
+  const handleShutdown = useCallback(async () => {
+    if (!sessionId) return;
+    try {
+      await deleteChatSession(sessionId);
+      navigate(`/dashboard/agents/${encodeURIComponent(agent || "")}`);
+    } catch (err: any) {
+      setError(err.message);
+    }
+  }, [sessionId, agent, navigate]);
 
   const isStreaming = messages.some((m) => m.role === "assistant" && !m.done);
 
@@ -113,6 +126,20 @@ export function ChatPage() {
                 : "Waiting for agent..."
               : "Disconnected"}
           </span>
+          <button
+            onClick={handleClear}
+            disabled={!sessionId}
+            className="px-3 py-1.5 text-xs font-medium rounded-md bg-yellow-600 hover:bg-yellow-700 disabled:opacity-40 text-white transition-colors"
+          >
+            Clear Context
+          </button>
+          <button
+            onClick={handleShutdown}
+            disabled={!sessionId}
+            className="px-3 py-1.5 text-xs font-medium rounded-md bg-red-600 hover:bg-red-700 disabled:opacity-40 text-white transition-colors"
+          >
+            Shutdown
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
Closes #337

## Summary

This PR addresses three issues with the chat feature:

### 1. One persistent chat session per agent
- **Backend (`routes.ts`)**: `POST /api/chat/sessions` is now idempotent per agent — returns existing session (with `created: false`) instead of creating a new one.
- **Frontend (`ChatPage.tsx`)**: Removed cleanup-on-unmount. Sessions persist until explicitly shut down.

### 2. Clear Context and Shutdown buttons
- **Backend (`routes.ts`)**: Added `POST /api/chat/sessions/:sessionId/clear` endpoint — stops old container (releasing locks), removes old session, creates new session and launches fresh container.
- **Frontend (`ChatPage.tsx`)**: Added Clear Context (yellow) and Shutdown (red) buttons in the header.
- **Frontend (`chat-api.ts`)**: Added `clearChatSession()` API function.
- **Frontend (`useChatSocket.ts`)**: Added `resetMessages()` to clear local message state on context clear.

### 3. Chat containers release locks on shutdown (bug fix)
- **Backend (`container-launcher.ts`)**: Chat containers now register with the gateway's ContainerRegistry when launched and unregister when stopped, triggering `lockStore.releaseAll()`.
- **Backend (`types.ts`)**: Added `shutdownSecret` field to `ChatSession`.
- **Backend (`session-manager.ts`)**: Added `setShutdownSecret()` and `getSessionByAgent()` methods.
- **Backend (`gateway-setup.ts`)**: Wired `registerContainer`/`unregisterContainer` callbacks into `ChatContainerLauncher`.
- **Backend (`ws-handler.ts`)**: Removed 60-second auto-shutdown grace period on browser disconnect.

## Tests
Added 20 new passing tests for: `getSessionByAgent`, `setShutdownSecret`, idempotent session creation, clear-context endpoint, container registration/unregistration, and credential cleanup.