### PR TITLE
Fix missing assistant text in host-user runtime logs

### DIFF
--- a/.changeset/fix-host-user-log-buffering.md
+++ b/.changeset/fix-host-user-log-buffering.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fix missing assistant text in `host-user` runtime logs. Output emitted between `launch()` and `streamLogs()` was silently dropped because `pipe()` put the stream into flowing mode immediately. Lines are now buffered from process start and replayed when `streamLogs()` attaches. Closes #380.

--- a/packages/action-llama/src/docker/host-user-runtime.ts
+++ b/packages/action-llama/src/docker/host-user-runtime.ts
@@ -54,12 +54,22 @@ function resolveGid(username: string): number | undefined {
   }
 }
 
+interface LogStreamState {
+  stdoutBuffer: string;
+  stderrBuffer: string;
+  bufferedLines: string[];
+  bufferedStderr: string[];
+  onLine: ((line: string) => void) | null;
+  onStderr: ((text: string) => void) | null;
+}
+
 export class HostUserRuntime implements Runtime {
   readonly needsGateway = false;
 
   private runAs: string;
   private processes = new Map<string, ChildProcess>();
   private runAgentNames = new Map<string, string>();
+  private logStreams = new Map<string, LogStreamState>();
 
   constructor(runAs: string = "al-agent") {
     this.runAs = runAs;
@@ -189,18 +199,66 @@ export class HostUserRuntime implements Runtime {
       cwd: workDir,
     });
 
-    // Pipe stdout/stderr to log file
-    proc.stdout?.pipe(logStream);
-    proc.stderr?.pipe(logStream);
+    // Set up buffering stream state — captures all output from process start,
+    // so streamLogs() can flush buffered lines without any data loss.
+    const streamState: LogStreamState = {
+      stdoutBuffer: "",
+      stderrBuffer: "",
+      bufferedLines: [],
+      bufferedStderr: [],
+      onLine: null,
+      onStderr: null,
+    };
 
+    proc.stdout?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      // Always write raw data to the run log file
+      logStream.write(text);
+      // Assemble complete lines and forward or buffer them
+      streamState.stdoutBuffer += text;
+      const lines = streamState.stdoutBuffer.split("\n");
+      streamState.stdoutBuffer = lines.pop() || "";
+      for (const line of lines) {
+        if (streamState.onLine) {
+          streamState.onLine(line);
+        } else {
+          streamState.bufferedLines.push(line);
+        }
+      }
+    });
+
+    proc.stderr?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      logStream.write(text);
+      const trimmed = text.trim();
+      if (trimmed) {
+        if (streamState.onStderr) {
+          streamState.onStderr(trimmed);
+        } else {
+          streamState.bufferedStderr.push(trimmed);
+        }
+      }
+    });
+
+    this.logStreams.set(runId, streamState);
     this.processes.set(runId, proc);
     this.runAgentNames.set(runId, opts.agentName);
 
     // Clean up tracking on exit
     proc.on("exit", () => {
+      // Flush any remaining partial stdout line
+      if (streamState.stdoutBuffer.trim()) {
+        if (streamState.onLine) {
+          streamState.onLine(streamState.stdoutBuffer);
+        } else {
+          streamState.bufferedLines.push(streamState.stdoutBuffer);
+        }
+        streamState.stdoutBuffer = "";
+      }
       logStream.end();
       this.processes.delete(runId);
       this.runAgentNames.delete(runId);
+      this.logStreams.delete(runId);
     });
 
     return runId;
