### PR TITLE
Docs: add Twitter and Slack webhook provider documentation

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -73,6 +73,8 @@
               "reference/webhooks/sentry",
               "reference/webhooks/linear",
               "reference/webhooks/mintlify",
+              "reference/webhooks/slack",
+              "reference/webhooks/twitter",
               "reference/gateway-api",
               "reference/web-dashboard"
             ]

--- a/packages/docs/reference/webhooks.mdx
+++ b/packages/docs/reference/webhooks.mdx
@@ -3,7 +3,7 @@ title: "Webhooks"
 description: "Webhook setup, providers, filter fields, and troubleshooting"
 ---
 
-Action Llama agents can be triggered by webhooks in addition to (or instead of) cron schedules. Four providers are supported: GitHub, Sentry, Linear, and Mintlify.
+Action Llama agents can be triggered by webhooks in addition to (or instead of) cron schedules. Six providers are supported: GitHub, Sentry, Linear, Mintlify, Slack, and X (Twitter).
 
 ## Supported Providers
 
@@ -13,6 +13,8 @@ Action Llama agents can be triggered by webhooks in addition to (or instead of) 
 | [Sentry](/reference/webhooks/sentry) | `"sentry"` | Error monitoring events: alerts, issues, errors, comments |
 | [Linear](/reference/webhooks/linear) | `"linear"` | Project management events: issues, comments, labels |
 | [Mintlify](/reference/webhooks/mintlify) | `"mintlify"` | Documentation events: build successes and failures |
+| [Slack](/reference/webhooks/slack) | `"slack"` | Workspace events: messages, app mentions, reactions |
+| [X (Twitter)](/reference/webhooks/twitter) | `"twitter"` | Account activity events: tweets, likes, follows, direct messages |
 
 See each provider's page for filter fields, setup instructions, and example configurations.
 
@@ -36,11 +38,19 @@ credential = "LinearMain"     # credential instance name (linear_webhook_secret:
 [webhooks.my-mintlify]
 type = "mintlify"
 credential = "MintlifyMain"   # credential instance name (mintlify_webhook_secret:MintlifyMain)
+
+[webhooks.my-slack]
+type = "slack"
+credential = "MainWorkspace"  # credential instance name (slack_signing_secret:MainWorkspace)
+
+[webhooks.my-twitter]
+type = "twitter"
+credential = "MyXApp"         # credential instance name (x_twitter_webhook_secret:MyXApp)
 ```
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `type` | string | Yes | Provider type: `"github"`, `"sentry"`, `"linear"`, or `"mintlify"` |
+| `type` | string | Yes | Provider type: `"github"`, `"sentry"`, `"linear"`, `"mintlify"`, `"slack"`, or `"twitter"` |
 | `credential` | string | No | Credential instance name for HMAC signature validation. Omit for unsigned webhooks. |
 
 ## Agent Webhook Triggers

--- a/packages/docs/reference/webhooks/slack.mdx
+++ b/packages/docs/reference/webhooks/slack.mdx
@@ -1,0 +1,50 @@
+---
+title: "Slack Webhooks"
+description: "Filter fields, setup, and examples for Slack webhook triggers"
+---
+
+Slack webhooks let agents respond to workspace events like messages, app mentions, and reactions via the Slack Events API.
+
+## Filter Fields (all optional)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `events` | string[] | Slack event types: `message`, `app_mention`, `reaction_added`, `reaction_removed`, `channel_created`, `member_joined_channel` |
+| `channels` | string[] | Only trigger for these Slack channel IDs |
+| `team_ids` | string[] | Only trigger for these Slack workspace/team IDs |
+
+## Setup
+
+1. In the Slack API dashboard (https://api.slack.com/apps), create or select your app
+2. Go to **Event Subscriptions** and enable events
+3. Set the Request URL to `https://your-server:8080/webhooks/slack`
+4. The gateway automatically responds to Slack's URL verification challenge
+5. Subscribe to the bot events you need (e.g., `message.channels`, `app_mention`)
+6. Go to **Basic Information → App Credentials** and copy the **Signing Secret**
+7. Set the signing secret credential to match `slack_signing_secret` referenced by the webhook source in `config.toml`
+
+## URL Verification
+
+The Slack provider automatically handles URL verification challenges. When Slack sends a `url_verification` request, the gateway validates the signature and responds with the challenge token. No manual setup is needed.
+
+## Replay Protection
+
+The provider rejects requests with timestamps older than 5 minutes, protecting against replay attacks.
+
+## Example Configuration
+
+```toml
+# In project config.toml
+[webhooks.my-slack]
+type = "slack"
+credential = "MainWorkspace"
+```
+
+```toml
+# In agents/<name>/config.toml
+[[webhooks]]
+source = "my-slack"
+events = ["message", "app_mention"]
+channels = ["C0123456789"]
+team_ids = ["T0123456789"]
+```

