### PR TITLE
feat: add --grep, --after, --before search flags to `al logs`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12139,7 +12139,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.18.8",
+      "version": "0.18.10",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/packages/action-llama/src/cli/commands/logs.ts
+++ b/packages/action-llama/src/cli/commands/logs.ts
@@ -187,6 +187,27 @@ function formatRunHeader(entry: LogEntry): string | null {
   return null;
 }
 
+// ── Time value parsing ────────────────────────────────────────────────────────
+
+/**
+ * Parse a time value string into a Unix timestamp (ms).
+ * Accepts relative durations like "2h" or "7d", and ISO date strings.
+ */
+function parseTimeValue(value: string): number {
+  // Try relative duration: Nh or Nd
+  const relMatch = value.match(/^(\d+)(h|d)$/);
+  if (relMatch) {
+    const n = parseInt(relMatch[1], 10);
+    const unit = relMatch[2];
+    const ms = unit === "h" ? n * 3_600_000 : n * 86_400_000;
+    return Date.now() - ms;
+  }
+  // Try ISO date / any date string
+  const parsed = Date.parse(value);
+  if (!isNaN(parsed)) return parsed;
+  throw new Error(`Invalid time value: "${value}". Use a relative duration (e.g. 2h, 7d) or an ISO date string.`);
+}
+
 // ── Shared parsing & file helpers ─────────────────────────────────────────────
 
 // ── Log level mapping ────────────────────────────────────────────────────────
@@ -310,14 +331,14 @@ async function readLastNLines(filePath: string, n: number): Promise<string[]> {
   return lines.slice(-n); // Ensure we return exactly n lines (or fewer if file is smaller)
 }
 
