### PR TITLE
feat: Add support for Slack webhook and API access with credentials

### DIFF
--- a/.changeset/add-slack-support.md
+++ b/.changeset/add-slack-support.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Add Slack webhook provider and credential support. Agents can now listen for Slack Events API webhooks and interact with Slack via the `SLACK_BOT_TOKEN` environment variable. Includes `slack_bot_token` and `slack_signing_secret` credential types, full signature verification with replay protection, and URL verification challenge handling.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12139,7 +12139,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.18.2",
+      "version": "0.18.4",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/packages/action-llama/src/credentials/builtins/index.ts
+++ b/packages/action-llama/src/credentials/builtins/index.ts
@@ -25,6 +25,8 @@ import cloudflareApiToken from "./cloudflare-api-token.js";
 import redditOAuth from "./reddit-oauth.js";
 import mintlifyToken from "./mintlify-token.js";
 import mintlifyWebhookSecret from "./mintlify-webhook-secret.js";
+import slackBotToken from "./slack-bot-token.js";
+import slackSigningSecret from "./slack-signing-secret.js";
 
 export const builtinCredentials: Record<string, CredentialDefinition> = {
   "github_token": githubToken,
@@ -53,4 +55,6 @@ export const builtinCredentials: Record<string, CredentialDefinition> = {
   "reddit_oauth": redditOAuth,
   "mintlify_token": mintlifyToken,
   "mintlify_webhook_secret": mintlifyWebhookSecret,
+  "slack_bot_token": slackBotToken,
+  "slack_signing_secret": slackSigningSecret,
 };

--- a/packages/action-llama/src/credentials/builtins/slack-bot-token.ts
+++ b/packages/action-llama/src/credentials/builtins/slack-bot-token.ts
@@ -1,0 +1,29 @@
+import type { CredentialDefinition } from "../schema.js";
+
+const slackBotToken: CredentialDefinition = {
+  id: "slack_bot_token",
+  label: "Slack Bot Token",
+  description: "Slack bot user OAuth token for interacting with the Slack API",
+  helpUrl: "https://api.slack.com/authentication/token-types#bot",
+  fields: [
+    { name: "token", label: "Bot Token", description: "Slack bot user OAuth token (xoxb-...)", secret: true },
+  ],
+  envVars: { token: "SLACK_BOT_TOKEN" },
+  agentContext: "`SLACK_BOT_TOKEN` — use for Slack API access via curl or HTTP libraries",
+
+  async validate(values) {
+    if (!values.token) throw new Error("Slack bot token is required");
+    const response = await fetch("https://slack.com/api/auth.test", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${values.token}`,
+        "Content-Type": "application/json",
+      },
+    });
+    const data = await response.json();
+    if (!data.ok) throw new Error(`Invalid Slack bot token: ${data.error}`);
+    return true;
+  },
+};
+
+export default slackBotToken;

--- a/packages/action-llama/src/credentials/builtins/slack-signing-secret.ts
+++ b/packages/action-llama/src/credentials/builtins/slack-signing-secret.ts
@@ -1,0 +1,20 @@
+import type { CredentialDefinition } from "../schema.js";
+
+const slackSigningSecret: CredentialDefinition = {
+  id: "slack_signing_secret",
+  label: "Slack Signing Secret",
+  description: "Signing secret for verifying Slack webhook payloads. Found in your Slack app settings under App Settings → Basic Information → App Credentials.",
+  helpUrl: "https://api.slack.com/authentication/verifying-requests-from-slack",
+  fields: [
+    { name: "secret", label: "Signing Secret", description: "Slack app signing secret (found in App Settings → Basic Information → App Credentials)", secret: true },
+  ],
+  // No envVars or agentContext — used by the gateway, not injected into agents
+
+  async validate(values) {
+    if (!values.secret) throw new Error("Signing secret is required");
+    if (values.secret.length < 8) throw new Error("Signing secret must be at least 8 characters");
+    return true;
+  },
+};
+
+export default slackSigningSecret;

--- a/packages/action-llama/src/events/routes/webhooks.ts
+++ b/packages/action-llama/src/events/routes/webhooks.ts
@@ -13,6 +13,8 @@ const SIGNATURE_HEADERS = new Set([
   "sentry-hook-signature",
   "linear-signature",
   "mintlify-signature",
+  "x-slack-signature",
+  "x-slack-request-timestamp",
 ]);
 
 const MAX_STORED_BODY = 256 * 1024; // 256 KB
@@ -133,6 +135,16 @@ export function registerWebhookRoutes(
 
     const secrets = webhookSecrets[source];
     const config = webhookConfigs[source];
+
+    // Handle provider setup challenges (e.g., Slack URL verification)
+    if (provider.handleChallenge) {
+      const challengeResponse = provider.handleChallenge(headers, rawBody, secrets, config?.allowUnsigned);
+      if (challengeResponse) {
+        logger.info({ source }, "webhook setup challenge handled");
+        return c.json(challengeResponse);
+      }
+    }
+
     const result = registry.dispatch(source, headers, rawBody, { secrets, config }, receiptId);
 
     // Update receipt status based on dispatch result

--- a/packages/action-llama/src/extensions/loader.ts
+++ b/packages/action-llama/src/extensions/loader.ts
@@ -44,6 +44,7 @@ async function loadWebhookExtensions(registry: ExtensionRegistry): Promise<void>
       linearWebhookExtension,
       mintlifyWebhookExtension,
       sentryWebhookExtension,
+      slackWebhookExtension,
       testWebhookExtension
     } = await import("../webhooks/providers/index.js");
     
@@ -51,6 +52,7 @@ async function loadWebhookExtensions(registry: ExtensionRegistry): Promise<void>
     await registry.register(linearWebhookExtension);
     await registry.register(mintlifyWebhookExtension);
     await registry.register(sentryWebhookExtension);
+    await registry.register(slackWebhookExtension);
     await registry.register(testWebhookExtension);
   } catch (error) {
     console.warn("Failed to load webhook extensions:", error);

--- a/packages/action-llama/src/webhooks/definitions/registry.ts
+++ b/packages/action-llama/src/webhooks/definitions/registry.ts
@@ -1,8 +1,9 @@
 import type { WebhookDefinition } from "./schema.js";
 import { github } from "./github.js";
 import { sentry } from "./sentry.js";
+import { slack } from "./slack.js";
 
-const definitions: WebhookDefinition[] = [github, sentry];
+const definitions: WebhookDefinition[] = [github, sentry, slack];
 
 export function resolveWebhookDefinition(id: string): WebhookDefinition {
   const def = definitions.find((d) => d.id === id);

--- a/packages/action-llama/src/webhooks/definitions/slack.ts
+++ b/packages/action-llama/src/webhooks/definitions/slack.ts
@@ -1,0 +1,26 @@
+import type { WebhookDefinition } from "./schema.js";
+
+export const slack: WebhookDefinition = {
+  id: "slack",
+  label: "Slack",
+  description: "Slack Events API webhook events",
+  secretCredential: "slack_signing_secret",
+  filterSpec: [
+    {
+      field: "events",
+      label: "Event Types",
+      type: "multi-select",
+      required: true,
+      options: [
+        { value: "message", label: "Messages" },
+        { value: "app_mention", label: "App Mentions" },
+        { value: "reaction_added", label: "Reaction Added" },
+        { value: "reaction_removed", label: "Reaction Removed" },
+        { value: "channel_created", label: "Channel Created" },
+        { value: "member_joined_channel", label: "Member Joined Channel" },
+      ],
+    },
+    { field: "channels", label: "Channels", type: "text[]" },
+    { field: "team_ids", label: "Team/Workspace IDs", type: "text[]" },
+  ],
+};

--- a/packages/action-llama/src/webhooks/providers/index.ts
+++ b/packages/action-llama/src/webhooks/providers/index.ts
@@ -7,6 +7,7 @@ import { GitHubWebhookProvider } from "./github.js";
 import { LinearWebhookProvider } from "./linear.js";
 import { MintlifyWebhookProvider } from "./mintlify.js";
 import { SentryWebhookProvider } from "./sentry.js";
+import { SlackWebhookProvider } from "./slack.js";
 import { TestWebhookProvider } from "./test.js";
 
 /**
@@ -121,6 +122,36 @@ export const sentryWebhookExtension: WebhookExtension = {
     ]
   },
   provider: new SentryWebhookProvider(),
+  async init() {
+    // No special initialization required
+  },
+  async shutdown() {
+    // No cleanup required
+  }
+};
+
+/**
+ * Slack webhook provider extension
+ */
+export const slackWebhookExtension: WebhookExtension = {
+  metadata: {
+    name: "slack",
+    version: "1.0.0",
+    description: "Slack Events API webhook provider",
+    type: "webhook",
+    requiredCredentials: [
+      { type: "slack_signing_secret", description: "Slack signing secret for request verification", optional: true }
+    ],
+    providesCredentialTypes: [
+      {
+        type: "slack_signing_secret",
+        fields: ["secret"],
+        description: "Slack signing secret",
+        envMapping: { secret: "SLACK_SIGNING_SECRET" }
+      }
+    ]
+  },
+  provider: new SlackWebhookProvider(),
   async init() {
     // No special initialization required
   },

--- a/packages/action-llama/src/webhooks/providers/slack.ts
+++ b/packages/action-llama/src/webhooks/providers/slack.ts
@@ -1,0 +1,153 @@
+import { createHmac, timingSafeEqual } from "crypto";
+import type { WebhookProvider, WebhookContext, WebhookFilter, SlackWebhookFilter } from "../types.js";
+import { truncateEventText as truncate } from "../validation.js";
+
+const MAX_TIMESTAMP_AGE_SECONDS = 5 * 60; // 5 minutes
+
+export class SlackWebhookProvider implements WebhookProvider {
+  source = "slack";
+
+  validateRequest(
+    headers: Record<string, string | undefined>,
+    rawBody: string,
+    secrets?: Record<string, string>,
+    allowUnsigned?: boolean
+  ): string | null {
+    // If no secrets configured, check allowUnsigned policy
+    if (!secrets || Object.keys(secrets).length === 0) {
+      return allowUnsigned ? "_unsigned" : null;
+    }
+
+    const timestamp = headers["x-slack-request-timestamp"];
+    const signature = headers["x-slack-signature"];
+
+    if (!timestamp || !signature) return null;
+
+    // Replay protection: reject if timestamp is older than 5 minutes
+    const now = Math.floor(Date.now() / 1000);
+    if (Math.abs(now - parseInt(timestamp, 10)) > MAX_TIMESTAMP_AGE_SECONDS) {
+      return null;
+    }
+
+    const signingBase = `v0:${timestamp}:${rawBody}`;
+
+    for (const [instanceName, secret] of Object.entries(secrets)) {
+      const expected = "v0=" + createHmac("sha256", secret).update(signingBase).digest("hex");
+      if (
+        signature.length === expected.length &&
+        timingSafeEqual(Buffer.from(signature), Buffer.from(expected))
+      ) {
+        return instanceName;
+      }
+    }
+
+    return null;
+  }
+
+  parseEvent(headers: Record<string, string | undefined>, body: any): WebhookContext | null {
+    // URL verification challenges are handled by handleChallenge, not dispatched
+    if (body.type === "url_verification") {
+      return null;
+    }
+
+    if (body.type !== "event_callback") {
+      return null;
+    }
+
+    const event = body.event;
+    if (!event) return null;
+
+    const eventType: string = event.type;
+    const teamId: string = body.team_id;
+    const sender: string = event.user || event.bot_id || "unknown";
+
+    const base: Partial<WebhookContext> = {
+      source: "slack",
+      event: eventType,
+      repo: teamId,
+      sender,
+      timestamp: new Date().toISOString(),
+    };
+
+    switch (eventType) {
+      case "message":
+        return {
+          ...base,
+          body: truncate(event.text),
+          comment: event.channel ? `channel:${event.channel}` : undefined,
+        } as WebhookContext;
+
+      case "app_mention":
+        return {
+          ...base,
+          body: truncate(event.text),
+          comment: event.channel ? `channel:${event.channel}` : undefined,
+        } as WebhookContext;
+
+      case "reaction_added":
+      case "reaction_removed":
+        return {
+          ...base,
+          title: event.reaction,
+          comment: event.item ? `${event.item.type}:${event.item.channel || ""}` : undefined,
+        } as WebhookContext;
+
+      default:
+        return {
+          ...base,
+          title: eventType,
+          body: truncate(event.text),
+        } as WebhookContext;
+    }
+  }
+
+  matchesFilter(context: WebhookContext, filter: WebhookFilter): boolean {
+    const f = filter as SlackWebhookFilter;
+
+    if (f.events?.length && !f.events.includes(context.event)) {
+      return false;
+    }
+
+    if (f.team_ids?.length && !f.team_ids.includes(context.repo)) {
+      return false;
+    }
+
+    // Channel matching: stored as comment field with "channel:<id>" format
+    if (f.channels?.length) {
+      const channelComment = context.comment;
+      if (!channelComment) return false;
+      const match = channelComment.match(/^channel:(.+)$/);
+      if (!match) return false;
+      const channelId = match[1];
+      if (!f.channels.includes(channelId)) return false;
+    }
+
+    return true;
+  }
+
+  handleChallenge(
+    headers: Record<string, string | undefined>,
+    rawBody: string,
+    secrets?: Record<string, string>,
+    allowUnsigned?: boolean
+  ): object | null {
+    let body: any;
+    try {
+      body = JSON.parse(rawBody);
+    } catch {
+      return null;
+    }
+
+    if (body.type !== "url_verification" || !body.challenge) {
+      return null;
+    }
+
+    // Validate the request signature before responding
+    const validationResult = this.validateRequest(headers, rawBody, secrets, allowUnsigned);
+    if (!validationResult) {
+      return null;
+    }
+
+    return { challenge: body.challenge };
+  }
+}

--- a/packages/action-llama/src/webhooks/types.ts
+++ b/packages/action-llama/src/webhooks/types.ts
@@ -57,7 +57,13 @@ export interface MintlifyWebhookFilter {
   branches?: string[];
 }
 
-export type WebhookFilter = GitHubWebhookFilter | SentryWebhookFilter | LinearWebhookFilter | MintlifyWebhookFilter;
+export interface SlackWebhookFilter {
+  events?: string[];     // e.g. "message", "app_mention", "reaction_added"
+  channels?: string[];   // Slack channel IDs
+  team_ids?: string[];   // Slack workspace/team IDs
+}
+
+export type WebhookFilter = GitHubWebhookFilter | SentryWebhookFilter | LinearWebhookFilter | MintlifyWebhookFilter | SlackWebhookFilter;
 
 // --- Webhook trigger (used in agent config) ---
 
@@ -84,6 +90,7 @@ export interface WebhookProvider {
   parseEvent(headers: Record<string, string | undefined>, body: any): WebhookContext | null;
   matchesFilter(context: WebhookContext, filter: WebhookFilter): boolean;
   getDeliveryId?(headers: Record<string, string | undefined>): string | null;
+  handleChallenge?(headers: Record<string, string | undefined>, rawBody: string, secrets?: Record<string, string>, allowUnsigned?: boolean): object | null;
 }
 
 // --- Registry binding ---

--- a/packages/action-llama/test/webhooks/providers/slack.test.ts
+++ b/packages/action-llama/test/webhooks/providers/slack.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createHmac } from "crypto";
+import { SlackWebhookProvider } from "../../../src/webhooks/providers/slack.js";
+import type { SlackWebhookFilter, WebhookContext } from "../../../src/webhooks/types.js";
+
+const provider = new SlackWebhookProvider();
+
+const secret = "slack-signing-secret-123";
+
+function makeTimestamp(): string {
+  return String(Math.floor(Date.now() / 1000));
+}
+
+function sign(rawBody: string, timestamp: string, s: string): string {
+  const signingBase = `v0:${timestamp}:${rawBody}`;
+  return "v0=" + createHmac("sha256", s).update(signingBase).digest("hex");
+}
+
+describe("SlackWebhookProvider", () => {
+  describe("validateRequest", () => {
+    it("accepts valid signature and returns instance name", () => {
+      const body = '{"type":"event_callback","event":{"type":"message"}}';
+      const ts = makeTimestamp();
+      const sig = sign(body, ts, secret);
+      expect(
+        provider.validateRequest(
+          { "x-slack-signature": sig, "x-slack-request-timestamp": ts },
+          body,
+          { MyWorkspace: secret }
+        )
+      ).toBe("MyWorkspace");
+    });
+
+    it("rejects invalid signature", () => {
+      const body = '{"type":"event_callback"}';
+      const ts = makeTimestamp();
+      const sig = sign("different body", ts, secret);
+      expect(
+        provider.validateRequest(
+          { "x-slack-signature": sig, "x-slack-request-timestamp": ts },
+          body,
+          { MyWorkspace: secret }
+        )
+      ).toBeNull();
+    });
+
+    it("rejects missing signature header", () => {
+      const body = '{"type":"event_callback"}';
+      const ts = makeTimestamp();
+      expect(
+        provider.validateRequest(
+          { "x-slack-request-timestamp": ts },
+          body,
+          { MyWorkspace: secret }
+        )
+      ).toBeNull();
+    });
+
+    it("rejects missing timestamp header", () => {
+      const body = '{"type":"event_callback"}';
+      const ts = makeTimestamp();
+      const sig = sign(body, ts, secret);
+      expect(
+        provider.validateRequest(
+          { "x-slack-signature": sig },
+          body,
+          { MyWorkspace: secret }
+        )
+      ).toBeNull();
+    });
+
+    it("rejects stale timestamp (older than 5 minutes)", () => {
+      const body = '{"type":"event_callback"}';
+      const staleTs = String(Math.floor(Date.now() / 1000) - 400); // 400 seconds ago
+      const sig = sign(body, staleTs, secret);
+      expect(
+        provider.validateRequest(
+          { "x-slack-signature": sig, "x-slack-request-timestamp": staleTs },
+          body,
+          { MyWorkspace: secret }
+        )
+      ).toBeNull();
+    });
+
+    it("allows unsigned when no secrets and allowUnsigned is true", () => {
+      const body = '{"type":"event_callback"}';
+      const ts = makeTimestamp();
+      expect(provider.validateRequest({ "x-slack-request-timestamp": ts }, body, undefined, true)).toBe("_unsigned");
+      expect(provider.validateRequest({ "x-slack-request-timestamp": ts }, body, {}, true)).toBe("_unsigned");
+    });
+
+    it("rejects when no secrets and allowUnsigned is false", () => {
+      const body = '{"type":"event_callback"}';
+      const ts = makeTimestamp();
+      expect(provider.validateRequest({ "x-slack-request-timestamp": ts }, body, undefined, false)).toBeNull();
+      expect(provider.validateRequest({ "x-slack-request-timestamp": ts }, body, {})).toBeNull();
+    });
+
+    it("matches correct instance when multiple secrets configured", () => {
+      const body = '{"type":"event_callback"}';
+      const ts = makeTimestamp();
+      const sig = sign(body, ts, "second-secret");
+      expect(
+        provider.validateRequest(
+          { "x-slack-signature": sig, "x-slack-request-timestamp": ts },
+          body,
+          { WorkspaceA: "wrong-secret", WorkspaceB: "second-secret" }
+        )
+      ).toBe("WorkspaceB");
+    });
+
+    it("rejects when none of multiple secrets match", () => {
+      const body = '{"type":"event_callback"}';
+      const ts = makeTimestamp();
+      const sig = sign(body, ts, "actual-secret");
+      expect(
+        provider.validateRequest(
+          { "x-slack-signature": sig, "x-slack-request-timestamp": ts },
+          body,
+          { WorkspaceA: "wrong-secret", WorkspaceB: "also-wrong" }
+        )
+      ).toBeNull();
+    });
+  });
+
+  describe("parseEvent", () => {
+    it("parses message event callback", () => {
+      const body = {
+        type: "event_callback",
+        team_id: "T123",
+        event: {
+          type: "message",
+          user: "U456",
+          text: "Hello world",
+          channel: "C789",
+        },
+      };
+      const result = provider.parseEvent({}, body);
+      expect(result).toMatchObject({
+        source: "slack",
+        event: "message",
+        repo: "T123",
+        sender: "U456",
+        body: "Hello world",
+        comment: "channel:C789",
+      });
+    });
+
+    it("parses app_mention event callback", () => {
+      const body = {
+        type: "event_callback",
+        team_id: "T123",
+        event: {
+          type: "app_mention",
+          user: "U456",
+          text: "<@BOTID> hello",
+          channel: "C789",
+        },
+      };
+      const result = provider.parseEvent({}, body);
+      expect(result).toMatchObject({
+        source: "slack",
+        event: "app_mention",
+        repo: "T123",
+        sender: "U456",
+        body: "<@BOTID> hello",
+        comment: "channel:C789",
+      });
+    });
+
+    it("parses reaction_added event callback", () => {
+      const body = {
+        type: "event_callback",
+        team_id: "T123",
+        event: {
+          type: "reaction_added",
+          user: "U456",
+          reaction: "thumbsup",
+          item: { type: "message", channel: "C789" },
+        },
+      };
+      const result = provider.parseEvent({}, body);
+      expect(result).toMatchObject({
+        source: "slack",
+        event: "reaction_added",
+        repo: "T123",
+        sender: "U456",
+        title: "thumbsup",
+      });
+    });
+
+    it("returns null for url_verification type", () => {
+      const body = {
+        type: "url_verification",
+        challenge: "abc123",
+      };
+      expect(provider.parseEvent({}, body)).toBeNull();
+    });
+
+    it("returns null for non-event_callback types", () => {
+      expect(provider.parseEvent({}, { type: "block_actions" })).toBeNull();
+    });
+
+    it("returns null when event field is missing", () => {
+      expect(provider.parseEvent({}, { type: "event_callback", team_id: "T123" })).toBeNull();
+    });
+
+    it("handles truncation of long text", () => {
+      const longText = "x".repeat(5000);
+      const body = {
+        type: "event_callback",
+        team_id: "T123",
+        event: {
+          type: "message",
+          user: "U456",
+          text: longText,
+          channel: "C789",
+        },
+      };
+      const result = provider.parseEvent({}, body);
+      expect(result?.body).toMatch(/^x+\.\.\.$/);
+      expect((result?.body?.length ?? 0)).toBeLessThan(longText.length);
+    });
+
+    it("handles unknown event types gracefully", () => {
+      const body = {
+        type: "event_callback",
+        team_id: "T123",
+        event: {
+          type: "channel_archive",
+          user: "U456",
+        },
+      };
+      const result = provider.parseEvent({}, body);
+      expect(result).toMatchObject({
+        source: "slack",
+        event: "channel_archive",
+        repo: "T123",
+        sender: "U456",
+      });
+    });
+  });
+
+  describe("matchesFilter", () => {
+    const context: WebhookContext = {
+      source: "slack",
+      event: "message",
+      repo: "T123",
+      sender: "U456",
+      comment: "channel:C789",
+      timestamp: "2024-01-01T12:00:00Z",
+    };
+
+    it("matches when no filters are specified", () => {
+      const filter: SlackWebhookFilter = {};
+      expect(provider.matchesFilter(context, filter)).toBe(true);
+    });
+
+    it("matches when event filter matches", () => {
+      const filter: SlackWebhookFilter = { events: ["message", "app_mention"] };
+      expect(provider.matchesFilter(context, filter)).toBe(true);
+    });
+
+    it("does not match when event filter does not match", () => {
+      const filter: SlackWebhookFilter = { events: ["app_mention"] };
+      expect(provider.matchesFilter(context, filter)).toBe(false);
+    });
+
+    it("matches when team_id filter matches", () => {
+      const filter: SlackWebhookFilter = { team_ids: ["T123", "T456"] };
+      expect(provider.matchesFilter(context, filter)).toBe(true);
+    });
+
+    it("does not match when team_id filter does not match", () => {
+      const filter: SlackWebhookFilter = { team_ids: ["T999"] };
+      expect(provider.matchesFilter(context, filter)).toBe(false);
+    });
+
+    it("matches when channel filter matches", () => {
+      const filter: SlackWebhookFilter = { channels: ["C789"] };
+      expect(provider.matchesFilter(context, filter)).toBe(true);
+    });
+
+    it("does not match when channel filter does not match", () => {
+      const filter: SlackWebhookFilter = { channels: ["C999"] };
+      expect(provider.matchesFilter(context, filter)).toBe(false);
+    });
+
+    it("does not match channel filter when context has no channel", () => {
+      const contextNoChannel = { ...context, comment: undefined };
+      const filter: SlackWebhookFilter = { channels: ["C789"] };
+      expect(provider.matchesFilter(contextNoChannel, filter)).toBe(false);
+    });
+
+    it("matches with combined filters all passing", () => {
+      const filter: SlackWebhookFilter = {
+        events: ["message"],
+        team_ids: ["T123"],
+        channels: ["C789"],
+      };
+      expect(provider.matchesFilter(context, filter)).toBe(true);
+    });
+
+    it("does not match when any combined filter fails", () => {
+      const filter: SlackWebhookFilter = {
+        events: ["message"],
+        team_ids: ["T123"],
+        channels: ["C999"], // fails
+      };
+      expect(provider.matchesFilter(context, filter)).toBe(false);
+    });
+  });
+
+  describe("handleChallenge", () => {
+    it("returns challenge for valid url_verification with valid signature", () => {
+      const body = JSON.stringify({
+        type: "url_verification",
+        challenge: "3eZbrw1aBm2rZgRNFdxV2595E9CY3gmdALWMmHkvFXO7tYXAYM8P",
+      });
+      const ts = makeTimestamp();
+      const sig = sign(body, ts, secret);
+      const result = provider.handleChallenge(
+        { "x-slack-signature": sig, "x-slack-request-timestamp": ts },
+        body,
+        { MyWorkspace: secret }
+      );
+      expect(result).toEqual({ challenge: "3eZbrw1aBm2rZgRNFdxV2595E9CY3gmdALWMmHkvFXO7tYXAYM8P" });
+    });
+
+    it("returns null for non-verification requests", () => {
+      const body = JSON.stringify({
+        type: "event_callback",
+        event: { type: "message" },
+      });
+      const ts = makeTimestamp();
+      const sig = sign(body, ts, secret);
+      const result = provider.handleChallenge(
+        { "x-slack-signature": sig, "x-slack-request-timestamp": ts },
+        body,
+        { MyWorkspace: secret }
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns null when signature validation fails", () => {
+      const body = JSON.stringify({
+        type: "url_verification",
+        challenge: "abc123",
+      });
+      const staleTs = String(Math.floor(Date.now() / 1000) - 400);
+      const sig = sign(body, staleTs, secret);
+      // Stale timestamp should fail validation
+      const result = provider.handleChallenge(
+        { "x-slack-signature": sig, "x-slack-request-timestamp": staleTs },
+        body,
+        { MyWorkspace: secret }
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns null for invalid JSON body", () => {
+      const result = provider.handleChallenge({}, "not-json", { MyWorkspace: secret });
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/docs/reference/credentials.mdx
+++ b/packages/docs/reference/credentials.mdx
@@ -26,6 +26,7 @@ Credentials are stored in `~/.action-llama/credentials/<type>/<instance>/<field>
 | `bugsnag_token` | `token` | Bugsnag auth token | `BUGSNAG_AUTH_TOKEN` env var |
 | `netlify_token` | `token` | Netlify Personal Access Token | `NETLIFY_AUTH_TOKEN` env var |
 | `mintlify_token` | `token` | Mintlify API token | `MINTLIFY_API_TOKEN` env var |
+| `slack_bot_token` | `token` | Slack bot user OAuth token | `SLACK_BOT_TOKEN` env var |
 | `git_ssh` | `id_rsa`, `username`, `email` | SSH private key + git author identity | SSH key mounted as file; `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL`/`GIT_COMMITTER_NAME`/`GIT_COMMITTER_EMAIL` set from `username`/`email` |
 | `x_twitter_api` | `api_key`, `api_secret`, `bearer_token`, `access_token`, `access_token_secret` | X (Twitter) API credentials | `X_API_KEY`, `X_API_SECRET`, `X_BEARER_TOKEN`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET` env vars |
 | `aws` | `access_key_id`, `secret_access_key`, `default_region` | AWS credentials | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` env vars |
@@ -39,6 +40,7 @@ Credentials are stored in `~/.action-llama/credentials/<type>/<instance>/<field>
 | `sentry_client_secret` | `secret` | Client secret for Sentry webhook verification |
 | `linear_webhook_secret` | `secret` | Shared secret for Linear webhook verification |
 | `mintlify_webhook_secret` | `secret` | Shared secret for Mintlify webhook verification |
+| `slack_signing_secret` | `secret` | Signing secret for Slack webhook verification |
 
 ### Infrastructure credentials
 


### PR DESCRIPTION
Closes #358

## Summary

This PR adds Slack as a first-class webhook provider and API credential type, following the existing integration patterns used by Linear, Sentry, Mintlify, and GitHub.

## Changes

### New files
- **`packages/action-llama/src/credentials/builtins/slack-bot-token.ts`** — Slack Bot Token credential (`SLACK_BOT_TOKEN` env var) with API validation
- **`packages/action-llama/src/credentials/builtins/slack-signing-secret.ts`** — Slack signing secret credential for webhook verification (gateway-only)
- **`packages/action-llama/src/webhooks/providers/slack.ts`** — `SlackWebhookProvider` implementing custom HMAC-SHA256 signature verification with replay protection
- **`packages/action-llama/src/webhooks/definitions/slack.ts`** — Slack webhook definition for the dashboard/CLI
- **`packages/action-llama/test/webhooks/providers/slack.test.ts`** — 31 unit tests covering all provider methods

### Modified files
- **`packages/action-llama/src/webhooks/types.ts`** — Added `SlackWebhookFilter` interface, updated `WebhookFilter` union, added optional `handleChallenge` method to `WebhookProvider`
- **`packages/action-llama/src/webhooks/providers/index.ts`** — Added `slackWebhookExtension` export
- **`packages/action-llama/src/credentials/builtins/index.ts`** — Registered `slack_bot_token` and `slack_signing_secret`
- **`packages/action-llama/src/webhooks/definitions/registry.ts`** — Registered Slack webhook definition
- **`packages/action-llama/src/extensions/loader.ts`** — Registered `slackWebhookExtension` in `loadWebhookExtensions()`
- **`packages/action-llama/src/events/routes/webhooks.ts`** — Added Slack headers to `SIGNATURE_HEADERS`, added challenge-response handling
- **`packages/docs/reference/credentials.mdx`** — Documented new credential types

## Key implementation notes

- **Slack signature verification** uses `v0:timestamp:rawBody` as the HMAC input (unique to Slack), so the shared `validateHmacSignature` utility is not used. Custom logic with 5-minute replay protection is implemented.
- **URL verification challenge** — Slack's `url_verification` POST is handled via the new optional `handleChallenge` method on `WebhookProvider`, keeping the route handler generic.
- **No `getDeliveryId`** — Slack puts `event_id` in the body, not headers, so header-based dedup is not applicable.
- **`WebhookContext.repo`** maps to `team_id` (closest Slack equivalent to an org/repo identifier).

## Tests

All 1664 existing tests pass, plus 31 new tests for the Slack provider.