--- a/packages/docs/reference/webhooks/twitter.mdx
+++ b/packages/docs/reference/webhooks/twitter.mdx
@@ -1,0 +1,43 @@
+---
+title: "Twitter Webhooks"
+description: "Filter fields, setup, and examples for X (Twitter) webhook triggers"
+---
+
+X (Twitter) webhooks let agents respond to account activity events like tweets, likes, follows, and direct messages via the Account Activity API.
+
+## Filter Fields (all optional)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `events` | string[] | Twitter event types: `tweet_create_events`, `tweet_delete_events`, `favorite_events`, `follow_events`, `unfollow_events`, `block_events`, `unblock_events`, `mute_events`, `unmute_events`, `direct_message_events`, `direct_message_indicate_typing_events`, `direct_message_mark_read_events` |
+| `users` | string[] | Only trigger for these subscribed user IDs (`for_user_id` values) |
+
+## Setup
+
+1. In the X Developer Portal, create or open your app
+2. Navigate to the Account Activity API settings
+3. Register your webhook URL: `https://your-server:8080/webhooks/twitter`
+4. The gateway handles the CRC challenge-response handshake automatically using the consumer secret
+5. Set the consumer secret credential to match `x_twitter_webhook_secret` — the API Secret (Consumer Secret) from your X app
+6. Subscribe the user accounts whose activity you want to receive
+
+## CRC Challenge
+
+The Twitter provider automatically handles CRC (Challenge-Response Check) validation. When Twitter sends a GET request with a `crc_token` query parameter, the gateway responds with the correct HMAC-SHA256 response token. No manual setup is needed.
+
+## Example Configuration
+
+```toml
+# In project config.toml
+[webhooks.my-twitter]
+type = "twitter"
+credential = "MyXApp"
+```
+
+```toml
+# In agents/<name>/config.toml
+[[webhooks]]
+source = "my-twitter"
+events = ["tweet_create_events", "favorite_events", "direct_message_events"]
+users = ["123456789"]
+```


### PR DESCRIPTION
Closes #370

## Summary

Added documentation for the Twitter (X) and Slack webhook providers, which were previously implemented in the codebase but missing from the docs site.

## Changes

- **New file** `packages/docs/reference/webhooks/twitter.mdx` — Twitter webhook reference page with filter fields (`events`, `users`), setup instructions for the Account Activity API, a note about automatic CRC challenge handling, and example configuration.
- **New file** `packages/docs/reference/webhooks/slack.mdx` — Slack webhook reference page with filter fields (`events`, `channels`, `team_ids`), setup instructions for the Slack Events API, notes about URL verification and replay protection, and example configuration.
- **Updated** `packages/docs/reference/webhooks.mdx` — Updated intro paragraph (four → six providers), added Slack and X (Twitter) rows to the Supported Providers table, added example webhook source config blocks for both providers, and updated the `type` field description.
- **Updated** `packages/docs/docs.json` — Added `reference/webhooks/slack` and `reference/webhooks/twitter` to the navigation sidebar after `reference/webhooks/mintlify`.