### PR TITLE
fix: persist scheduler state so jobs survive restarts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12139,7 +12139,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.18.8",
+      "version": "0.18.10",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/packages/action-llama/src/agents/container-runner.ts
+++ b/packages/action-llama/src/agents/container-runner.ts
@@ -136,6 +136,109 @@ export class ContainerAgentRunner {
     }
   }
 
+  /**
+   * Adopt an already-running container from a previous scheduler session.
+   * Re-attaches log streaming, monitors exit, and records the result.
+   * Skips image launch, credential preparation, and env setup.
+   */
+  async adoptContainer(
+    containerName: string,
+    shutdownSecret: string,
+    instanceId: string,
+    triggerInfo?: { type: 'schedule' | 'manual' | 'webhook' | 'agent'; source?: string },
+  ): Promise<RunOutcome> {
+    if (this._running) {
+      this.logger.warn("runner already busy, cannot adopt");
+      return { result: "error", triggers: [] };
+    }
+
+    this._running = true;
+    this._aborting = false;
+    this._returnValue = undefined;
+    this._tokenUsage = undefined;
+    this.instanceId = instanceId;
+    this._containerName = containerName;
+    this.logger = this.baseLogger.child({ instance: this.instanceId });
+
+    const runStartTime = Date.now();
+    let runError: string | undefined;
+    let runResult: RunResult = "error";
+
+    this.statusTracker?.startRun(this.agentConfig.name, "re-adopted");
+    this.statusTracker?.registerInstance({
+      id: this.instanceId,
+      agentName: this.agentConfig.name,
+      status: "running",
+      startedAt: new Date(),
+      trigger: "re-adopted",
+    });
+
+    let logStream: { stop: () => void } | undefined;
+
+    try {
+      const timeout = this.agentConfig.timeout ?? this.globalConfig.local?.timeout ?? 900;
+
+      // Re-register with gateway so locks/shutdown/calls route correctly
+      if (this.gatewayUrl) {
+        await this.registerContainer(shutdownSecret, {
+          containerName,
+          agentName: this.agentConfig.name,
+          instanceId: this.instanceId,
+        });
+      }
+
+      this.logger.info({ container: containerName }, "re-adopted orphan container");
+      this.statusTracker?.addLogLine(this.agentConfig.name, `${this.instanceId} re-adopted`);
+
+      // Re-attach log streaming
+      logStream = this.runtime.streamLogs(
+        containerName,
+        (line) => this.forwardLogLine(line),
+        (text) => this.logger.warn({ stderr: text.slice(0, 500) }, "container stderr"),
+      );
+
+      // Wait for exit
+      const startTime = Date.now();
+      const exitCode = await this.runtime.waitForExit(containerName, timeout);
+      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+
+      // Give the log stream a moment to flush
+      await new Promise((r) => setTimeout(r, 500));
+      logStream.stop();
+      logStream = undefined;
+
+      if (exitCode === 42) {
+        runResult = "rerun";
+      } else if (exitCode !== 0) {
+        runError = `Container exited with code ${exitCode}`;
+        runResult = "error";
+      } else {
+        runResult = "completed";
+      }
+      this.logger.info({ exitCode, elapsed: `${elapsed}s` }, `adopted container finished (${runResult})`);
+      this.statusTracker?.addLogLine(this.agentConfig.name, `${this.instanceId} ${runResult} (${elapsed}s)`);
+    } catch (err: any) {
+      this.logger.error({ err }, "adopted container monitoring failed");
+      runError = String(err?.message || err).slice(0, 200);
+    } finally {
+      if (logStream) logStream.stop();
+      if (this.gatewayUrl) {
+        await this.unregisterContainer(shutdownSecret);
+      }
+      if (containerName) {
+        await this.runtime.remove(containerName);
+      }
+      this._containerName = undefined;
+      const elapsed = Date.now() - runStartTime;
+      const instanceStatus = this._aborting ? "killed" as const : runError ? "error" as const : "completed" as const;
+      this.statusTracker?.completeInstance(this.instanceId, instanceStatus);
+      this.statusTracker?.endRun(this.agentConfig.name, elapsed, runError, this._tokenUsage);
+      this._running = false;
+    }
+
+    return { result: runResult, triggers: [], returnValue: this._returnValue, usage: this._tokenUsage };
+  }
+
   async run(prompt: string, triggerInfo?: { type: 'schedule' | 'manual' | 'webhook' | 'agent'; source?: string }, instanceId?: string): Promise<RunOutcome> {
     if (this._running) {
       this.logger.warn(`${this.agentConfig.name} is already running, skipping`);

--- a/packages/action-llama/src/docker/host-user-runtime.ts
+++ b/packages/action-llama/src/docker/host-user-runtime.ts
@@ -390,4 +390,8 @@ export class HostUserRuntime implements Runtime {
   getTaskUrl(): string | null {
     return null;
   }
+
+  async inspectContainer(): Promise<null> {
+    return null;
+  }
 }

--- a/packages/action-llama/src/docker/local-runtime.ts
+++ b/packages/action-llama/src/docker/local-runtime.ts
@@ -437,4 +437,20 @@ export class LocalDockerRuntime implements Runtime, ContainerRuntime {
     return null;
   }
 
+  async inspectContainer(containerName: string): Promise<{ env: Record<string, string> } | null> {
+    try {
+      const raw = docker("inspect", "--format", "{{json .Config.Env}}", containerName);
+      // Returns JSON array like ["KEY=val", "KEY2=val2"]
+      const envArr: string[] = JSON.parse(raw);
+      const env: Record<string, string> = {};
+      for (const entry of envArr) {
+        const idx = entry.indexOf("=");
+        if (idx > 0) env[entry.slice(0, idx)] = entry.slice(idx + 1);
+      }
+      return { env };
+    } catch {
+      return null;
+    }
+  }
+
 }

--- a/packages/action-llama/src/docker/runtime.ts
+++ b/packages/action-llama/src/docker/runtime.ts
@@ -125,6 +125,13 @@ export interface Runtime {
 
   /** Return a URL for this task/execution, or null. */
   getTaskUrl(runId: string): string | null;
+
+  /**
+   * Inspect a running container and return its environment variables.
+   * Returns null if the container is not found or inspection is not supported.
+   * Optional — only implemented by runtimes that manage Docker containers directly.
+   */
+  inspectContainer?(containerName: string): Promise<{ env: Record<string, string> } | null>;
 }
 
 /**

--- a/packages/action-llama/src/docker/ssh-docker-runtime.ts
+++ b/packages/action-llama/src/docker/ssh-docker-runtime.ts
@@ -416,4 +416,8 @@ export class SshDockerRuntime implements Runtime, ContainerRuntime {
   getTaskUrl(): string | null {
     return null; // No cloud console for VPS
   }
+
+  async inspectContainer(): Promise<null> {
+    return null;
+  }
 }

--- a/packages/action-llama/src/execution/container-registry.ts
+++ b/packages/action-llama/src/execution/container-registry.ts
@@ -60,6 +60,17 @@ export class ContainerRegistry {
     return Array.from(this.cache.values());
   }
 
+  /**
+   * Find the secret and registration for a container by its container name.
+   * Used during re-adoption of orphan containers on scheduler restart.
+   */
+  findByContainerName(containerName: string): { secret: string; reg: ContainerRegistration } | undefined {
+    for (const [secret, reg] of this.cache.entries()) {
+      if (reg.containerName === containerName) return { secret, reg };
+    }
+    return undefined;
+  }
+
   /** Remove all registrations from both the cache and the persistent store. */
   async clear(): Promise<void> {
     for (const key of this.cache.keys()) {

--- a/packages/action-llama/src/scheduler/gateway-setup.ts
+++ b/packages/action-llama/src/scheduler/gateway-setup.ts
@@ -168,7 +168,6 @@ export async function setupGateway(opts: {
         logger.info("Stop requested via control API");
         if (state.schedulerCtx) {
           state.schedulerCtx.shuttingDown = true;
-          state.schedulerCtx.workQueue.clearAll();
           state.schedulerCtx.workQueue.close();
         }
         for (const job of state.cronJobs) job.stop();

--- a/packages/action-llama/src/scheduler/index.ts
+++ b/packages/action-llama/src/scheduler/index.ts
@@ -124,44 +124,6 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
 
   logger.info({ runtime: "local" }, "Container mode enabled — initializing infrastructure");
 
-  // Check for orphan containers from a previous scheduler run
-  try {
-    const ownAgentNames = new Set(activeAgentConfigs.map((a) => a.name));
-    const orphans = (await runtime.listRunningAgents()).filter((o) => ownAgentNames.has(o.agentName));
-    if (orphans.length > 0) {
-      for (const orphan of orphans) {
-        logger.warn({ agent: orphan.agentName, task: orphan.taskId }, "found orphan container");
-      }
-      for (const orphan of orphans) {
-        try { await runtime.kill(orphan.taskId); await runtime.remove(orphan.taskId); } catch {}
-      }
-      logger.info({ count: orphans.length }, "cleaned up local orphan containers");
-    }
-  } catch (err) {
-    logger.debug({ err }, "orphan detection skipped (runtime does not support listing)");
-  }
-
-  // Clean up stale container registry entries and their locks.
-  // At this point all containers from the previous run are dead (either exited
-  // normally or just killed above). No new containers have been launched yet,
-  // so every registry entry is stale.
-  try {
-    const staleEntries = gateway.containerRegistry.listAll();
-    if (staleEntries.length > 0) {
-      let releasedLocks = 0;
-      for (const entry of staleEntries) {
-        releasedLocks += gateway.lockStore.releaseAll(entry.instanceId);
-      }
-      await gateway.containerRegistry.clear();
-      logger.info(
-        { releasedLocks, staleRegistrations: staleEntries.length },
-        "cleaned up orphan locks and stale container registrations",
-      );
-    }
-  } catch (err) {
-    logger.warn({ err }, "failed to clean up stale container registrations");
-  }
-
   // Build base + per-agent images (only for agents using container runtime)
   const containerAgentConfigs = activeAgentConfigs.filter(
     (a) => !agentRuntimeOverrides[a.name] // agents without overrides use the default container runtime
@@ -200,6 +162,116 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
 
   // Populate late-binding state
   Object.assign(state.runnerPools, runnerPools);
+
+  // Re-adopt orphan containers from a previous scheduler run (or clean up stale state)
+  try {
+    const ownAgentNames = new Set(activeAgentConfigs.map((a) => a.name));
+    const orphans = (await runtime.listRunningAgents()).filter((o) => ownAgentNames.has(o.agentName));
+
+    if (orphans.length > 0) {
+      const registeredContainers = gateway.containerRegistry.listAll();
+      const runningNames = new Set(orphans.map((o) => o.taskId));
+      let adopted = 0;
+      let killed = 0;
+
+      for (const orphan of orphans) {
+        const found = gateway.containerRegistry.findByContainerName(orphan.taskId);
+
+        if (!found) {
+          // Container exists but has no registry entry — unknown, kill it
+          logger.warn({ agent: orphan.agentName, task: orphan.taskId }, "killing unregistered orphan container");
+          try { await runtime.kill(orphan.taskId); await runtime.remove(orphan.taskId); } catch {}
+          killed++;
+          continue;
+        }
+
+        const { secret: oldSecret, reg } = found;
+        const pool = runnerPools[orphan.agentName];
+        if (!pool) {
+          logger.warn({ agent: orphan.agentName, task: orphan.taskId }, "no runner pool for orphan, killing");
+          try { await runtime.kill(orphan.taskId); await runtime.remove(orphan.taskId); } catch {}
+          gateway.lockStore.releaseAll(reg.instanceId);
+          await gateway.containerRegistry.unregister(oldSecret);
+          killed++;
+          continue;
+        }
+
+        // Get shutdown secret from container env vars
+        let shutdownSecret: string | undefined;
+        if (runtime.inspectContainer) {
+          const info = await runtime.inspectContainer(orphan.taskId);
+          shutdownSecret = info?.env?.SHUTDOWN_SECRET;
+        }
+
+        if (!shutdownSecret) {
+          logger.warn({ agent: orphan.agentName, task: orphan.taskId }, "cannot read SHUTDOWN_SECRET from orphan, killing");
+          try { await runtime.kill(orphan.taskId); await runtime.remove(orphan.taskId); } catch {}
+          gateway.lockStore.releaseAll(reg.instanceId);
+          await gateway.containerRegistry.unregister(oldSecret);
+          killed++;
+          continue;
+        }
+
+        const runner = pool.getAvailableRunner();
+        if (!runner) {
+          logger.warn({ agent: orphan.agentName, task: orphan.taskId }, "no available runner for orphan, killing");
+          try { await runtime.kill(orphan.taskId); await runtime.remove(orphan.taskId); } catch {}
+          gateway.lockStore.releaseAll(reg.instanceId);
+          await gateway.containerRegistry.unregister(oldSecret);
+          killed++;
+          continue;
+        }
+
+        // Unregister old secret mapping — will be re-registered inside adoptContainer
+        await gateway.containerRegistry.unregister(oldSecret);
+
+        logger.info({ agent: orphan.agentName, task: orphan.taskId, instance: reg.instanceId }, "re-adopting orphan container");
+
+        const containerRunner = runner as any;
+        if (typeof containerRunner.adoptContainer === "function") {
+          containerRunner
+            .adoptContainer(orphan.taskId, shutdownSecret, reg.instanceId, { type: "schedule" as const, source: "re-adopted" })
+            .then(() => { if (state.schedulerCtx) drainQueues(state.schedulerCtx); })
+            .catch((err: any) => logger.error({ err, agent: orphan.agentName }, "orphan re-adoption failed"));
+          adopted++;
+        } else {
+          logger.warn({ agent: orphan.agentName }, "runner does not support adoption, killing orphan");
+          try { await runtime.kill(orphan.taskId); await runtime.remove(orphan.taskId); } catch {}
+          killed++;
+        }
+      }
+
+      // Clean up registry entries for containers that exited while scheduler was down
+      for (const reg of registeredContainers) {
+        if (!runningNames.has(reg.containerName)) {
+          const found = gateway.containerRegistry.findByContainerName(reg.containerName);
+          if (found) {
+            gateway.lockStore.releaseAll(reg.instanceId);
+            await gateway.containerRegistry.unregister(found.secret);
+            logger.info({ agent: reg.agentName, instance: reg.instanceId }, "cleaned up stale registration (container exited while scheduler was down)");
+          }
+        }
+      }
+
+      logger.info({ adopted, killed, total: orphans.length }, "orphan container handling complete");
+    } else {
+      // No running containers — clean up all stale registry entries
+      const staleEntries = gateway.containerRegistry.listAll();
+      if (staleEntries.length > 0) {
+        let releasedLocks = 0;
+        for (const entry of staleEntries) {
+          releasedLocks += gateway.lockStore.releaseAll(entry.instanceId);
+        }
+        await gateway.containerRegistry.clear();
+        logger.info(
+          { releasedLocks, staleRegistrations: staleEntries.length },
+          "cleaned up stale registrations (no running containers)",
+        );
+      }
+    }
+  } catch (err) {
+    logger.debug({ err }, "orphan detection/re-adoption skipped (runtime does not support listing)");
+  }
 
   // Create work queue + scheduler context
   const queueSize = globalConfig.workQueueSize ?? globalConfig.webhookQueueSize ?? 20;

--- a/packages/action-llama/src/scheduler/shutdown.ts
+++ b/packages/action-llama/src/scheduler/shutdown.ts
@@ -25,7 +25,6 @@ export function registerShutdownHandlers(deps: {
     logger.info("Shutting down scheduler...");
     watcherHandle.stop();
     schedulerCtx.shuttingDown = true;
-    schedulerCtx.workQueue.clearAll();
     schedulerCtx.workQueue.close();
     for (const job of cronJobs) {
       job.stop();

--- a/packages/action-llama/test/agents/container-runner.test.ts
+++ b/packages/action-llama/test/agents/container-runner.test.ts
@@ -841,4 +841,82 @@ describe("ContainerAgentRunner", () => {
       });
     });
   });
+
+  describe("adoptContainer()", () => {
+    it("re-registers, streams logs, waits for exit, then cleans up", async () => {
+      const registerContainer = vi.fn().mockResolvedValue(undefined);
+      const unregisterContainer = vi.fn().mockResolvedValue(undefined);
+      const runner = new ContainerAgentRunner(
+        runtime, globalConfig, agentConfig, mockLogger,
+        registerContainer, unregisterContainer, "http://gateway:8080", "/tmp", "test-image:latest",
+      );
+
+      const outcome = await runner.adoptContainer("al-test-agent-abc", "my-secret", "test-agent-abc");
+
+      expect(registerContainer).toHaveBeenCalledWith("my-secret", expect.objectContaining({
+        containerName: "al-test-agent-abc",
+        agentName: "test-agent",
+        instanceId: "test-agent-abc",
+      }));
+      expect(runtime.streamLogs).toHaveBeenCalledWith("al-test-agent-abc", expect.any(Function), expect.any(Function));
+      expect(runtime.waitForExit).toHaveBeenCalledWith("al-test-agent-abc", expect.any(Number));
+      expect(unregisterContainer).toHaveBeenCalledWith("my-secret");
+      expect(runtime.remove).toHaveBeenCalledWith("al-test-agent-abc");
+      expect(outcome.result).toBe("completed");
+    });
+
+    it("returns error when container exits with non-zero code", async () => {
+      const errorRuntime = createMockRuntime({
+        waitForExit: vi.fn().mockResolvedValue(1),
+      });
+      const runner = new ContainerAgentRunner(
+        errorRuntime, globalConfig, agentConfig, mockLogger,
+        vi.fn(), vi.fn(), "", "/tmp", "test-image:latest",
+      );
+
+      const outcome = await runner.adoptContainer("al-test-agent-err", "secret", "test-agent-err");
+      expect(outcome.result).toBe("error");
+    });
+
+    it("returns rerun when container exits with code 42", async () => {
+      const rerunRuntime = createMockRuntime({
+        waitForExit: vi.fn().mockResolvedValue(42),
+      });
+      const runner = new ContainerAgentRunner(
+        rerunRuntime, globalConfig, agentConfig, mockLogger,
+        vi.fn(), vi.fn(), "", "/tmp", "test-image:latest",
+      );
+
+      const outcome = await runner.adoptContainer("al-test-agent-rerun", "secret", "test-agent-rerun");
+      expect(outcome.result).toBe("rerun");
+    });
+
+    it("returns error immediately when runner is already busy", async () => {
+      const runner = new ContainerAgentRunner(
+        runtime, globalConfig, agentConfig, mockLogger,
+        vi.fn(), vi.fn(), "", "/tmp", "test-image:latest",
+      );
+
+      // Start a run to mark the runner as busy
+      const runPromise = runner.run("busy");
+      await Promise.resolve(); // let it enter async
+
+      const outcome = await runner.adoptContainer("other-container", "secret", "other-instance");
+      expect(outcome.result).toBe("error");
+
+      // Clean up
+      await runPromise;
+    });
+
+    it("skips registerContainer when gatewayUrl is empty", async () => {
+      const registerContainer = vi.fn().mockResolvedValue(undefined);
+      const runner = new ContainerAgentRunner(
+        runtime, globalConfig, agentConfig, mockLogger,
+        registerContainer, vi.fn(), "", "/tmp", "test-image:latest",
+      );
+
+      await runner.adoptContainer("al-test-agent-nogw", "secret", "test-agent-nogw");
+      expect(registerContainer).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/action-llama/test/docker/local-runtime.test.ts
+++ b/packages/action-llama/test/docker/local-runtime.test.ts
@@ -878,3 +878,41 @@ describe("LocalDockerRuntime.followLogs and getTaskUrl", () => {
     expect(runtime.getTaskUrl()).toBeNull();
   });
 });
+
+describe("LocalDockerRuntime.inspectContainer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("parses environment variables from docker inspect output", async () => {
+    mockExecFileSync.mockReturnValue(JSON.stringify(["KEY=val", "SHUTDOWN_SECRET=abc123", "EMPTY="]));
+    const runtime = new LocalDockerRuntime();
+    const result = await runtime.inspectContainer("al-test-agent-abc");
+    expect(result).not.toBeNull();
+    expect(result!.env).toEqual({ KEY: "val", SHUTDOWN_SECRET: "abc123", EMPTY: "" });
+  });
+
+  it("handles env vars with = in the value", async () => {
+    mockExecFileSync.mockReturnValue(JSON.stringify(["BASE64=abc=def=ghi"]));
+    const runtime = new LocalDockerRuntime();
+    const result = await runtime.inspectContainer("al-test-agent-abc");
+    expect(result!.env).toEqual({ BASE64: "abc=def=ghi" });
+  });
+
+  it("returns null when docker inspect throws (container not found)", async () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("No such container");
+    });
+    const runtime = new LocalDockerRuntime();
+    const result = await runtime.inspectContainer("nonexistent-container");
+    expect(result).toBeNull();
+  });
+
+  it("returns empty env object for container with no env vars", async () => {
+    mockExecFileSync.mockReturnValue("[]");
+    const runtime = new LocalDockerRuntime();
+    const result = await runtime.inspectContainer("al-test-agent-abc");
+    expect(result).not.toBeNull();
+    expect(result!.env).toEqual({});
+  });
+});

--- a/packages/action-llama/test/execution/container-registry.test.ts
+++ b/packages/action-llama/test/execution/container-registry.test.ts
@@ -239,6 +239,52 @@ describe("ContainerRegistry", () => {
     });
   });
 