@@ -214,26 +272,32 @@ export class HostUserRuntime implements Runtime {
     const proc = this.processes.get(runId);
     if (!proc) return { stop: () => {} };
 
-    let buffer = "";
-    const onData = (chunk: Buffer) => {
-      buffer += chunk.toString();
-      const lines = buffer.split("\n");
-      buffer = lines.pop() || "";
-      for (const line of lines) {
-        onLine(line);
-      }
-    };
+    const streamState = this.logStreams.get(runId);
+    if (!streamState) return { stop: () => {} };
 
-    proc.stdout?.on("data", onData);
-    proc.stderr?.on("data", (chunk: Buffer) => {
-      const text = chunk.toString().trim();
-      if (text && onStderr) onStderr(text);
-    });
+    // Flush lines buffered between launch() and now (no data loss)
+    for (const line of streamState.bufferedLines) {
+      onLine(line);
+    }
+    streamState.bufferedLines.length = 0;
+
+    for (const text of streamState.bufferedStderr) {
+      if (onStderr) onStderr(text);
+    }
+    streamState.bufferedStderr.length = 0;
+
+    // Forward all future lines through the callbacks
+    streamState.onLine = onLine;
+    streamState.onStderr = onStderr ?? null;
 
     return {
       stop: () => {
-        proc.stdout?.removeListener("data", onData);
-        if (buffer.trim()) onLine(buffer);
+        streamState.onLine = null;
+        streamState.onStderr = null;
+        if (streamState.stdoutBuffer.trim()) {
+          onLine(streamState.stdoutBuffer);
+          streamState.stdoutBuffer = "";
+        }
       },
     };
   }

--- a/packages/action-llama/test/docker/host-user-runtime.test.ts
+++ b/packages/action-llama/test/docker/host-user-runtime.test.ts
@@ -208,6 +208,55 @@ describe("HostUserRuntime", () => {
       expect(() => handle.stop()).not.toThrow();
     });
 
+    it("buffers lines emitted before streamLogs() is called and replays them", async () => {
+      const fakeProc = makeFakeProc();
+      mockSpawn.mockReturnValueOnce(fakeProc);
+
+      const runId = await runtime.launch({
+        image: "ignored",
+        agentName: "buffer-test",
+        env: {},
+        credentials: { strategy: "host-user" as const, stagingDir: "/tmp/creds", bundle: {} },
+      });
+
+      // Simulate data arriving BEFORE streamLogs() is attached (the race condition)
+      fakeProc.stdout.emit("data", Buffer.from("early line one\nearly line two\n"));
+
+      // Now attach streamLogs — should receive both buffered lines
+      const lines: string[] = [];
+      runtime.streamLogs(runId, (line) => lines.push(line));
+
+      expect(lines).toEqual(["early line one", "early line two"]);
+
+      // Lines emitted after should also be received
+      fakeProc.stdout.emit("data", Buffer.from("late line\n"));
+      expect(lines).toEqual(["early line one", "early line two", "late line"]);
+
+      fakeProc.emit("exit", 0);
+    });
+
+    it("buffers stderr emitted before streamLogs() and replays it", async () => {
+      const fakeProc = makeFakeProc();
+      mockSpawn.mockReturnValueOnce(fakeProc);
+
+      const runId = await runtime.launch({
+        image: "ignored",
+        agentName: "buffer-stderr",
+        env: {},
+        credentials: { strategy: "host-user" as const, stagingDir: "/tmp/creds", bundle: {} },
+      });
+
+      // Emit stderr before streamLogs() is attached
+      fakeProc.stderr.emit("data", Buffer.from("early stderr\n"));
+
+      const errors: string[] = [];
+      runtime.streamLogs(runId, () => {}, (msg) => errors.push(msg));
+
+      expect(errors).toContain("early stderr");
+
+      fakeProc.emit("exit", 0);
+    });
+
     it("receives stdout lines from active process", async () => {
       const fakeProc = makeFakeProc();
       mockSpawn.mockReturnValueOnce(fakeProc);


### PR DESCRIPTION
Closes #380

## Problem

In `HostUserRuntime`, calling `proc.stdout?.pipe(logStream)` in `launch()` immediately puts the readable stream into flowing mode. Data events fire as soon as data arrives. When `streamLogs()` later attaches its own listener (after async gateway setup in `ContainerAgentRunner`), it only receives data from that point forward — anything emitted in the gap is consumed by the pipe and written to the run log file, but never reaches `forwardLogLine()` or the pino logger.

This caused assistant reasoning text (which arrives early in the first LLM response) to be silently dropped, while bash command logs (which arrive later during tool use) appeared correctly.

## Fix

- Replace `pipe()` with a `data` listener in `launch()` that writes raw output to the log file **and** either forwards to the callback or buffers the line
- `streamLogs()` now flushes all buffered lines/stderr before registering live callbacks — ensuring zero data loss regardless of timing

## Testing

Added two new unit tests that verify the buffering behaviour:
- Lines emitted before `streamLogs()` is called are buffered and replayed
- Stderr emitted before `streamLogs()` is called is buffered and replayed