### PR TITLE
fix: queryCallGraph computes avgDurationMs from completion events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12139,7 +12139,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.18.7",
+      "version": "0.18.8",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/packages/action-llama/src/stats/event-store.ts
+++ b/packages/action-llama/src/stats/event-store.ts
@@ -376,8 +376,11 @@ export class EventSourcedStatsStore {
       totalDuration: number;
       durationCount: number;
     }>();
+
+    // Map from callId -> "callerAgent:targetAgent" key for joining with completion events
+    const callIdToKey = new Map<number, string>();
     
-    // Process call initiation events
+    // Process call initiation events to build count/depth stats and callId index
     for await (const event of this.statsStream.replay({
       type: EventTypes.CALL_INITIATED,
       from: query.since,
@@ -394,13 +397,37 @@ export class EventSourcedStatsStore {
       
       stats.count++;
       stats.totalDepth += event.data.depth || 0;
-      
-      if (event.data.durationMs) {
+      callGraph.set(key, stats);
+
+      if (event.data.callId !== undefined) {
+        callIdToKey.set(event.data.callId, key);
+      }
+    }
+
+    // Process completion events (CALL_COMPLETED and CALL_FAILED) to accumulate duration stats
+    for (const completionType of [EventTypes.CALL_COMPLETED, EventTypes.CALL_FAILED]) {
+      for await (const event of this.statsStream.replay({
+        type: completionType,
+        from: query.since,
+      })) {
+        if (!event.data.durationMs) continue;
+
+        // Determine the callGraph key: prefer callerAgent/targetAgent on event, fall back to callIdToKey
+        let key: string | undefined;
+        if (event.data.callerAgent && event.data.targetAgent) {
+          key = `${event.data.callerAgent}:${event.data.targetAgent}`;
+        } else if (event.data.callId !== undefined) {
+          key = callIdToKey.get(event.data.callId);
+        }
+
+        if (!key) continue;
+
+        const stats = callGraph.get(key);
+        if (!stats) continue;
+
         stats.totalDuration += event.data.durationMs;
         stats.durationCount++;
       }
-      
-      callGraph.set(key, stats);
     }
     
     // Convert to final format

--- a/packages/action-llama/test/stats/event-store.test.ts
+++ b/packages/action-llama/test/stats/event-store.test.ts
@@ -227,6 +227,47 @@ describe("EventSourcedStatsStore", () => {
       if (abEdge) expect(abEdge.count).toBe(2);
       if (acEdge) expect(acEdge.count).toBe(1);
     });
+
+    it("computes avgDurationMs from CALL_COMPLETED events via updateCallEdge", async () => {
+      const id1 = await store.recordCallEdge(makeCallEdge({ callerAgent: "orch", targetAgent: "worker" }));
+      const id2 = await store.recordCallEdge(makeCallEdge({ callerAgent: "orch", targetAgent: "worker" }));
+      await store.updateCallEdge(id1, { durationMs: 1000, status: "completed" });
+      await store.updateCallEdge(id2, { durationMs: 3000, status: "completed" });
+
+      const graph = await store.queryCallGraph();
+      const edge = graph.find((e) => e.callerAgent === "orch" && e.targetAgent === "worker");
+      expect(edge).toBeDefined();
+      expect(edge!.avgDurationMs).toBe(2000);
+    });
+
+    it("computes avgDurationMs from CALL_COMPLETED events when durationMs is set on recordCallEdge", async () => {
+      await store.recordCallEdge(makeCallEdge({ callerAgent: "a", targetAgent: "b", durationMs: 500, status: "completed" }));
+      await store.recordCallEdge(makeCallEdge({ callerAgent: "a", targetAgent: "b", durationMs: 1500, status: "completed" }));
+
+      const graph = await store.queryCallGraph();
+      const edge = graph.find((e) => e.callerAgent === "a" && e.targetAgent === "b");
+      expect(edge).toBeDefined();
+      expect(edge!.avgDurationMs).toBe(1000);
+    });
+
+    it("computes avgDurationMs from CALL_FAILED events", async () => {
+      const id = await store.recordCallEdge(makeCallEdge({ callerAgent: "a", targetAgent: "b" }));
+      await store.updateCallEdge(id, { durationMs: 200, status: "error" });
+
+      const graph = await store.queryCallGraph();
+      const edge = graph.find((e) => e.callerAgent === "a" && e.targetAgent === "b");
+      expect(edge).toBeDefined();
+      expect(edge!.avgDurationMs).toBe(200);
+    });
+
+    it("returns null avgDurationMs when no completion events exist", async () => {
+      await store.recordCallEdge(makeCallEdge({ callerAgent: "a", targetAgent: "b" }));
+
+      const graph = await store.queryCallGraph();
+      const edge = graph.find((e) => e.callerAgent === "a" && e.targetAgent === "b");
+      expect(edge).toBeDefined();
+      expect(edge!.avgDurationMs).toBeNull();
+    });
   });
 
   describe("createSnapshot / loadSnapshot", () => {


### PR DESCRIPTION
Closes #383

## Problem

The `queryCallGraph` method was only replaying `CALL_INITIATED` events to compute duration statistics. However, `CALL_INITIATED` events never contain `durationMs` — duration is only recorded in `CALL_COMPLETED` and `CALL_FAILED` events. This caused `avgDurationMs` to always be `null`.

## Fix

Updated `queryCallGraph` in `packages/action-llama/src/stats/event-store.ts` to:

1. First replay `CALL_INITIATED` events to build call count/depth stats and a `callId → key` lookup map.
2. Then replay `CALL_COMPLETED` and `CALL_FAILED` events to accumulate `durationMs` values, joining by either:
   - `callerAgent`/`targetAgent` fields on the event (when available, e.g. from `recordCallEdge`), or
   - `callId` looked up from the index (for `updateCallEdge` events that only carry `callId`)

## Tests

Added 4 new test cases to `test/stats/event-store.test.ts`:
- `computes avgDurationMs from CALL_COMPLETED events via updateCallEdge`
- `computes avgDurationMs from CALL_COMPLETED events when durationMs is set on recordCallEdge`
- `computes avgDurationMs from CALL_FAILED events`
- `returns null avgDurationMs when no completion events exist`

All 3710 unit tests pass.