### PR TITLE
feat: Add Twitter webhook provider with CRC support

### DIFF
--- a/packages/action-llama/src/credentials/builtins/index.ts
+++ b/packages/action-llama/src/credentials/builtins/index.ts
@@ -27,6 +27,7 @@ import mintlifyToken from "./mintlify-token.js";
 import mintlifyWebhookSecret from "./mintlify-webhook-secret.js";
 import slackBotToken from "./slack-bot-token.js";
 import slackSigningSecret from "./slack-signing-secret.js";
+import xTwitterWebhookSecret from "./x-twitter-webhook-secret.js";
 
 export const builtinCredentials: Record<string, CredentialDefinition> = {
   "github_token": githubToken,
@@ -57,4 +58,5 @@ export const builtinCredentials: Record<string, CredentialDefinition> = {
   "mintlify_webhook_secret": mintlifyWebhookSecret,
   "slack_bot_token": slackBotToken,
   "slack_signing_secret": slackSigningSecret,
+  "x_twitter_webhook_secret": xTwitterWebhookSecret,
 };

--- a/packages/action-llama/src/credentials/builtins/x-twitter-webhook-secret.ts
+++ b/packages/action-llama/src/credentials/builtins/x-twitter-webhook-secret.ts
@@ -1,0 +1,14 @@
+import type { CredentialDefinition } from "../schema.js";
+
+const xTwitterWebhookSecret: CredentialDefinition = {
+  id: "x_twitter_webhook_secret",
+  label: "X (Twitter) Webhook Secret",
+  description: "Consumer Secret (API Secret) from the X Developer Portal. Used for CRC challenge-response handshake and HMAC signature validation of incoming webhooks.",
+  helpUrl: "https://developer.x.com/en/docs/twitter-api/enterprise/account-activity-api/guides/securing-webhooks",
+  fields: [
+    { name: "secret", label: "Consumer Secret", description: "The API Secret / Consumer Secret from your X app", secret: true },
+  ],
+  // No envVars or agentContext — used by the gateway, not injected into agents
+};
+
+export default xTwitterWebhookSecret;

--- a/packages/action-llama/src/events/routes/webhooks.ts
+++ b/packages/action-llama/src/events/routes/webhooks.ts
@@ -15,6 +15,7 @@ const SIGNATURE_HEADERS = new Set([
   "mintlify-signature",
   "x-slack-signature",
   "x-slack-request-timestamp",
+  "x-twitter-webhooks-signature",
 ]);
 
 const MAX_STORED_BODY = 256 * 1024; // 256 KB
@@ -38,6 +39,31 @@ export function registerWebhookRoutes(
   statusTracker?: StatusTracker,
   statsStore?: StatsStore,
 ): void {
+  // GET route for CRC challenge-response (e.g. Twitter Account Activity API)
+  app.get("/webhooks/:source", async (c) => {
+    const source = c.req.param("source");
+    const provider = registry.getProvider(source);
+    if (!provider || !provider.handleCrcChallenge) {
+      return c.json({ error: "CRC not supported for this source" }, 404);
+    }
+
+    const url = new URL(c.req.url);
+    const queryParams: Record<string, string> = {};
+    for (const [key, value] of url.searchParams.entries()) {
+      queryParams[key] = value;
+    }
+
+    const secrets = webhookSecrets[source];
+    const result = provider.handleCrcChallenge(queryParams, secrets);
+    if (!result) {
+      logger.warn({ source }, "CRC challenge failed — missing crc_token or no secrets");
+      return c.json({ error: "CRC challenge failed" }, 400);
+    }
+
+    logger.info({ source }, "CRC challenge-response completed");
+    return c.json(result.body, result.status as any);
+  });
+
   app.post("/webhooks/:source", async (c) => {
     const source = c.req.param("source");
     logger.debug({ source }, "webhook request received");

--- a/packages/action-llama/src/events/webhook-setup.ts
+++ b/packages/action-llama/src/events/webhook-setup.ts
@@ -15,7 +15,8 @@ import { SentryWebhookProvider } from "../webhooks/providers/sentry.js";
 import { LinearWebhookProvider } from "../webhooks/providers/linear.js";
 import { MintlifyWebhookProvider } from "../webhooks/providers/mintlify.js";
 import { TestWebhookProvider } from "../webhooks/providers/test.js";
-import type { WebhookFilter, WebhookTrigger, GitHubWebhookFilter, SentryWebhookFilter, LinearWebhookFilter, MintlifyWebhookFilter } from "../webhooks/types.js";
+import { TwitterWebhookProvider } from "../webhooks/providers/twitter.js";
+import type { WebhookFilter, WebhookTrigger, GitHubWebhookFilter, SentryWebhookFilter, LinearWebhookFilter, MintlifyWebhookFilter, TwitterWebhookFilter } from "../webhooks/types.js";
 import type { TestWebhookFilter } from "../webhooks/providers/test.js";
 
 /**
@@ -34,6 +35,7 @@ export const PROVIDER_TO_CREDENTIAL: Record<string, string> = {
   sentry: "sentry_client_secret",
   linear: "linear_webhook_secret",
   mintlify: "mintlify_webhook_secret",
+  twitter: "x_twitter_webhook_secret",
 };
 
 export function resolveWebhookSource(
@@ -96,11 +98,17 @@ export function buildFilterFromTrigger(trigger: WebhookTrigger, providerType: st
     if (trigger.branches) f.branches = trigger.branches;
     return Object.keys(f).length > 0 ? f : undefined;
   }
+  if (providerType === "twitter") {
+    const f: TwitterWebhookFilter = {};
+    if (trigger.events) f.events = trigger.events;
+    if (trigger.repos) f.users = trigger.repos; // Map repos to users for Twitter
+    return Object.keys(f).length > 0 ? f : undefined;
+  }
   return undefined;
 }
 
 /** Known webhook provider types (used by doctor for validation) */
-export const KNOWN_PROVIDER_TYPES = new Set(["github", "sentry", "linear", "mintlify", "test"]);
+export const KNOWN_PROVIDER_TYPES = new Set(["github", "sentry", "linear", "mintlify", "test", "twitter"]);
 
 // Valid trigger fields per provider type (filter fields + source)
 const VALID_TRIGGER_FIELDS: Record<string, Set<string>> = {
@@ -109,6 +117,7 @@ const VALID_TRIGGER_FIELDS: Record<string, Set<string>> = {
   linear: new Set(["source", "events", "actions", "organizations", "labels", "assignee", "author"]),
   test: new Set(["source", "events", "actions", "repos"]),
   mintlify: new Set(["source", "events", "actions", "repos", "branches"]),
+  twitter: new Set(["source", "events", "repos"]),
 };
 
 // Suggest similar valid fields for common typos
@@ -183,6 +192,7 @@ export async function setupWebhookRegistry(
   registry.registerProvider(new LinearWebhookProvider());
   registry.registerProvider(new MintlifyWebhookProvider());
   registry.registerProvider(new TestWebhookProvider());
+  registry.registerProvider(new TwitterWebhookProvider());
 
   // Load secrets for each provider type referenced by webhook sources
   const secrets: Record<string, Record<string, string>> = {};

--- a/packages/action-llama/src/webhooks/definitions/registry.ts
+++ b/packages/action-llama/src/webhooks/definitions/registry.ts
@@ -2,8 +2,9 @@ import type { WebhookDefinition } from "./schema.js";
 import { github } from "./github.js";
 import { sentry } from "./sentry.js";
 import { slack } from "./slack.js";
+import { twitter } from "./twitter.js";
 
-const definitions: WebhookDefinition[] = [github, sentry, slack];
+const definitions: WebhookDefinition[] = [github, sentry, slack, twitter];
 
 export function resolveWebhookDefinition(id: string): WebhookDefinition {
   const def = definitions.find((d) => d.id === id);

--- a/packages/action-llama/src/webhooks/definitions/twitter.ts
+++ b/packages/action-llama/src/webhooks/definitions/twitter.ts
@@ -1,0 +1,31 @@
+import type { WebhookDefinition } from "./schema.js";
+
+export const twitter: WebhookDefinition = {
+  id: "twitter",
+  label: "X (Twitter)",
+  description: "X (Twitter) Account Activity API webhook events",
+  secretCredential: "x_twitter_webhook_secret",
+  filterSpec: [
+    {
+      field: "events",
+      label: "Events",
+      type: "multi-select",
+      required: true,
+      options: [
+        { value: "tweet_create_events", label: "Tweet created" },
+        { value: "tweet_delete_events", label: "Tweet deleted" },
+        { value: "favorite_events", label: "Liked" },
+        { value: "follow_events", label: "Followed" },
+        { value: "unfollow_events", label: "Unfollowed" },
+        { value: "block_events", label: "Blocked" },
+        { value: "unblock_events", label: "Unblocked" },
+        { value: "mute_events", label: "Muted" },
+        { value: "unmute_events", label: "Unmuted" },
+        { value: "direct_message_events", label: "Direct message" },
+        { value: "direct_message_indicate_typing_events", label: "DM typing" },
+        { value: "direct_message_mark_read_events", label: "DM read" },
+      ],
+    },
+    { field: "users", label: "Subscribed user IDs", type: "text[]" },
+  ],
+};

--- a/packages/action-llama/src/webhooks/providers/index.ts
+++ b/packages/action-llama/src/webhooks/providers/index.ts
@@ -9,6 +9,7 @@ import { MintlifyWebhookProvider } from "./mintlify.js";
 import { SentryWebhookProvider } from "./sentry.js";
 import { SlackWebhookProvider } from "./slack.js";
 import { TestWebhookProvider } from "./test.js";
+import { TwitterWebhookProvider } from "./twitter.js";
 
 /**
  * GitHub webhook provider extension
@@ -172,6 +173,36 @@ export const testWebhookExtension: WebhookExtension = {
     requiredCredentials: [] // Test provider doesn't require credentials
   },
   provider: new TestWebhookProvider(),
+  async init() {
+    // No special initialization required
+  },
+  async shutdown() {
+    // No cleanup required
+  }
+};
+
+/**
+ * Twitter webhook provider extension
+ */
+export const twitterWebhookExtension: WebhookExtension = {
+  metadata: {
+    name: "twitter",
+    version: "1.0.0",
+    description: "X (Twitter) webhook provider with CRC support",
+    type: "webhook",
+    requiredCredentials: [
+      { type: "x_twitter_webhook_secret", description: "Consumer secret for CRC handshake and HMAC validation", optional: true }
+    ],
+    providesCredentialTypes: [
+      {
+        type: "x_twitter_webhook_secret",
+        fields: ["secret"],
+        description: "X (Twitter) consumer secret",
+        envMapping: { secret: "X_TWITTER_WEBHOOK_SECRET" }
+      }
+    ]
+  },
+  provider: new TwitterWebhookProvider(),
   async init() {
     // No special initialization required
   },

--- a/packages/action-llama/src/webhooks/providers/twitter.ts
+++ b/packages/action-llama/src/webhooks/providers/twitter.ts
@@ -1,0 +1,227 @@
+import { createHmac } from "crypto";
+import type { WebhookProvider, WebhookContext, WebhookFilter } from "../types.js";
+import type { TwitterWebhookFilter } from "../types.js";
+import { truncateEventText as truncate, validateHmacSignature } from "../validation.js";
+
+export class TwitterWebhookProvider implements WebhookProvider {
+  source = "twitter";
+
+  validateRequest(
+    headers: Record<string, string | undefined>,
+    rawBody: string,
+    secrets?: Record<string, string>,
+    allowUnsigned?: boolean
+  ): string | null {
+    return validateHmacSignature(rawBody, headers["x-twitter-webhooks-signature"], secrets, "sha256=", allowUnsigned);
+  }
+
+  handleCrcChallenge(
+    queryParams: Record<string, string>,
+    secrets?: Record<string, string>
+  ): { status: number; body: any } | null {
+    const crcToken = queryParams["crc_token"];
+    if (!crcToken) return null;
+
+    if (!secrets || Object.keys(secrets).length === 0) return null;
+
+    // Use the first available secret
+    const secret = Object.values(secrets)[0];
+    const hmac = createHmac("sha256", secret).update(crcToken).digest("base64");
+    return {
+      status: 200,
+      body: { response_token: `sha256=${hmac}` },
+    };
+  }
+
+  parseEvent(headers: Record<string, string | undefined>, body: any): WebhookContext | null {
+    if (!body || typeof body !== "object") return null;
+
+    const forUserId: string = body.for_user_id ?? "unknown";
+
+    // Metadata keys that are not event arrays
+    const metadataKeys = new Set(["for_user_id", "user_has_blocked"]);
+
+    // Find the first event key in the payload
+    let eventKey: string | null = null;
+    for (const key of Object.keys(body)) {
+      if (!metadataKeys.has(key) && Array.isArray(body[key])) {
+        eventKey = key;
+        break;
+      }
+    }
+
+    if (!eventKey) return null;
+
+    const events = body[eventKey];
+    const firstEvent = Array.isArray(events) && events.length > 0 ? events[0] : null;
+
+    // Derive action from event key (e.g. tweet_create_events -> create, favorite_events -> favorite)
+    const withoutSuffix = eventKey.replace(/_events$/, "");
+    const lastUnderscore = withoutSuffix.lastIndexOf("_");
+    const action = lastUnderscore >= 0 ? withoutSuffix.slice(lastUnderscore + 1) : withoutSuffix;
+
+    const base: Partial<WebhookContext> = {
+      source: "twitter",
+      event: eventKey,
+      action,
+      repo: forUserId,
+      sender: "unknown",
+      timestamp: new Date().toISOString(),
+    };
+
+    if (!firstEvent) {
+      return base as WebhookContext;
+    }
+
+    return this.extractContext(eventKey, firstEvent, base);
+  }
+
+  private extractContext(
+    eventKey: string,
+    event: any,
+    base: Partial<WebhookContext>
+  ): WebhookContext {
+    switch (eventKey) {
+      case "tweet_create_events": {
+        return {
+          ...base,
+          sender: event.user?.screen_name ?? event.user?.id_str ?? "unknown",
+          title: truncate(event.text),
+          body: truncate(event.text),
+          url: event.user?.screen_name && event.id_str
+            ? `https://twitter.com/${event.user.screen_name}/status/${event.id_str}`
+            : undefined,
+          timestamp: event.created_at ? new Date(event.created_at).toISOString() : base.timestamp!,
+        } as WebhookContext;
+      }
+
+      case "tweet_delete_events": {
+        return {
+          ...base,
+          sender: event.user_id ?? "unknown",
+          title: `Deleted tweet ${event.status?.id ?? "unknown"}`,
+          timestamp: event.timestamp_ms
+            ? new Date(parseInt(event.timestamp_ms)).toISOString()
+            : base.timestamp!,
+        } as WebhookContext;
+      }
+
+      case "favorite_events": {
+        return {
+          ...base,
+          sender: event.user?.screen_name ?? event.user?.id_str ?? "unknown",
+          title: `Liked tweet by @${event.favorited_status?.user?.screen_name ?? "unknown"}`,
+          body: truncate(event.favorited_status?.text),
+          url: event.favorited_status?.user?.screen_name && event.favorited_status?.id_str
+            ? `https://twitter.com/${event.favorited_status.user.screen_name}/status/${event.favorited_status.id_str}`
+            : undefined,
+          timestamp: event.created_at ? new Date(event.created_at).toISOString() : base.timestamp!,
+        } as WebhookContext;
+      }
+
+      case "follow_events": {
+        return {
+          ...base,
+          sender: event.source?.screen_name ?? event.source?.id ?? "unknown",
+          title: `@${event.source?.screen_name ?? "unknown"} followed @${event.target?.screen_name ?? "unknown"}`,
+          timestamp: event.created_timestamp
+            ? new Date(parseInt(event.created_timestamp)).toISOString()
+            : base.timestamp!,
+        } as WebhookContext;
+      }
+
+      case "unfollow_events": {
+        return {
+          ...base,
+          sender: event.source?.screen_name ?? event.source?.id ?? "unknown",
+          title: `@${event.source?.screen_name ?? "unknown"} unfollowed @${event.target?.screen_name ?? "unknown"}`,
+          timestamp: event.created_timestamp
+            ? new Date(parseInt(event.created_timestamp)).toISOString()
+            : base.timestamp!,
+        } as WebhookContext;
+      }
+
+      case "block_events":
+      case "unblock_events": {
+        const evtType = eventKey === "block_events" ? "blocked" : "unblocked";
+        return {
+          ...base,
+          sender: event.source?.screen_name ?? event.source?.id ?? "unknown",
+          title: `@${event.source?.screen_name ?? "unknown"} ${evtType} @${event.target?.screen_name ?? "unknown"}`,
+          timestamp: event.created_timestamp
+            ? new Date(parseInt(event.created_timestamp)).toISOString()
+            : base.timestamp!,
+        } as WebhookContext;
+      }
+
+      case "mute_events":
+      case "unmute_events": {
+        const evtType = eventKey === "mute_events" ? "muted" : "unmuted";
+        return {
+          ...base,
+          sender: event.source?.screen_name ?? event.source?.id ?? "unknown",
+          title: `@${event.source?.screen_name ?? "unknown"} ${evtType} @${event.target?.screen_name ?? "unknown"}`,
+          timestamp: event.created_timestamp
+            ? new Date(parseInt(event.created_timestamp)).toISOString()
+            : base.timestamp!,
+        } as WebhookContext;
+      }
+
+      case "direct_message_events": {
+        const msgData = event.message_create?.message_data;
+        const senderId = event.message_create?.sender_id ?? "unknown";
+        return {
+          ...base,
+          sender: senderId,
+          title: `Direct message from ${senderId}`,
+          body: truncate(msgData?.text),
+          timestamp: event.created_timestamp
+            ? new Date(parseInt(event.created_timestamp)).toISOString()
+            : base.timestamp!,
+        } as WebhookContext;
+      }
+
+      case "direct_message_indicate_typing_events": {
+        return {
+          ...base,
+          sender: event.sender_id ?? "unknown",
+          title: `Typing indicator from ${event.sender_id ?? "unknown"}`,
+          timestamp: event.created_timestamp
+            ? new Date(parseInt(event.created_timestamp)).toISOString()
+            : base.timestamp!,
+        } as WebhookContext;
+      }
+
+      case "direct_message_mark_read_events": {
+        return {
+          ...base,
+          sender: event.sender_id ?? "unknown",
+          title: `Message read by ${event.sender_id ?? "unknown"}`,
+          timestamp: event.created_timestamp
+            ? new Date(parseInt(event.created_timestamp)).toISOString()
+            : base.timestamp!,
+        } as WebhookContext;
+      }
+
+      default:
+        return {
+          ...base,
+          title: eventKey,
+        } as WebhookContext;
+    }
+  }
+
+  matchesFilter(context: WebhookContext, filter: WebhookFilter): boolean {
+    const f = filter as TwitterWebhookFilter;
+
+    if (f.events?.length && !f.events.includes(context.event)) {
+      return false;
+    }
+
+    if (f.users?.length && !f.users.includes(context.repo)) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/packages/action-llama/src/webhooks/types.ts
+++ b/packages/action-llama/src/webhooks/types.ts
@@ -63,7 +63,12 @@ export interface SlackWebhookFilter {
   team_ids?: string[];   // Slack workspace/team IDs
 }
 
-export type WebhookFilter = GitHubWebhookFilter | SentryWebhookFilter | LinearWebhookFilter | MintlifyWebhookFilter | SlackWebhookFilter;
+export interface TwitterWebhookFilter {
+  events?: string[];   // e.g. tweet_create_events, favorite_events, follow_events
+  users?: string[];    // for_user_id values (subscribed account IDs)
+}
+
+export type WebhookFilter = GitHubWebhookFilter | SentryWebhookFilter | LinearWebhookFilter | MintlifyWebhookFilter | SlackWebhookFilter | TwitterWebhookFilter;
 
 // --- Webhook trigger (used in agent config) ---
 
@@ -91,6 +96,7 @@ export interface WebhookProvider {
   matchesFilter(context: WebhookContext, filter: WebhookFilter): boolean;
   getDeliveryId?(headers: Record<string, string | undefined>): string | null;
   handleChallenge?(headers: Record<string, string | undefined>, rawBody: string, secrets?: Record<string, string>, allowUnsigned?: boolean): object | null;
+  handleCrcChallenge?(queryParams: Record<string, string>, secrets?: Record<string, string>): { status: number; body: any } | null;
 }
 
 // --- Registry binding ---

--- a/packages/action-llama/test/webhooks/providers/twitter.test.ts
+++ b/packages/action-llama/test/webhooks/providers/twitter.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect } from "vitest";
+import { createHmac } from "crypto";
+import { TwitterWebhookProvider } from "../../../src/webhooks/providers/twitter.js";
+import type { TwitterWebhookFilter } from "../../../src/webhooks/types.js";
+
+const provider = new TwitterWebhookProvider();
+
+function sign(body: string, secret: string): string {
+  return "sha256=" + createHmac("sha256", secret).update(body).digest("hex");
+}
+
+function crcBase64(token: string, secret: string): string {
+  return "sha256=" + createHmac("sha256", secret).update(token).digest("base64");
+}
+
+describe("TwitterWebhookProvider", () => {
+  describe("validateRequest", () => {
+    const secret = "test-consumer-secret";
+
+    it("accepts valid HMAC signature and returns instance name", () => {
+      const body = '{"for_user_id":"123","tweet_create_events":[]}';
+      const sig = sign(body, secret);
+      expect(provider.validateRequest({ "x-twitter-webhooks-signature": sig }, body, { myApp: secret })).toBe("myApp");
+    });
+
+    it("rejects invalid HMAC signature", () => {
+      const body = '{"for_user_id":"123"}';
+      const sig = sign("different body", secret);
+      expect(provider.validateRequest({ "x-twitter-webhooks-signature": sig }, body, { myApp: secret })).toBeNull();
+    });
+
+    it("rejects missing signature when secret is configured", () => {
+      expect(provider.validateRequest({}, '{"for_user_id":"123"}', { myApp: secret })).toBeNull();
+    });
+
+    it("accepts any request when no secret is configured and allowUnsigned is true", () => {
+      expect(provider.validateRequest({}, '{}', undefined, true)).toBe("_unsigned");
+      expect(provider.validateRequest({}, '{}', {}, true)).toBe("_unsigned");
+    });
+
+    it("rejects requests when no secret is configured and allowUnsigned is false", () => {
+      expect(provider.validateRequest({}, '{}')).toBeNull();
+      expect(provider.validateRequest({}, '{}', undefined)).toBeNull();
+      expect(provider.validateRequest({}, '{}', {})).toBeNull();
+    });
+
+    it("accepts when any of multiple secrets matches and returns correct instance", () => {
+      const body = '{"for_user_id":"123"}';
+      const sig = sign(body, "second-secret");
+      expect(provider.validateRequest({ "x-twitter-webhooks-signature": sig }, body, { AppA: "wrong-secret", AppB: "second-secret" })).toBe("AppB");
+    });
+
+    it("rejects when none of multiple secrets match", () => {
+      const body = '{"for_user_id":"123"}';
+      const sig = sign(body, "actual-secret");
+      expect(provider.validateRequest({ "x-twitter-webhooks-signature": sig }, body, { AppA: "wrong1", AppB: "wrong2" })).toBeNull();
+    });
+  });
+
+  describe("handleCrcChallenge", () => {
+    const secret = "consumer-secret-abc";
+
+    it("returns correct base64 response_token for valid crc_token", () => {
+      const crcToken = "test_crc_token_123";
+      const result = provider.handleCrcChallenge({ crc_token: crcToken }, { myApp: secret });
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(200);
+      expect(result!.body.response_token).toBe(crcBase64(crcToken, secret));
+    });
+
+    it("uses sha256= prefix in response_token", () => {
+      const result = provider.handleCrcChallenge({ crc_token: "token" }, { myApp: secret });
+      expect(result!.body.response_token).toMatch(/^sha256=/);
+    });
+
+    it("returns null when crc_token is missing", () => {
+      expect(provider.handleCrcChallenge({}, { myApp: secret })).toBeNull();
+    });
+
+    it("returns null when no secrets are provided", () => {
+      expect(provider.handleCrcChallenge({ crc_token: "token" }, undefined)).toBeNull();
+      expect(provider.handleCrcChallenge({ crc_token: "token" }, {})).toBeNull();
+    });
+
+    it("uses the first available secret when multiple are provided", () => {
+      const secrets = { first: "secret1", second: "secret2" };
+      const result = provider.handleCrcChallenge({ crc_token: "mytoken" }, secrets);
+      expect(result).not.toBeNull();
+      // Should match the first secret in object iteration order
+      const firstSecret = Object.values(secrets)[0];
+      expect(result!.body.response_token).toBe(crcBase64("mytoken", firstSecret));
+    });
+  });
+
+  describe("parseEvent", () => {
+    it("returns null for null body", () => {
+      expect(provider.parseEvent({}, null)).toBeNull();
+    });
+
+    it("returns null for non-object body", () => {
+      expect(provider.parseEvent({}, "string")).toBeNull();
+      expect(provider.parseEvent({}, 42)).toBeNull();
+    });
+
+    it("returns null when no event arrays found", () => {
+      expect(provider.parseEvent({}, { for_user_id: "123" })).toBeNull();
+    });
+
+    it("parses tweet_create_events", () => {
+      const body = {
+        for_user_id: "123456",
+        tweet_create_events: [
+          {
+            id_str: "tweet_001",
+            text: "Hello Twitter!",
+            created_at: "Thu Mar 26 18:00:00 +0000 2026",
+            user: { screen_name: "alice", id_str: "111" },
+          },
+        ],
+      };
+      const ctx = provider.parseEvent({}, body);
+      expect(ctx).not.toBeNull();
+      expect(ctx!.source).toBe("twitter");
+      expect(ctx!.event).toBe("tweet_create_events");
+      expect(ctx!.action).toBe("create");
+      expect(ctx!.repo).toBe("123456");
+      expect(ctx!.sender).toBe("alice");
+      expect(ctx!.title).toBe("Hello Twitter!");
+      expect(ctx!.url).toContain("tweet_001");
+    });
+
+    it("parses tweet_delete_events", () => {
+      const body = {
+        for_user_id: "123456",
+        tweet_delete_events: [
+          {
+            user_id: "111",
+            status: { id: "tweet_001" },
+            timestamp_ms: "1742000000000",
+          },
+        ],
+      };
+      const ctx = provider.parseEvent({}, body);
+      expect(ctx).not.toBeNull();
+      expect(ctx!.event).toBe("tweet_delete_events");
+      expect(ctx!.action).toBe("delete");
+      expect(ctx!.sender).toBe("111");
+    });
+
+    it("parses favorite_events", () => {
+      const body = {
+        for_user_id: "123456",
+        favorite_events: [
+          {
+            user: { screen_name: "bob" },
+            created_at: "Thu Mar 26 18:00:00 +0000 2026",
+            favorited_status: {
+              id_str: "tweet_002",
+              text: "Original tweet",
+              user: { screen_name: "alice" },
+            },
+          },
+        ],
+      };
+      const ctx = provider.parseEvent({}, body);
+      expect(ctx).not.toBeNull();
+      expect(ctx!.event).toBe("favorite_events");
+      expect(ctx!.action).toBe("favorite");
+      expect(ctx!.sender).toBe("bob");
+      expect(ctx!.body).toBe("Original tweet");
+    });
+
+    it("parses follow_events", () => {
+      const body = {
+        for_user_id: "123456",
+        follow_events: [
+          {
+            source: { screen_name: "bob", id: "222" },
+            target: { screen_name: "alice", id: "111" },
+            created_timestamp: "1742000000000",
+          },
+        ],
+      };
+      const ctx = provider.parseEvent({}, body);
+      expect(ctx).not.toBeNull();
+      expect(ctx!.event).toBe("follow_events");
+      expect(ctx!.action).toBe("follow");
+      expect(ctx!.sender).toBe("bob");
+      expect(ctx!.title).toContain("followed");
+    });
+
+    it("parses direct_message_events", () => {
+      const body = {
+        for_user_id: "123456",
+        direct_message_events: [
+          {
+            created_timestamp: "1742000000000",
+            message_create: {
+              sender_id: "999",
+              message_data: { text: "Hey there!" },
+            },
+          },
+        ],
+      };
+      const ctx = provider.parseEvent({}, body);
+      expect(ctx).not.toBeNull();
+      expect(ctx!.event).toBe("direct_message_events");
+      expect(ctx!.sender).toBe("999");
+      expect(ctx!.body).toBe("Hey there!");
+    });
+
+    it("handles events with empty arrays gracefully", () => {
+      const body = {
+        for_user_id: "123456",
+        tweet_create_events: [],
+      };
+      const ctx = provider.parseEvent({}, body);
+      expect(ctx).not.toBeNull();
+      expect(ctx!.event).toBe("tweet_create_events");
+      expect(ctx!.repo).toBe("123456");
+    });
+
+    it("handles malformed tweet with missing user", () => {
+      const body = {
+        for_user_id: "123456",
+        tweet_create_events: [{ id_str: "001", text: "no user" }],
+      };
+      const ctx = provider.parseEvent({}, body);
+      expect(ctx).not.toBeNull();
+      expect(ctx!.sender).toBe("unknown");
+    });
+  });
+
+  describe("matchesFilter", () => {
+    const baseCtx = {
+      source: "twitter",
+      event: "tweet_create_events",
+      action: "create",
+      repo: "123456",
+      sender: "alice",
+      timestamp: new Date().toISOString(),
+    };
+
+    it("empty filter matches all events", () => {
+      expect(provider.matchesFilter(baseCtx, {})).toBe(true);
+    });
+
+    it("events filter matches when event is in the list", () => {
+      const filter: TwitterWebhookFilter = { events: ["tweet_create_events", "favorite_events"] };
+      expect(provider.matchesFilter(baseCtx, filter)).toBe(true);
+    });
+
+    it("events filter rejects when event is not in the list", () => {
+      const filter: TwitterWebhookFilter = { events: ["favorite_events"] };
+      expect(provider.matchesFilter(baseCtx, filter)).toBe(false);
+    });
+
+    it("users filter matches when repo (for_user_id) is in the list", () => {
+      const filter: TwitterWebhookFilter = { users: ["123456", "789012"] };
+      expect(provider.matchesFilter(baseCtx, filter)).toBe(true);
+    });
+
+    it("users filter rejects when repo is not in the list", () => {
+      const filter: TwitterWebhookFilter = { users: ["999999"] };
+      expect(provider.matchesFilter(baseCtx, filter)).toBe(false);
+    });
+
+    it("combined events and users filter — both must match", () => {
+      const filter: TwitterWebhookFilter = {
+        events: ["tweet_create_events"],
+        users: ["123456"],
+      };
+      expect(provider.matchesFilter(baseCtx, filter)).toBe(true);
+    });
+
+    it("combined events and users filter — rejects when users don't match", () => {
+      const filter: TwitterWebhookFilter = {
+        events: ["tweet_create_events"],
+        users: ["999999"],
+      };
+      expect(provider.matchesFilter(baseCtx, filter)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes #364

## Summary

Adds X (Twitter) Account Activity API webhook support to Action Llama, including CRC (Challenge-Response Check) handshake handling.

## Changes

### New files
-  — Twitter webhook provider implementing  with HMAC validation and CRC challenge handling
-  — Webhook definition with filter spec for events and user IDs
-  — Credential definition for the Consumer Secret
-  — 29 unit tests covering validation, CRC, parsing, and filter matching

### Modified files
-  — Added `TwitterWebhookFilter` interface, added to `WebhookFilter` union, added optional `handleCrcChallenge` to `WebhookProvider`
-  — Registered `twitterWebhookExtension`
-  — Registered Twitter definition
-  — Added GET route for CRC challenges, added `x-twitter-webhooks-signature` to `SIGNATURE_HEADERS`
-  — Added `twitter` to `PROVIDER_TO_CREDENTIAL`, `KNOWN_PROVIDER_TYPES`, `buildFilterFromTrigger`, `VALID_TRIGGER_FIELDS`, and provider registration
-  — Registered `x_twitter_webhook_secret`

## Key Implementation Notes

- **CRC response uses base64** (not hex) — Twitter's Account Activity API requires `sha256=<base64>` in the `response_token` field
- **GET route at `/webhooks/twitter`** handles the CRC handshake automatically when Twitter sends `?crc_token=...`
- **`repos` trigger field maps to `users`** (for_user_id) in the filter, consistent with how Mintlify maps `repos` to `projects`
- **Dedicated credential type** `x_twitter_webhook_secret` follows the established per-provider pattern