### PR TITLE
Move agents deploy trigger from CI to Release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,13 +245,3 @@ jobs:
             /tmp/docker-logs-*
           retention-days: 7
 
-  trigger-deploy:
-    name: Trigger Agents Deploy
-    runs-on: ubuntu-latest
-    needs: [test, e2e]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    steps:
-      - name: Dispatch deploy to agents repo
-        run: gh api repos/Action-Llama/agents/dispatches -f event_type=deploy
-        env:
-          GH_TOKEN: ${{ secrets.AGENTS_DEPLOY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,3 +63,9 @@ jobs:
       - name: Publish to npm
         if: steps.has-changesets.outputs.has_changesets == 'true'
         run: npm publish -w packages/action-llama --access public --tag next
+
+      - name: Trigger agents deploy
+        if: steps.has-changesets.outputs.has_changesets == 'true'
+        run: gh api repos/Action-Llama/agents/dispatches -f event_type=deploy
+        env:
+          GH_TOKEN: ${{ secrets.AGENTS_DEPLOY_TOKEN }}


### PR DESCRIPTION
Closes #346

## Changes

- ****: Removed the `trigger-deploy` job that previously triggered the `Action-Llama/agents` deployment after every successful CI run on main.
- ****: Added a `Trigger agents deploy` step at the end of the `release` job, gated on `has_changesets == 'true'`, so the agents project is only deployed when a new version is actually published.

This ensures the agents deployment happens after a successful Release run (npm publish) rather than after every CI run on main.