### PR TITLE
feat: show deadLetterReason in trigger history UI

### DIFF
--- a/.changeset/dead-letter-reason-display.md
+++ b/.changeset/dead-letter-reason-display.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Show specific dead letter reason (e.g. "No Match", "Validation Failed", "Parse Error") in the trigger history UI instead of the generic "Dead Letter" label. Closes #360.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12139,7 +12139,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.18.2",
+      "version": "0.18.4",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/packages/action-llama/src/control/routes/stats.ts
+++ b/packages/action-llama/src/control/routes/stats.ts
@@ -50,6 +50,7 @@ export function registerStatsRoutes(app: Hono, statsStore?: StatsStore, statusTr
             instanceId: inst.id,
             result: "running",
             webhookReceiptId: null,
+            deadLetterReason: null,
           };
         });
       mergedTriggers = [...running, ...triggers].sort((a, b) => b.ts - a.ts);

--- a/packages/action-llama/src/stats/store.ts
+++ b/packages/action-llama/src/stats/store.ts
@@ -45,6 +45,7 @@ export interface TriggerHistoryRow {
   triggerSource: string | null;
   result: string;
   webhookReceiptId: string | null;
+  deadLetterReason: string | null;
 }
 
 export interface CallEdgeRecord {
@@ -264,19 +265,22 @@ export class StatsStore {
       queryTriggerHistory: this.db.prepare(`
         SELECT started_at AS ts, instance_id AS instanceId, agent_name AS agentName,
                trigger_type AS triggerType, trigger_source AS triggerSource,
-               result, webhook_receipt_id AS webhookReceiptId
+               result, webhook_receipt_id AS webhookReceiptId,
+               NULL AS deadLetterReason
         FROM runs WHERE started_at > @since
         UNION ALL
         SELECT timestamp AS ts, NULL AS instanceId, NULL AS agentName,
                'webhook' AS triggerType, source AS triggerSource,
-               'dead-letter' AS result, id AS webhookReceiptId
+               'dead-letter' AS result, id AS webhookReceiptId,
+               dead_letter_reason AS deadLetterReason
         FROM webhook_receipts WHERE status = 'dead-letter' AND timestamp > @since
         ORDER BY ts DESC LIMIT @limit OFFSET @offset
       `),
       queryTriggerHistoryNoDeadLetters: this.db.prepare(`
         SELECT started_at AS ts, instance_id AS instanceId, agent_name AS agentName,
                trigger_type AS triggerType, trigger_source AS triggerSource,
-               result, webhook_receipt_id AS webhookReceiptId
+               result, webhook_receipt_id AS webhookReceiptId,
+               NULL AS deadLetterReason
         FROM runs WHERE started_at > @since
         ORDER BY ts DESC LIMIT @limit OFFSET @offset
       `),
@@ -289,7 +293,8 @@ export class StatsStore {
       queryTriggerHistoryByAgent: this.db.prepare(`
         SELECT started_at AS ts, instance_id AS instanceId, agent_name AS agentName,
                trigger_type AS triggerType, trigger_source AS triggerSource,
-               result, webhook_receipt_id AS webhookReceiptId
+               result, webhook_receipt_id AS webhookReceiptId,
+               NULL AS deadLetterReason
         FROM runs WHERE started_at > @since AND agent_name = @agentName
         ORDER BY ts DESC LIMIT @limit OFFSET @offset
       `),

--- a/packages/action-llama/test/stats/store.test.ts
+++ b/packages/action-llama/test/stats/store.test.ts
@@ -404,6 +404,10 @@ describe("StatsStore", () => {
     expect(rows[0].result).toBe("dead-letter");
     expect(rows[1].agentName).toBe("b");
     expect(rows[2].agentName).toBe("a");
+    // deadLetterReason should be populated for dead-letter rows, null for runs
+    expect(rows[0].deadLetterReason).toBe("no_match");
+    expect(rows[1].deadLetterReason).toBeNull();
+    expect(rows[2].deadLetterReason).toBeNull();
     store.close();
   });
 

--- a/packages/frontend/src/components/Badge.tsx
+++ b/packages/frontend/src/components/Badge.tsx
@@ -18,7 +18,7 @@ export function TriggerTypeBadge({ type }: { type: string }) {
   );
 }
 
-export function ResultBadge({ result }: { result: string }) {
+export function ResultBadge({ result, deadLetterReason }: { result: string; deadLetterReason?: string | null }) {
   if (result === "completed" || result === "rerun") {
     return (
       <span className="text-green-600 dark:text-green-400 text-xs font-medium">
@@ -27,9 +27,15 @@ export function ResultBadge({ result }: { result: string }) {
     );
   }
   if (result === "dead-letter") {
+    const reasonLabels: Record<string, string> = {
+      no_match: "No Match",
+      validation_failed: "Validation Failed",
+      parse_error: "Parse Error",
+    };
+    const label = deadLetterReason ? (reasonLabels[deadLetterReason] ?? deadLetterReason) : "Dead Letter";
     return (
       <span className="px-1.5 py-0.5 text-xs font-medium rounded bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300">
-        Dead Letter
+        {label}
       </span>
     );
   }

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -106,6 +106,7 @@ export interface TriggerHistoryRow {
   agentName?: string;
   instanceId?: string;
   result: string;
+  deadLetterReason?: string | null;
 }
 
 export interface AgentSummary {

--- a/packages/frontend/src/pages/AgentDetailPage.tsx
+++ b/packages/frontend/src/pages/AgentDetailPage.tsx
@@ -414,7 +414,7 @@ export function AgentDetailPage() {
                     )}
                   </td>
                   <td className="px-4 py-2 whitespace-nowrap">
-                    <ResultBadge result={t.result} />
+                    <ResultBadge result={t.result} deadLetterReason={t.deadLetterReason} />
                   </td>
                 </tr>
               ))}

--- a/packages/frontend/src/pages/DashboardPage.tsx
+++ b/packages/frontend/src/pages/DashboardPage.tsx
@@ -329,7 +329,7 @@ export function DashboardPage() {
                     )}
                   </td>
                   <td className="px-4 py-2 whitespace-nowrap">
-                    <ResultBadge result={t.result} />
+                    <ResultBadge result={t.result} deadLetterReason={t.deadLetterReason} />
                   </td>
                 </tr>
               ))}