+  describe("findByContainerName()", () => {
+    it("returns undefined when the registry is empty", () => {
+      const registry = new ContainerRegistry();
+      expect(registry.findByContainerName("container-1")).toBeUndefined();
+    });
+
+    it("returns the secret and registration for a known container name", async () => {
+      const reg = makeReg({ containerName: "my-container", instanceId: "i1" });
+      const registry = new ContainerRegistry();
+      await registry.register("secret-xyz", reg);
+
+      const result = registry.findByContainerName("my-container");
+      expect(result).toBeDefined();
+      expect(result!.secret).toBe("secret-xyz");
+      expect(result!.reg).toEqual(reg);
+    });
+
+    it("returns undefined for an unknown container name", async () => {
+      const registry = new ContainerRegistry();
+      await registry.register("secret-xyz", makeReg({ containerName: "known-container" }));
+
+      expect(registry.findByContainerName("unknown-container")).toBeUndefined();
+    });
+
+    it("finds the correct entry among multiple registrations", async () => {
+      const registry = new ContainerRegistry();
+      const reg1 = makeReg({ containerName: "container-a", instanceId: "i1" });
+      const reg2 = makeReg({ containerName: "container-b", instanceId: "i2" });
+      await registry.register("secret-1", reg1);
+      await registry.register("secret-2", reg2);
+
+      const result = registry.findByContainerName("container-b");
+      expect(result).toBeDefined();
+      expect(result!.secret).toBe("secret-2");
+      expect(result!.reg).toEqual(reg2);
+    });
+
+    it("returns undefined after the entry is unregistered", async () => {
+      const registry = new ContainerRegistry();
+      await registry.register("secret-xyz", makeReg({ containerName: "my-container" }));
+      await registry.unregister("secret-xyz");
+
+      expect(registry.findByContainerName("my-container")).toBeUndefined();
+    });
+  });
+
   describe("size", () => {
     it("returns 0 for a new registry", () => {
       const registry = new ContainerRegistry();

--- a/packages/action-llama/test/scheduler/gateway-setup.test.ts
+++ b/packages/action-llama/test/scheduler/gateway-setup.test.ts
@@ -667,7 +667,7 @@ describe("setupGateway", () => {
         await controlDeps.stopScheduler();
 
         expect(schedulerCtx.shuttingDown).toBe(true);
-        expect(workQueue.clearAll).toHaveBeenCalledOnce();
+        expect(workQueue.clearAll).not.toHaveBeenCalled();
         expect(workQueue.close).toHaveBeenCalledOnce();
         expect(job1.stop).toHaveBeenCalledOnce();
         expect(processExitSpy).toHaveBeenCalledWith(0);

--- a/packages/action-llama/test/scheduler/shutdown.test.ts
+++ b/packages/action-llama/test/scheduler/shutdown.test.ts
@@ -74,7 +74,7 @@ describe("registerShutdownHandlers", () => {
 
     expect(watcherStop).toHaveBeenCalledOnce();
     expect(ctx.shuttingDown).toBe(true);
-    expect(ctx.workQueue.clearAll).toHaveBeenCalledOnce();
+    expect(ctx.workQueue.clearAll).not.toHaveBeenCalled();
     expect(ctx.workQueue.close).toHaveBeenCalledOnce();
     expect(processExitSpy).toHaveBeenCalledWith(0);
   });


### PR DESCRIPTION
Closes #388

## Summary

This PR implements crash-resilient scheduler state persistence so running agent containers survive scheduler restarts.

## Changes

### Container re-adoption on restart
Instead of killing all orphan containers on startup, the scheduler now re-adopts them: reads SHUTDOWN_SECRET via docker inspect, re-registers with the gateway, re-attaches log streaming, and monitors exit normally.

### inspectContainer() on Runtime
Optional method added to the Runtime interface. LocalDockerRuntime implements it; SSH and host-user runtimes return null.

### findByContainerName() on ContainerRegistry
Reverse-lookup to find the secret associated with a container name. Used at startup to match running containers to their registry entries.

### adoptContainer() on ContainerAgentRunner
New public method that takes over monitoring of an already-running container without launching a new one.

### Work queue preservation
Removed workQueue.clearAll() from shutdown.ts and gateway-setup.ts. The SQLite-backed queue now persists across restarts.

### Crash resilience
Container registry entries are written to SQLite eagerly on each register() call. Lock store hydrates from StateStore on startup so adopted containers keep their locks.

## Tests
- Updated shutdown and gateway-setup tests (clearAll no longer called)
- New tests for ContainerRegistry.findByContainerName()
- New tests for ContainerAgentRunner.adoptContainer()
- New tests for LocalDockerRuntime.inspectContainer()