-async function readLastN(filePath: string, n: number, fmt: Formatter): Promise<void> {
+async function readLastN(filePath: string, n: number, fmt: Formatter, showRunHeaders = false): Promise<void> {
   const lines = await readLastNLines(filePath, n * 3); // Read more raw lines to account for filtering
   const entries: string[] = [];
 
   for (const line of lines) {
     const entry = parseLine(line);
     if (entry) {
-      const header = fmt === formatConversationEntry ? formatRunHeader(entry) : null;
+      const header = showRunHeaders ? formatRunHeader(entry) : null;
       const formatted = fmt(entry);
       if (header) {
         entries.push(header);
@@ -335,7 +356,7 @@ async function readLastN(filePath: string, n: number, fmt: Formatter): Promise<v
   }
 }
 
-async function readNewData(filePath: string, start: number, fmt: Formatter): Promise<{ newPosition: number }> {
+async function readNewData(filePath: string, start: number, fmt: Formatter, showRunHeaders = false): Promise<{ newPosition: number }> {
   const currentSize = statSync(filePath).size;
   if (currentSize <= start) return { newPosition: start };
 
@@ -345,7 +366,7 @@ async function readNewData(filePath: string, start: number, fmt: Formatter): Pro
   for await (const line of rl) {
     const entry = parseLine(line);
     if (entry) {
-      if (fmt === formatConversationEntry) {
+      if (showRunHeaders) {
         const header = formatRunHeader(entry);
         if (header) console.log(header);
       }
@@ -357,8 +378,8 @@ async function readNewData(filePath: string, start: number, fmt: Formatter): Pro
   return { newPosition: currentSize };
 }
 
-async function followFile(filePath: string, lastN: number, fmt: Formatter): Promise<void> {
-  await readLastN(filePath, lastN, fmt);
+async function followFile(filePath: string, lastN: number, fmt: Formatter, showRunHeaders = false): Promise<void> {
+  await readLastN(filePath, lastN, fmt, showRunHeaders);
 
   let position = statSync(filePath).size;
 
@@ -379,7 +400,7 @@ async function followFile(filePath: string, lastN: number, fmt: Formatter): Prom
 
   const readNewChanges = async () => {
     try {
-      const { newPosition } = await readNewData(filePath, position, fmt);
+      const { newPosition } = await readNewData(filePath, position, fmt, showRunHeaders);
       position = newPosition;
     } catch {
       // File may have been rotated or removed — ignore
@@ -416,7 +437,7 @@ async function followFile(filePath: string, lastN: number, fmt: Formatter): Prom
 
 export async function execute(
   agent: string,
-  opts: { project: string; lines: string; follow?: boolean; date?: string; raw?: boolean; all?: boolean; env?: string; instance?: string }
+  opts: { project: string; lines: string; follow?: boolean; date?: string; raw?: boolean; all?: boolean; env?: string; instance?: string; grep?: string; after?: string; before?: string }
 ): Promise<void> {
   const projectPath = resolve(opts.project);
   const fmt: Formatter = opts.raw
@@ -430,6 +451,24 @@ export async function execute(
     : undefined;
 
   const n = parseInt(opts.lines, 10);
+
+  // Parse --after / --before / --grep
+  let afterTs: number | undefined;
+  let beforeTs: number | undefined;
+  let grepRe: RegExp | undefined;
+
+  if (opts.after) {
+    try { afterTs = parseTimeValue(opts.after); }
+    catch (e: any) { console.error(`Error: ${e.message}`); process.exit(1); }
+  }
+  if (opts.before) {
+    try { beforeTs = parseTimeValue(opts.before); }
+    catch (e: any) { console.error(`Error: ${e.message}`); process.exit(1); }
+  }
+  if (opts.grep) {
+    try { grepRe = new RegExp(opts.grep); }
+    catch { console.error(`Error: Invalid grep pattern: "${opts.grep}"`); process.exit(1); }
+  }
 
   // Build API path
   let apiPath: string;
@@ -455,24 +494,40 @@ export async function execute(
       }
     };
 
+    // Helper to apply grep filter on entries received from gateway
+    const applyGrepFilter = (entries: LogEntry[]): LogEntry[] => {
+      if (!grepRe) return entries;
+      return entries.filter((e) => grepRe!.test(JSON.stringify(e)));
+    };
+
+    // Build base query params (time range + grep forwarded for server-side pre-filtering)
+    const buildBaseParams = () => {
+      const p = new URLSearchParams({ lines: String(n) });
+      if (afterTs !== undefined) p.set("after", String(afterTs));
+      if (beforeTs !== undefined) p.set("before", String(beforeTs));
+      if (opts.grep) p.set("grep", opts.grep);
+      return p;
+    };
+
     if (opts.follow) {
       // Initial fetch
-      const params = new URLSearchParams({ lines: String(n) });
+      const params = buildBaseParams();
       const res = await gatewayFetch({ project: opts.project, path: `${apiPath}?${params}`, env: opts.env });
       if (!res.ok) throw new Error(`Gateway returned ${res.status}`);
       const data = await res.json() as { entries: LogEntry[]; cursor: string | null; hasMore: boolean };
-      formatAndPrintEntries(data.entries);
+      formatAndPrintEntries(applyGrepFilter(data.entries));
       let cursor = data.cursor;
 
       // Poll with cursor
       const poll = async () => {
         const p = new URLSearchParams();
         if (cursor) p.set("cursor", cursor);
+        if (opts.grep) p.set("grep", opts.grep);
         try {
           const r = await gatewayFetch({ project: opts.project, path: `${apiPath}?${p}`, env: opts.env });
           if (r.ok) {
             const d = await r.json() as { entries: LogEntry[]; cursor: string | null; hasMore: boolean };
-            formatAndPrintEntries(d.entries);
+            formatAndPrintEntries(applyGrepFilter(d.entries));
             if (d.cursor) cursor = d.cursor;
           }
         } catch {
@@ -487,14 +542,15 @@ export async function execute(
       });
       await new Promise(() => {});
     } else {
-      const params = new URLSearchParams({ lines: String(n) });
+      const params = buildBaseParams();
       const res = await gatewayFetch({ project: opts.project, path: `${apiPath}?${params}`, env: opts.env });
       if (!res.ok) throw new Error(`Gateway returned ${res.status}`);
       const data = await res.json() as { entries: LogEntry[]; cursor: string | null; hasMore: boolean };
-      if (data.entries.length === 0) {
+      const filtered = applyGrepFilter(data.entries);
+      if (filtered.length === 0) {
         console.log(`No log entries found for "${agent}".`);
       } else {
-        formatAndPrintEntries(data.entries);
+        formatAndPrintEntries(filtered);
       }
     }
   } catch {
@@ -508,16 +564,23 @@ export async function execute(
       process.exit(1);
     }
 
-    // When --instance is specified, wrap the formatter to skip non-matching entries
+    // When --instance / --after / --before / --grep are specified, wrap the formatter
     const instanceFilter = instanceSuffix !== undefined ? `${agent}-${instanceSuffix}` : undefined;
-    const filteredFmt: Formatter = instanceFilter
-      ? (entry) => entry.instance === instanceFilter ? fmt(entry) : null
-      : fmt;
+    const filteredFmt: Formatter = (entry) => {
+      if (instanceFilter && entry.instance !== instanceFilter) return null;
+      if (afterTs !== undefined && entry.time <= afterTs) return null;
+      if (beforeTs !== undefined && entry.time >= beforeTs) return null;
+      if (grepRe && !grepRe.test(JSON.stringify(entry))) return null;
+      return fmt(entry);
+    };
+
+    // Show run headers only in default conversation mode (not raw, not --all)
+    const showRunHeaders = fmt === formatConversationEntry;
 
     if (opts.follow) {
-      await followFile(logFile, n, filteredFmt);
+      await followFile(logFile, n, filteredFmt, showRunHeaders);
     } else {
-      await readLastN(logFile, n, filteredFmt);
+      await readLastN(logFile, n, filteredFmt, showRunHeaders);
     }
   }
 }

--- a/packages/action-llama/src/cli/main.ts
+++ b/packages/action-llama/src/cli/main.ts
@@ -121,6 +121,9 @@ program
   .option("-a, --all", "show all log levels (no filtering)")
   .option("-E, --env <name>", "use named environment")
   .option("-i, --instance <N>", "instance number (for agents with scale > 1)")
+  .option("-g, --grep <pattern>", "filter log lines matching regex pattern (searches full JSON line)")
+  .option("--after <time>", "show entries after this time (ISO date or relative: 2h, 7d)")
+  .option("--before <time>", "show entries before this time (ISO date or relative: 2h, 7d)")
   .action(withCommand(async (agent: string, opts) => {
     const { execute } = await import("./commands/logs.js");
     await execute(agent, opts);

--- a/packages/action-llama/src/control/routes/logs.ts
+++ b/packages/action-llama/src/control/routes/logs.ts
@@ -88,6 +88,7 @@ async function readEntriesForward(
   afterTime?: number,
   beforeTime?: number,
   instanceFilter?: string,
+  grep?: RegExp,
 ): Promise<{ entries: LogEntry[]; newOffset: number }> {
   try {
     const stat = await fs.stat(filePath);
@@ -108,6 +109,7 @@ async function readEntriesForward(
         if (afterTime && entry.time <= afterTime) continue;
         if (beforeTime && entry.time >= beforeTime) continue;
         if (instanceFilter && entry.instance !== instanceFilter) continue;
+        if (grep && !grep.test(JSON.stringify(entry))) continue;
         entries.push(entry);
       }
 
@@ -127,6 +129,7 @@ async function readLastEntries(
   afterTime?: number,
   beforeTime?: number,
   instanceFilter?: string,
+  grep?: RegExp,
 ): Promise<{ entries: LogEntry[]; byteOffset: number }> {
   try {
     const stat = await fs.stat(filePath);
@@ -161,6 +164,7 @@ async function readLastEntries(
           if (afterTime && entry.time <= afterTime) continue;
           if (beforeTime && entry.time >= beforeTime) continue;
           if (instanceFilter && entry.instance !== instanceFilter) continue;
+          if (grep && !grep.test(JSON.stringify(entry))) continue;
           entries.unshift(entry);
           if (entries.length > limit) entries.shift();
         }
@@ -170,7 +174,8 @@ async function readLastEntries(
         const entry = parseLine(remainder);
         if (entry) {
           const inRange = (!afterTime || entry.time > afterTime) && (!beforeTime || entry.time < beforeTime)
-            && (!instanceFilter || entry.instance === instanceFilter);
+            && (!instanceFilter || entry.instance === instanceFilter)
+            && (!grep || grep.test(JSON.stringify(entry)));
           if (inRange) {
             entries.unshift(entry);
             if (entries.length > limit) entries.shift();
@@ -197,14 +202,20 @@ function parseQueryParams(query: Record<string, string | undefined>) {
   const cursor = query.cursor || undefined;
   const after = query.after ? parseInt(query.after, 10) : undefined;
   const before = query.before ? parseInt(query.before, 10) : undefined;
+  const grep = query.grep || undefined;
 
-  return { lines, cursor, after: isNaN(after as number) ? undefined : after, before: isNaN(before as number) ? undefined : before };
+  return { lines, cursor, after: isNaN(after as number) ? undefined : after, before: isNaN(before as number) ? undefined : before, grep };
 }
 
 export function registerLogRoutes(app: Hono, projectPath: string): void {
   // ── Scheduler logs ────────────────────────────────────────────────────────
   app.get("/api/logs/scheduler", async (c) => {
-    const { lines, cursor, after, before } = parseQueryParams(c.req.query());
+    const { lines, cursor, after, before, grep } = parseQueryParams(c.req.query());
+    let grepRe: RegExp | undefined;
+    if (grep) {
+      try { grepRe = new RegExp(grep); }
+      catch { return c.json({ error: "Invalid grep pattern" }, 400); }
+    }
 
     if (cursor) {
       const parsed = decodeCursor(cursor);
@@ -216,7 +227,7 @@ export function registerLogRoutes(app: Hono, projectPath: string): void {
       const currentDate = dateFromLogFile(file);
       // If date rolled over, read from start of new file
       const offset = currentDate !== parsed.date ? 0 : parsed.offsets[0] || 0;
-      const { entries, newOffset } = await readEntriesForward(file, offset, lines, after, before);
+      const { entries, newOffset } = await readEntriesForward(file, offset, lines, after, before, undefined, grepRe);
       const newCursor = encodeCursor(currentDate || parsed.date, [newOffset]);
       return c.json({ entries, cursor: newCursor, hasMore: entries.length >= lines });
     }
@@ -224,7 +235,7 @@ export function registerLogRoutes(app: Hono, projectPath: string): void {
     const file = findLatestLogFile(projectPath, "scheduler");
     if (!file) return c.json({ entries: [], cursor: null, hasMore: false });
 
-    const { entries, byteOffset } = await readLastEntries(file, lines, after, before);
+    const { entries, byteOffset } = await readLastEntries(file, lines, after, before, undefined, grepRe);
     const date = dateFromLogFile(file) || "";
     const resCursor = encodeCursor(date, [byteOffset]);
     return c.json({ entries, cursor: resCursor, hasMore: false });
@@ -235,7 +246,12 @@ export function registerLogRoutes(app: Hono, projectPath: string): void {
     const name = c.req.param("name");
     if (!SAFE_AGENT_NAME.test(name)) return c.json({ error: "Invalid agent name" }, 400);
 
-    const { lines, cursor, after, before } = parseQueryParams(c.req.query());
+    const { lines, cursor, after, before, grep } = parseQueryParams(c.req.query());
+    let grepRe: RegExp | undefined;
+    if (grep) {
+      try { grepRe = new RegExp(grep); }
+      catch { return c.json({ error: "Invalid grep pattern" }, 400); }
+    }
 
     const file = findLatestLogFile(projectPath, name);
     if (!file) return c.json({ entries: [], cursor: null, hasMore: false });
@@ -245,12 +261,12 @@ export function registerLogRoutes(app: Hono, projectPath: string): void {
       if (!parsed) return c.json({ error: "Invalid cursor" }, 400);
       const currentDate = dateFromLogFile(file);
       const offset = currentDate !== parsed.date ? 0 : parsed.offsets[0] || 0;
-      const { entries, newOffset } = await readEntriesForward(file, offset, lines, after, before);
+      const { entries, newOffset } = await readEntriesForward(file, offset, lines, after, before, undefined, grepRe);
       const newCursor = encodeCursor(currentDate || parsed.date, [newOffset]);
       return c.json({ entries, cursor: newCursor, hasMore: entries.length >= lines });
     }
 
-    const { entries, byteOffset } = await readLastEntries(file, lines, after, before);
+    const { entries, byteOffset } = await readLastEntries(file, lines, after, before, undefined, grepRe);
     const date = dateFromLogFile(file) || "";
     return c.json({ entries, cursor: encodeCursor(date, [byteOffset]), hasMore: false });
   });
@@ -262,7 +278,12 @@ export function registerLogRoutes(app: Hono, projectPath: string): void {
     if (!SAFE_AGENT_NAME.test(name)) return c.json({ error: "Invalid agent name" }, 400);
     if (!SAFE_AGENT_NAME.test(instanceId)) return c.json({ error: "Invalid instance ID" }, 400);
 
-    const { lines, cursor, after, before } = parseQueryParams(c.req.query());
+    const { lines, cursor, after, before, grep } = parseQueryParams(c.req.query());
+    let grepRe: RegExp | undefined;
+    if (grep) {
+      try { grepRe = new RegExp(grep); }
+      catch { return c.json({ error: "Invalid grep pattern" }, 400); }
+    }
     const instanceFilter = instanceId;
 
     const file = findLatestLogFile(projectPath, name);
@@ -273,12 +294,12 @@ export function registerLogRoutes(app: Hono, projectPath: string): void {
       if (!parsed) return c.json({ error: "Invalid cursor" }, 400);
       const currentDate = dateFromLogFile(file);
       const offset = currentDate !== parsed.date ? 0 : parsed.offsets[0] || 0;
-      const { entries, newOffset } = await readEntriesForward(file, offset, lines, after, before, instanceFilter);
+      const { entries, newOffset } = await readEntriesForward(file, offset, lines, after, before, instanceFilter, grepRe);
       const newCursor = encodeCursor(currentDate || parsed.date, [newOffset]);
       return c.json({ entries, cursor: newCursor, hasMore: entries.length >= lines });
     }
 
-    const { entries, byteOffset } = await readLastEntries(file, lines, after, before, instanceFilter);
+    const { entries, byteOffset } = await readLastEntries(file, lines, after, before, instanceFilter, grepRe);
     const date = dateFromLogFile(file) || "";
     return c.json({ entries, cursor: encodeCursor(date, [byteOffset]), hasMore: false });
   });

--- a/packages/action-llama/test/cli/commands/logs-gateway.test.ts
+++ b/packages/action-llama/test/cli/commands/logs-gateway.test.ts
@@ -182,4 +182,104 @@ describe("logs command — gateway path", () => {
       expect(output.some((l) => l.includes("Run completed"))).toBe(true);
     });
   });
+
+  // ── --after / --before passed as query params ────────────────────────────
+
+  describe("--after / --before forwarded to gateway", () => {
+    it("passes after as Unix timestamp query param", async () => {
+      let calledPath = "";
+      mockGatewayFetch.mockImplementation(async (opts: { path: string }) => {
+        calledPath = opts.path;
+        return { ok: true, json: async () => ({ entries: [], cursor: null, hasMore: false }) };
+      });
+
+      const output: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: any[]) => output.push(args.join(" "));
+      await execute("dev", { project: tmpDir, lines: "50", after: "2h" });
+      console.log = origLog;
+
+      expect(calledPath).toContain("after=");
+      // Verify it's a numeric Unix timestamp in the URL
+      const match = calledPath.match(/after=(\d+)/);
+      expect(match).not.toBeNull();
+      const ts = parseInt(match![1], 10);
+      // Should be roughly 2 hours ago (within 10 second tolerance)
+      expect(ts).toBeGreaterThan(Date.now() - 2 * 3_600_000 - 10_000);
+      expect(ts).toBeLessThan(Date.now() - 2 * 3_600_000 + 10_000);
+    });
+
+    it("passes before as Unix timestamp query param", async () => {
+      let calledPath = "";
+      mockGatewayFetch.mockImplementation(async (opts: { path: string }) => {
+        calledPath = opts.path;
+        return { ok: true, json: async () => ({ entries: [], cursor: null, hasMore: false }) };
+      });
+
+      const output: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: any[]) => output.push(args.join(" "));
+      await execute("dev", { project: tmpDir, lines: "50", before: "2025-03-28T12:00:00Z" });
+      console.log = origLog;
+
+      expect(calledPath).toContain("before=");
+      const match = calledPath.match(/before=(\d+)/);
+      expect(match).not.toBeNull();
+      expect(parseInt(match![1], 10)).toBe(new Date("2025-03-28T12:00:00Z").getTime());
+    });
+  });
+
+  // ── --grep forwarded to gateway + client-side filtering ──────────────────
+
+  describe("--grep with gateway", () => {
+    it("passes grep pattern as query param to gateway", async () => {
+      let calledPath = "";
+      mockGatewayFetch.mockImplementation(async (opts: { path: string }) => {
+        calledPath = opts.path;
+        return { ok: true, json: async () => ({ entries: [], cursor: null, hasMore: false }) };
+      });
+
+      const output: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: any[]) => output.push(args.join(" "));
+      await execute("dev", { project: tmpDir, lines: "50", grep: "deploy" });
+      console.log = origLog;
+
+      expect(calledPath).toContain("grep=deploy");
+    });
+
+    it("applies client-side grep filtering on entries returned by gateway", async () => {
+      const entries = [
+        makePinoEntry({ msg: "bash", cmd: "deploy to prod" }),
+        makePinoEntry({ msg: "bash", cmd: "echo hello" }),
+        makePinoEntry({ msg: "bash", cmd: "deploy to staging" }),
+      ];
+      mockGatewayFetch.mockResolvedValueOnce(makeGatewayResponse(entries));
+
+      const output: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: any[]) => output.push(args.join(" "));
+      await execute("dev", { project: tmpDir, lines: "50", grep: "deploy" });
+      console.log = origLog;
+
+      expect(output).toHaveLength(2);
+      expect(output.every((l) => l.includes("deploy"))).toBe(true);
+    });
+
+    it("shows 'No log entries found' when grep filters out all entries", async () => {
+      const entries = [
+        makePinoEntry({ msg: "bash", cmd: "echo hello" }),
+      ];
+      mockGatewayFetch.mockResolvedValueOnce(makeGatewayResponse(entries));
+
+      const output: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: any[]) => output.push(args.join(" "));
+      await execute("dev", { project: tmpDir, lines: "50", grep: "deploy" });
+      console.log = origLog;
+
+      expect(output).toHaveLength(1);
+      expect(output[0]).toContain("No log entries found");
+    });
+  });
 });

--- a/packages/action-llama/test/cli/commands/logs.test.ts
+++ b/packages/action-llama/test/cli/commands/logs.test.ts
@@ -987,4 +987,241 @@ describe("logs command", () => {
     });
   });
 
+  // ── --grep filtering ──────────────────────────────────────────────────────
+
+  describe("--grep filtering (local file path)", () => {
+    it("filters entries matching the grep pattern", async () => {
+      const date = new Date().toISOString().slice(0, 10);
+      const logFile = resolve(tmpDir, ".al", "logs", `dev-${date}.log`);
+      const t = Date.now();
+      const content = [
+        makePinoLine({ msg: "bash", cmd: "deploy", time: t }),
+        makePinoLine({ msg: "bash", cmd: "echo hello", time: t + 1000 }),
+        makePinoLine({ msg: "bash", cmd: "deploy again", time: t + 2000 }),
+        makePinoLine({ msg: "run completed", time: t + 3000 }),
+      ].join("\n") + "\n";
+      writeFileSync(logFile, content);
+
+      const output: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: any[]) => output.push(args.join(" "));
+      await execute("dev", { project: tmpDir, lines: "50", grep: "deploy" });
+      console.log = origLog;
+
+      // Only lines containing "deploy" in their JSON representation
+      expect(output).toHaveLength(2);
+      expect(output[0]).toContain("deploy");
+      expect(output[1]).toContain("deploy");
+    });
+
+    it("grep searches the full JSON line (including non-msg fields)", async () => {
+      const date = new Date().toISOString().slice(0, 10);
+      const logFile = resolve(tmpDir, ".al", "logs", `dev-${date}.log`);
+      const t = Date.now();
+      const content = [
+        makePinoLine({ msg: "bash", cmd: "docker ps", time: t }),
+        makePinoLine({ msg: "bash", cmd: "ls -la", time: t + 1000 }),
+      ].join("\n") + "\n";
+      writeFileSync(logFile, content);
+
+      const output: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: any[]) => output.push(args.join(" "));
+      // Search for "docker" in the cmd field (not msg)
+      await execute("dev", { project: tmpDir, lines: "50", grep: "docker" });
+      console.log = origLog;
+
+      expect(output).toHaveLength(1);
+      expect(output[0]).toContain("docker ps");
+    });
+
+    it("exits with error on invalid grep pattern", async () => {
+      const date = new Date().toISOString().slice(0, 10);
+      const logFile = resolve(tmpDir, ".al", "logs", `dev-${date}.log`);
+      writeFileSync(logFile, makePinoLine({ msg: "test" }) + "\n");
+
+      const origExit = process.exit;
+      const origError = console.error;
+      let exitCode: number | undefined;
+      let errorMsg = "";
+
+      process.exit = ((code?: number) => { exitCode = code; throw new Error("EXIT"); }) as any;
+      console.error = (...args: any[]) => { errorMsg = args.join(" "); };
+
+      try {
+        await execute("dev", { project: tmpDir, lines: "50", grep: "[invalid" });
+      } catch {
+        // expected EXIT thrown
+      } finally {
+        process.exit = origExit;
+        console.error = origError;
+      }
+
+      expect(exitCode).toBe(1);
+      expect(errorMsg).toContain("Invalid grep pattern");
+    });
+  });
+
+  // ── --after / --before filtering ─────────────────────────────────────────
+
+  describe("--after / --before filtering (local file path)", () => {
+    it("filters entries with --after (relative duration)", async () => {
+      const date = new Date().toISOString().slice(0, 10);
+      const logFile = resolve(tmpDir, ".al", "logs", `dev-${date}.log`);
+      // Create entries: 5 hours ago and 1 hour ago
+      const now = Date.now();
+      const content = [
+        makePinoLine({ msg: "bash", cmd: "echo old", time: now - 5 * 3_600_000 }),
+        makePinoLine({ msg: "bash", cmd: "echo recent", time: now - 1 * 3_600_000 }),
+      ].join("\n") + "\n";
+      writeFileSync(logFile, content);
+
+      const output: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: any[]) => output.push(args.join(" "));
+      await execute("dev", { project: tmpDir, lines: "50", after: "2h" });
+      console.log = origLog;
+
+      // Only the entry within the last 2 hours
+      expect(output).toHaveLength(1);
+      expect(output[0]).toContain("echo recent");
+    });
+
+    it("filters entries with --before (ISO date string)", async () => {
+      const date = new Date().toISOString().slice(0, 10);
+      const logFile = resolve(tmpDir, ".al", "logs", `dev-${date}.log`);
+      const cutoff = new Date("2025-03-28T12:00:00Z").getTime();
+      const content = [
+        makePinoLine({ msg: "bash", cmd: "echo before cutoff", time: cutoff - 1000 }),
+        makePinoLine({ msg: "bash", cmd: "echo after cutoff", time: cutoff + 1000 }),
+      ].join("\n") + "\n";
+      writeFileSync(logFile, content);
+
+      const output: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: any[]) => output.push(args.join(" "));
+      await execute("dev", { project: tmpDir, lines: "50", before: "2025-03-28T12:00:00Z" });
+      console.log = origLog;
+
+      expect(output).toHaveLength(1);
+      expect(output[0]).toContain("echo before cutoff");
+    });
+
+    it("filters entries with both --after and --before", async () => {
+      const date = new Date().toISOString().slice(0, 10);
+      const logFile = resolve(tmpDir, ".al", "logs", `dev-${date}.log`);
+      const base = new Date("2025-03-28T10:00:00Z").getTime();
+      const content = [
+        makePinoLine({ msg: "bash", cmd: "msg A", time: base }),           // 10:00 (excluded: not strictly after 10:00)
+        makePinoLine({ msg: "bash", cmd: "msg B", time: base + 3_600_000 }), // 11:00 (included)
+        makePinoLine({ msg: "bash", cmd: "msg C", time: base + 2 * 3_600_000 }), // 12:00 (included)
+        makePinoLine({ msg: "bash", cmd: "msg D", time: base + 3 * 3_600_000 }), // 13:00 (excluded: not strictly before 13:00)
+      ].join("\n") + "\n";
+      writeFileSync(logFile, content);
+
+      const output: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: any[]) => output.push(args.join(" "));
+      await execute("dev", { project: tmpDir, lines: "50", after: "2025-03-28T10:00:00Z", before: "2025-03-28T13:00:00Z" });
+      console.log = origLog;
+
+      // Entries strictly after 10:00 and strictly before 13:00 → msg B and msg C
+      expect(output).toHaveLength(2);
+      expect(output[0]).toContain("msg B");
+      expect(output[1]).toContain("msg C");
+    });
+
+    it("exits with error on invalid --after value", async () => {
+      const date = new Date().toISOString().slice(0, 10);
+      const logFile = resolve(tmpDir, ".al", "logs", `dev-${date}.log`);
+      writeFileSync(logFile, makePinoLine({ msg: "test" }) + "\n");
+
+      const origExit = process.exit;
+      const origError = console.error;
+      let exitCode: number | undefined;
+      let errorMsg = "";
+
+      process.exit = ((code?: number) => { exitCode = code; throw new Error("EXIT"); }) as any;
+      console.error = (...args: any[]) => { errorMsg = args.join(" "); };
+
+      try {
+        await execute("dev", { project: tmpDir, lines: "50", after: "not-a-time" });
+      } catch {
+        // expected EXIT
+      } finally {
+        process.exit = origExit;
+        console.error = origError;
+      }
+
+      expect(exitCode).toBe(1);
+      expect(errorMsg).toContain("Invalid time value");
+    });
+
+    it("accepts ISO date string for --after", async () => {
+      const date = new Date().toISOString().slice(0, 10);
+      const logFile = resolve(tmpDir, ".al", "logs", `dev-${date}.log`);
+      const cutoff = new Date("2025-03-28T12:00:00Z").getTime();
+      const content = [
+        makePinoLine({ msg: "bash", cmd: "echo before", time: cutoff - 1000 }),
+        makePinoLine({ msg: "bash", cmd: "echo after", time: cutoff + 1000 }),
+      ].join("\n") + "\n";
+      writeFileSync(logFile, content);
+
+      const output: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: any[]) => output.push(args.join(" "));
+      await execute("dev", { project: tmpDir, lines: "50", after: "2025-03-28T12:00:00Z" });
+      console.log = origLog;
+
+      expect(output).toHaveLength(1);
+      expect(output[0]).toContain("echo after");
+    });
+
+    it("accepts day-based relative duration for --after", async () => {
+      const date = new Date().toISOString().slice(0, 10);
+      const logFile = resolve(tmpDir, ".al", "logs", `dev-${date}.log`);
+      const now = Date.now();
+      const content = [
+        makePinoLine({ msg: "bash", cmd: "echo too old", time: now - 10 * 86_400_000 }),
+        makePinoLine({ msg: "bash", cmd: "echo recent", time: now - 1 * 86_400_000 }),
+      ].join("\n") + "\n";
+      writeFileSync(logFile, content);
+
+      const output: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: any[]) => output.push(args.join(" "));
+      await execute("dev", { project: tmpDir, lines: "50", after: "7d" });
+      console.log = origLog;
+
+      expect(output).toHaveLength(1);
+      expect(output[0]).toContain("echo recent");
+    });
+  });
+
+  // ── --grep combined with --after / --before ───────────────────────────────
+
+  describe("--grep combined with --after / --before", () => {
+    it("applies both time range and grep filter", async () => {
+      const date = new Date().toISOString().slice(0, 10);
+      const logFile = resolve(tmpDir, ".al", "logs", `dev-${date}.log`);
+      const now = Date.now();
+      const content = [
+        makePinoLine({ msg: "bash", cmd: "echo error old", time: now - 5 * 3_600_000 }),
+        makePinoLine({ msg: "bash", cmd: "echo hello recent", time: now - 1 * 3_600_000 }),
+        makePinoLine({ msg: "bash", cmd: "echo error recent", time: now - 30 * 60_000 }),
+      ].join("\n") + "\n";
+      writeFileSync(logFile, content);
+
+      const output: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: any[]) => output.push(args.join(" "));
+      await execute("dev", { project: tmpDir, lines: "50", after: "2h", grep: "error" });
+      console.log = origLog;
+
+      // Only the "error recent" entry is both within 2h AND matches "error"
+      expect(output).toHaveLength(1);
+      expect(output[0]).toContain("echo error recent");
+    });
+  });
+
 });

--- a/packages/action-llama/test/control/routes/logs.test.ts
+++ b/packages/action-llama/test/control/routes/logs.test.ts
@@ -345,4 +345,145 @@ describe("log API routes", () => {
       expect(res.status).toBe(200);
     });
   });
+
+  // ── grep filtering ──────────────────────────────────────────────────────
+
+  describe("grep filtering", () => {
+    it("filters scheduler entries by grep pattern", async () => {
+      const lines = [
+        pinoLine(30, 1710700001000, "deploy started"),
+        pinoLine(30, 1710700002000, "health check"),
+        pinoLine(30, 1710700003000, "deploy finished"),
+      ];
+      writeFileSync(join(logsPath, "scheduler-2024-03-18.log"), lines.join("\n") + "\n");
+
+      const app = createTestApp(tmpDir);
+      const res = await app.request("/api/logs/scheduler?grep=deploy");
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.entries).toHaveLength(2);
+      expect(data.entries[0].msg).toBe("deploy started");
+      expect(data.entries[1].msg).toBe("deploy finished");
+    });
+
+    it("filters agent log entries by grep pattern", async () => {
+      const lines = [
+        pinoLine(30, 1710700001000, "deploy started"),
+        pinoLine(30, 1710700002000, "health check"),
+        pinoLine(30, 1710700003000, "deploy finished"),
+      ];
+      writeFileSync(join(logsPath, "dev-2024-03-18.log"), lines.join("\n") + "\n");
+
+      const app = createTestApp(tmpDir);
+      const res = await app.request("/api/logs/agents/dev?grep=deploy");
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.entries).toHaveLength(2);
+      expect(data.entries[0].msg).toBe("deploy started");
+      expect(data.entries[1].msg).toBe("deploy finished");
+    });
+
+    it("filters instance log entries by grep pattern", async () => {
+      const lines = [
+        pinoLine(30, 1710700001000, "deploy started", { instance: "dev-aa11bb22" }),
+        pinoLine(30, 1710700002000, "health check", { instance: "dev-aa11bb22" }),
+        pinoLine(30, 1710700003000, "deploy finished", { instance: "dev-aa11bb22" }),
+      ];
+      writeFileSync(join(logsPath, "dev-2024-03-18.log"), lines.join("\n") + "\n");
+
+      const app = createTestApp(tmpDir);
+      const res = await app.request("/api/logs/agents/dev/dev-aa11bb22?grep=deploy");
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.entries).toHaveLength(2);
+      expect(data.entries[0].msg).toBe("deploy started");
+      expect(data.entries[1].msg).toBe("deploy finished");
+    });
+
+    it("returns 400 for invalid grep pattern on scheduler", async () => {
+      const app = createTestApp(tmpDir);
+      const res = await app.request("/api/logs/scheduler?grep=%5Binvalid");
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe("Invalid grep pattern");
+    });
+
+    it("returns 400 for invalid grep pattern on agent logs", async () => {
+      const app = createTestApp(tmpDir);
+      const res = await app.request("/api/logs/agents/dev?grep=%5Binvalid");
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe("Invalid grep pattern");
+    });
+
+    it("returns 400 for invalid grep pattern on instance logs", async () => {
+      writeFileSync(join(logsPath, "dev-2024-03-18.log"), pinoLine(30, 1710700001000, "msg") + "\n");
+      const app = createTestApp(tmpDir);
+      const res = await app.request("/api/logs/agents/dev/dev-aa11bb22?grep=%5Binvalid");
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe("Invalid grep pattern");
+    });
+
+    it("grep searches the full JSON line (including extra fields)", async () => {
+      const lines = [
+        pinoLine(30, 1710700001000, "bash", { cmd: "docker ps" }),
+        pinoLine(30, 1710700002000, "bash", { cmd: "echo hello" }),
+      ];
+      writeFileSync(join(logsPath, "scheduler-2024-03-18.log"), lines.join("\n") + "\n");
+
+      const app = createTestApp(tmpDir);
+      const res = await app.request("/api/logs/scheduler?grep=docker");
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.entries).toHaveLength(1);
+      expect((data.entries[0] as any).cmd).toBe("docker ps");
+    });
+
+    it("combines grep with after/before time range", async () => {
+      const lines = [
+        pinoLine(30, 1710700001000, "deploy old"),
+        pinoLine(30, 1710700005000, "deploy recent"),
+        pinoLine(30, 1710700007000, "health check"),
+      ];
+      writeFileSync(join(logsPath, "scheduler-2024-03-18.log"), lines.join("\n") + "\n");
+
+      const app = createTestApp(tmpDir);
+      const res = await app.request("/api/logs/scheduler?after=1710700003000&grep=deploy");
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.entries).toHaveLength(1);
+      expect(data.entries[0].msg).toBe("deploy recent");
+    });
+
+    it("grep works with cursor pagination (returns only matching new entries)", async () => {
+      const lines = [
+        pinoLine(30, 1710700001000, "deploy started"),
+        pinoLine(30, 1710700002000, "health check"),
+      ];
+      writeFileSync(join(logsPath, "scheduler-2024-03-18.log"), lines.join("\n") + "\n");
+
+      const app = createTestApp(tmpDir);
+      // Initial fetch
+      const res1 = await app.request("/api/logs/scheduler?lines=10&grep=deploy");
+      const data1 = await res1.json();
+      expect(data1.entries).toHaveLength(1);
+      const cursor = data1.cursor;
+
+      // Append new data: one matching and one non-matching entry
+      const newLines = [
+        pinoLine(30, 1710700010000, "deploy finished"),
+        pinoLine(30, 1710700011000, "status update"),
+      ];
+      writeFileSync(
+        join(logsPath, "scheduler-2024-03-18.log"),
+        lines.join("\n") + "\n" + newLines.join("\n") + "\n",
+      );
+
+      const res2 = await app.request(`/api/logs/scheduler?cursor=${encodeURIComponent(cursor)}&grep=deploy`);
+      const data2 = await res2.json();
+      expect(data2.entries).toHaveLength(1);
+      expect(data2.entries[0].msg).toBe("deploy finished");
+    });
+  });
 });


