### PR TITLE
fix: install Playwright Chromium in e2e global setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5698,7 +5698,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6911,7 +6911,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {

--- a/packages/e2e/src/global-setup.ts
+++ b/packages/e2e/src/global-setup.ts
@@ -1,7 +1,11 @@
 import Docker from "dockerode";
+import { execSync } from "child_process";
 import { assertDockerAvailable, isDockerAvailable } from "./docker-utils.js";
 
 export async function setup() {
+  // Ensure Playwright Chromium browser is installed before running browser tests
+  execSync("npx playwright install --with-deps chromium", { stdio: "inherit" });
+
   // Check if Docker is available before proceeding
   await assertDockerAvailable();
 


### PR DESCRIPTION
Closes #375

## Problem

The `browser-ui-flows.test.ts` suite was failing at `beforeAll` because Playwright's Chromium browser binary was not present in the test environment:

```
browserType.launch: Executable does not exist at .cache/ms-playwright/chromium_headless_shell-1208/...
Please run: npx playwright install
```

## Fix

Added `execSync('npx playwright install --with-deps chromium')` to the `setup()` function in `packages/e2e/src/global-setup.ts`. This ensures Chromium is installed automatically before any test runs, without requiring a separate manual step or CI script change.

The `--with-deps` flag installs the required OS-level dependencies alongside the browser binary, which is necessary in CI/container environments.