--- a/packages/frontend/src/pages/TriggerHistoryPage.tsx
+++ b/packages/frontend/src/pages/TriggerHistoryPage.tsx
@@ -199,7 +199,7 @@ export function TriggerHistoryPage() {
                     )}
                   </td>
                   <td className="px-4 py-2.5">
-                    <ResultBadge result={t.result} />
+                    <ResultBadge result={t.result} deadLetterReason={t.deadLetterReason} />
                   </td>
                 </tr>
               ))}


### PR DESCRIPTION
Closes #360

## Summary

When dead-letter webhook receipts are shown in the trigger history UI, the badge now displays a human-readable reason (e.g. "No Match", "Validation Failed", "Parse Error") instead of the generic "Dead Letter" label.

## Changes

- **`packages/action-llama/src/stats/store.ts`**: Added `deadLetterReason` field to `TriggerHistoryRow` interface; updated `queryTriggerHistory`, `queryTriggerHistoryNoDeadLetters`, and `queryTriggerHistoryByAgent` SQL queries to include `dead_letter_reason AS deadLetterReason` (or `NULL AS deadLetterReason` for run rows).
- **`packages/action-llama/src/control/routes/stats.ts`**: Added `deadLetterReason: null` to synthetic running-instance rows.
- **`packages/frontend/src/lib/api.ts`**: Added `deadLetterReason` to the frontend `TriggerHistoryRow` type.
- **`packages/frontend/src/components/Badge.tsx`**: Updated `ResultBadge` to accept optional `deadLetterReason` prop and display human-readable labels (`no_match` → "No Match", `validation_failed` → "Validation Failed", `parse_error` → "Parse Error"), falling back to "Dead Letter" if no reason is present.
- **`packages/frontend/src/pages/TriggerHistoryPage.tsx`**, **`DashboardPage.tsx`**, **`AgentDetailPage.tsx`**: Pass `deadLetterReason` to `ResultBadge`.
- **`packages/action-llama/test/stats/store.test.ts`**: Added assertions that `deadLetterReason` is correctly populated for dead-letter rows and `null` for run rows.