### PR DESCRIPTION
Closes #385

## Summary

Adds log search capability to the `al logs` command and the underlying API:

### CLI changes
- **`--grep <pattern>`** (): Filter log entries matching a regex pattern, searched against the full JSON log line (all fields including `msg`, `cmd`, `tool`, `instance`, etc.)
- **`--after <time>`**: Show entries after this time (ISO date string like `2025-03-28T10:00:00Z` or relative duration like `2h`, `7d`)
- **`--before <time>`**: Show entries before this time (same formats as `--after`)

### API changes (`/api/logs/*`)
- New **`grep`** query parameter: Pre-filters entries server-side for efficiency; invalid regex returns 400
- `after` and `before` query params now forwarded from CLI (were already supported by API but not exposed)

### Implementation details
- CLI parses time values via new `parseTimeValue()` helper (supports `Nh`/`Nd` relative durations and ISO date strings)
- Grep is sent to the API for server-side pre-filtering AND applied client-side as a safety net
- Filter order in local path: instance → time range → grep (cheap checks first, regex last)
- In follow mode (`-f`), grep and time filters apply to new entries as they arrive
- Invalid regex or time values exit with a clear error message before making any API calls

### Example usage
```bash
# Search for errors in the last 24 hours
al logs dev --grep "error" --after 24h

# Search for a specific command
al logs dev --grep "docker ps"

# Time range with grep
al logs dev --after "2025-03-28" --before "2025-03-29" --grep "deploy"

# Relative duration
al logs dev --after 7d --grep "SIGKILL"
```

### Tests added
- **`test/cli/commands/logs.test.ts`**: Tests for `--grep`, `--after`, `--before` in local file path
- **`test/cli/commands/logs-gateway.test.ts`**: Tests for params forwarded to gateway + client-side grep
- **`test/control/routes/logs.test.ts`**: Tests for `grep` query param on all API routes, including invalid patterns (400) and combined filtering