### PR TITLE
fix: skip webhook secret credential when allowUnsigned=true

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pr-repo",
+  "name": "repo",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -12139,7 +12139,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.18.4",
+      "version": "0.18.7",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/packages/action-llama/src/shared/credential-refs.ts
+++ b/packages/action-llama/src/shared/credential-refs.ts
@@ -52,6 +52,9 @@ export function collectCredentialRefs(projectPath: string, globalConfig: GlobalC
       const providerCreds = PROVIDER_CREDENTIALS[sourceConfig.type];
       if (!providerCreds) continue;
 
+      // Skip webhook secret credentials when the source allows unsigned requests
+      if (sourceConfig.allowUnsigned) continue;
+
       for (const cred of providerCreds) {
         const instance = resolveCredentialInstance(sourceConfig, cred.type);
         const ref = `${cred.type}:${instance}`;

--- a/packages/action-llama/test/shared/credential-refs.test.ts
+++ b/packages/action-llama/test/shared/credential-refs.test.ts
@@ -54,6 +54,21 @@ describe("collectCredentialRefs", () => {
     expect(refs.has("github_webhook_secret:default")).toBe(true);
   });
 
+  it("skips webhook secret when allowUnsigned is true", () => {
+    mockDiscoverAgents.mockReturnValue(["dev"]);
+    mockLoadAgentConfig.mockReturnValue({
+      name: "dev",
+      credentials: [],
+      webhooks: [{ source: "my-github", events: ["issues"] }],
+    });
+
+    const refs = collectCredentialRefs("/tmp/project", {
+      webhooks: { "my-github": { type: "github", allowUnsigned: true } },
+    });
+    expect(refs.has("github_webhook_secret:default")).toBe(false);
+    expect(refs.size).toBe(0);
+  });
+
   it("returns empty set when no agents", () => {
     mockDiscoverAgents.mockReturnValue([]);
     const refs = collectCredentialRefs("/tmp/project", {});


### PR DESCRIPTION
Closes #372

## Summary

Fixed a bug in `collectCredentialRefs` where webhook secret credentials were always added to the required set, even when the webhook source had `allowUnsigned = true`.

## Changes

- **`packages/action-llama/src/shared/credential-refs.ts`**: Added `if (sourceConfig.allowUnsigned) continue;` check inside the webhook credential loop, consistent with the pattern already used in `doctor.ts` (line ~217).
- **`packages/action-llama/test/shared/credential-refs.test.ts`**: Added test case verifying that webhook secret credentials are skipped when `allowUnsigned = true`.

## Testing

All 1866 tests pass (116 test files).