### PR TITLE
fix: add /triggers SPA fallback route to gateway

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12139,7 +12139,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.18.8",
+      "version": "0.18.10",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/packages/action-llama/src/gateway/index.ts
+++ b/packages/action-llama/src/gateway/index.ts
@@ -256,6 +256,7 @@ export async function startGateway(opts: GatewayOptions): Promise<GatewayServer>
         app.get("/login", (c) => c.html(indexHtml));
         app.get("/dashboard", (c) => c.html(indexHtml));
         app.get("/dashboard/*", (c) => c.html(indexHtml));
+        app.get("/triggers", (c) => c.html(indexHtml));
       } else {
         logger.warn("@action-llama/frontend not found — dashboard UI will not be served. API routes are still available.");
       }

--- a/packages/action-llama/test/gateway/gateway-routes.test.ts
+++ b/packages/action-llama/test/gateway/gateway-routes.test.ts
@@ -143,6 +143,43 @@ describe("Gateway /login SPA route", () => {
   });
 });
 
+// ── /triggers SPA route ───────────────────────────────────────────────────────
+
+describe("Gateway /triggers SPA route", () => {
+  let gateway: any;
+  let frontendDist: string;
+  const logger = makeLogger();
+  const TEST_API_KEY = "test-key-triggers-101";
+
+  beforeAll(async () => {
+    frontendDist = createMockFrontendDist();
+    gateway = await startGateway({
+      port: 0,
+      logger,
+      apiKey: TEST_API_KEY,
+      webUI: true,
+      statusTracker: mockStatusTracker(),
+      frontendDistPath: frontendDist,
+    });
+  });
+
+  afterAll(async () => {
+    await gateway.close();
+    rmSync(frontendDist, { recursive: true, force: true });
+  });
+
+  it("serves index.html at /triggers", async () => {
+    const addr = gateway.server.address() as any;
+    const res = await fetch(`http://localhost:${addr.port}/triggers`, {
+      headers: { Authorization: `Bearer ${TEST_API_KEY}` },
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('<div id="root">');
+    expect(res.headers.get("content-type")).toContain("text/html");
+  });
+});
+
 // ── /chat and /chat/* SPA routes ──────────────────────────────────────────────
 
 describe("Gateway /chat SPA routes", () => {


### PR DESCRIPTION
Closes #392

## Problem
When a user refreshes the browser at `/triggers`, the Hono gateway server had no matching route and returned 404. The React SPA defines this route client-side, but the server needs to serve `index.html` for it.

## Solution
Added a SPA fallback route for `/triggers` in `packages/action-llama/src/gateway/index.ts`, alongside the existing fallbacks for `/login`, `/dashboard`, and `/dashboard/*`.

## Changes
- `packages/action-llama/src/gateway/index.ts` — added `app.get("/triggers", (c) => c.html(indexHtml))`
- `packages/action-llama/test/gateway/gateway-routes.test.ts` — added test verifying `/triggers` returns 200 with `index.html`

## Testing
All 188 unit tests pass.