### PR TITLE
fix: ensure all form inputs have font-size 16px or larger

### DIFF
--- a/packages/frontend/src/components/RunModal.tsx
+++ b/packages/frontend/src/components/RunModal.tsx
@@ -43,7 +43,7 @@ export function RunModal({
           onChange={(e) => setPrompt(e.target.value)}
           placeholder="Optional: describe a specific task..."
           rows={3}
-          className="w-full px-3 py-2 text-sm bg-slate-50 dark:bg-slate-950 border border-slate-300 dark:border-slate-700 rounded-md text-slate-900 dark:text-slate-200 placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+          className="w-full px-3 py-2 text-base bg-slate-50 dark:bg-slate-950 border border-slate-300 dark:border-slate-700 rounded-md text-slate-900 dark:text-slate-200 placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
           onKeyDown={(e) => {
             if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) handleSubmit();
           }}

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -40,3 +40,10 @@
   background: #334155;
   border-radius: 3px;
 }
+
+/* Prevent Safari iOS auto-zoom on input focus (requires >= 16px) */
+input,
+textarea,
+select {
+  font-size: 1rem; /* 16px */
+}

--- a/packages/frontend/src/pages/AgentDetailPage.tsx
+++ b/packages/frontend/src/pages/AgentDetailPage.tsx
@@ -211,7 +211,7 @@ export function AgentDetailPage() {
                 min={1}
                 value={scaleInput}
                 onChange={(e) => setScaleInput(e.target.value)}
-                className="w-14 px-2 py-1 bg-white dark:bg-slate-950 border border-slate-300 dark:border-slate-700 rounded text-xs text-slate-900 dark:text-slate-200"
+                className="w-16 px-2 py-1 bg-white dark:bg-slate-950 border border-slate-300 dark:border-slate-700 rounded text-base text-slate-900 dark:text-slate-200"
               />
               <button
                 onClick={handleScaleUpdate}

--- a/packages/frontend/src/pages/ChatPage.tsx
+++ b/packages/frontend/src/pages/ChatPage.tsx
@@ -173,7 +173,7 @@ export function ChatPage() {
             placeholder={isStreaming ? "Agent is responding..." : "Type a message..."}
             disabled={!connected}
             rows={1}
-            className="flex-1 bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-sm text-white placeholder-slate-400 resize-none focus:outline-none focus:border-blue-500 disabled:opacity-50"
+            className="flex-1 bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-base text-white placeholder-slate-400 resize-none focus:outline-none focus:border-blue-500 disabled:opacity-50"
           />
           {isStreaming ? (
             <button

--- a/packages/frontend/src/pages/DashboardPage.tsx
+++ b/packages/frontend/src/pages/DashboardPage.tsx
@@ -355,7 +355,7 @@ export function DashboardPage() {
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder="Search agents…"
-              className="pl-3 pr-7 py-1 text-xs rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-blue-500 w-48"
+              className="pl-3 pr-7 py-1 text-base rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-blue-500 w-48"
             />
             {searchQuery && (
               <button

--- a/packages/frontend/src/pages/LoginPage.tsx
+++ b/packages/frontend/src/pages/LoginPage.tsx
@@ -58,7 +58,7 @@ export function LoginPage() {
             placeholder="Paste your gateway API key"
             autoFocus
             required
-            className="w-full px-3 py-2.5 bg-white dark:bg-slate-950 border border-slate-300 dark:border-slate-700 rounded-lg text-slate-900 dark:text-slate-200 text-sm outline-none focus:border-blue-500 dark:focus:border-blue-400 transition-colors"
+            className="w-full px-3 py-2.5 bg-white dark:bg-slate-950 border border-slate-300 dark:border-slate-700 rounded-lg text-slate-900 dark:text-slate-200 text-base outline-none focus:border-blue-500 dark:focus:border-blue-400 transition-colors"
           />
           <button
             type="submit"

--- a/packages/frontend/src/pages/ProjectConfigPage.tsx
+++ b/packages/frontend/src/pages/ProjectConfigPage.tsx
@@ -108,7 +108,7 @@ export function ProjectConfigPage() {
             min={1}
             value={scaleInput}
             onChange={(e) => setScaleInput(e.target.value)}
-            className="w-20 px-2 py-1.5 bg-white dark:bg-slate-950 border border-slate-300 dark:border-slate-700 rounded text-sm text-slate-900 dark:text-slate-200"
+            className="w-20 px-2 py-1.5 bg-white dark:bg-slate-950 border border-slate-300 dark:border-slate-700 rounded text-base text-slate-900 dark:text-slate-200"
           />
           <button
             onClick={handleScaleUpdate}


### PR DESCRIPTION
Closes #352

## Changes

Prevents iPhone Safari from auto-zooming on input focus by ensuring all form controls have a font-size of 16px or larger. Safari triggers auto-zoom when the focused element has a font-size below ~16px.

### Files changed

- **`packages/frontend/src/index.css`** — Added a global CSS rule as a safety net: `input, textarea, select { font-size: 1rem; }`. This covers all current and future form controls without needing to remember to add `text-base` everywhere.
- **`packages/frontend/src/pages/LoginPage.tsx`** — Replaced `text-sm` (14px) with `text-base` (16px) on the password input.
- **`packages/frontend/src/pages/ChatPage.tsx`** — Replaced `text-sm` (14px) with `text-base` (16px) on the chat textarea.
- **`packages/frontend/src/pages/DashboardPage.tsx`** — Replaced `text-xs` (12px) with `text-base` (16px) on the agent search input.
- **`packages/frontend/src/pages/ProjectConfigPage.tsx`** — Replaced `text-sm` (14px) with `text-base` (16px) on the project scale number input.
- **`packages/frontend/src/pages/AgentDetailPage.tsx`** — Replaced `text-xs` (12px) with `text-base` (16px) on the agent scale number input; also widened from `w-14` to `w-16` to accommodate the larger font.
- **`packages/frontend/src/components/RunModal.tsx`** — Replaced `text-sm` (14px) with `text-base` (16px) on the prompt textarea.

### Build

✅ `npm run build -w packages/frontend` passes with no errors.