### PR TITLE
fix: pass original workId in buildQueueState WORK_QUEUED replay

### DIFF
--- a/packages/action-llama/src/events/event-queue-unified.ts
+++ b/packages/action-llama/src/events/event-queue-unified.ts
@@ -50,7 +50,7 @@ export class EventSourcedWorkQueue<T> implements WorkQueue<T> {
           state.enqueue({
             context: event.data.context,
             receivedAt: new Date(event.data.receivedAt),
-          });
+          }, event.data.workId);
           break;
         case EventTypes.WORK_DEQUEUED:
           state.dequeue(event.data.workId);

--- a/packages/action-llama/test/events/event-queue-unified.test.ts
+++ b/packages/action-llama/test/events/event-queue-unified.test.ts
@@ -387,6 +387,32 @@ describe("EventSourcedWorkQueue", () => {
 
       queue2.close();
     });
+
+    it("replays WORK_DEQUEUED and WORK_DROPPED with correct workIds so size is exact after initialize()", async () => {
+      // Regression test: buildQueueState must pass the original workId when replaying
+      // WORK_QUEUED events, otherwise WORK_DEQUEUED / WORK_DROPPED replay silently fails.
+      const smallQueue = new EventSourcedWorkQueue<string>(store, 1);
+
+      smallQueue.enqueue("agent-replay-exact", "item-1");
+      await flushAsync();
+      // Second enqueue evicts item-1 via WORK_DROPPED and adds item-2
+      smallQueue.enqueue("agent-replay-exact", "item-2");
+      await flushAsync();
+      await flushAsync();
+
+      expect(smallQueue.size("agent-replay-exact")).toBe(1);
+      smallQueue.close();
+
+      // Rebuild from persisted events
+      const queue2 = new EventSourcedWorkQueue<string>(store, 100);
+      await queue2.initialize();
+
+      // Must be exactly 1 — if workId was not preserved during replay,
+      // WORK_DROPPED would fail to find item-1 and size would incorrectly be 2.
+      expect(queue2.size("agent-replay-exact")).toBe(1);
+
+      queue2.close();
+    });
   });
 
   describe("max-size eviction", () => {


### PR DESCRIPTION
Closes #382

## Problem

In `buildQueueState`, `WORK_QUEUED` events were replayed without passing the original `workId` to `state.enqueue()`. Each item received a new random workId during replay, so subsequent `WORK_DEQUEUED` and `WORK_DROPPED` events (which reference the original workId) could not find the corresponding item and silently failed. This caused the in-memory queue size to be incorrect after `initialize()`.

## Fix

Pass `event.data.workId` as the second argument to `state.enqueue()` in the `WORK_QUEUED` branch of `buildQueueState`:

```ts
case EventTypes.WORK_QUEUED:
  state.enqueue({
    context: event.data.context,
    receivedAt: new Date(event.data.receivedAt),
  }, event.data.workId);  // ← pass original workId
  break;
```

## Tests

Added a regression test (`replays WORK_DEQUEUED and WORK_DROPPED with correct workIds so size is exact after initialize()`) that enqueues two items into a size-1 queue (triggering a `WORK_DROPPED` event), closes the queue, then rebuilds from the persistence store via `initialize()` and asserts the size is exactly 1. This test would fail before the fix (size would be 2) and passes after.

All 3711 existing tests continue to pass.