### PR TITLE
feat: Introduce Drizzle ORM and consolidated SQLite database

### DIFF
--- a/.changeset/drizzle-migrations.md
+++ b/.changeset/drizzle-migrations.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Introduce Drizzle ORM as the data access layer for all SQLite operations. Consolidates the three separate databases (`.al/state.db`, `.al/stats.db`, `.al/work-queue.db`) into a single `.al/action-llama.db` managed by Drizzle migrations. On startup, pending migrations are applied automatically and existing data from legacy databases is migrated transparently. Existing `.db` files are backed up to `.al/backups/<timestamp>/` before migration. Closes #398.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1144,6 +1144,13 @@
         "prettier": "^2.7.1"
       }
     },
+    "node_modules/@drizzle-team/brocli": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
+      "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@emnapi/core": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
@@ -1176,6 +1183,910 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.3.2.tgz",
+      "integrity": "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==",
+      "deprecated": "Merged into tsx: https://tsx.is",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.18.20",
+        "source-map-support": "^0.5.21"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/@esbuild-kit/esm-loader": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.6.5.tgz",
+      "integrity": "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==",
+      "deprecated": "Merged into tsx: https://tsx.is",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^3.3.2",
+        "get-tsconfig": "^4.7.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@google/genai": {
@@ -4252,6 +5163,13 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@petamoriken/float16": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.3.tgz",
+      "integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
@@ -5592,7 +6510,7 @@
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -6469,6 +7387,13 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/buildcheck": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
@@ -7119,6 +8044,578 @@
         "node": ">=10"
       }
     },
+    "node_modules/drizzle-kit": {
+      "version": "0.30.6",
+      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.30.6.tgz",
+      "integrity": "sha512-U4wWit0fyZuGuP7iNmRleQyK2V8wCuv57vf5l3MnG4z4fzNTjY/U13M8owyQ5RavqvqxBifWORaR3wIUzlN64g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@drizzle-team/brocli": "^0.10.2",
+        "@esbuild-kit/esm-loader": "^2.5.5",
+        "esbuild": "^0.19.7",
+        "esbuild-register": "^3.5.0",
+        "gel": "^2.0.0"
+      },
+      "bin": {
+        "drizzle-kit": "bin.cjs"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
+      "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/android-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
+      "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/android-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
+      "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/android-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
+      "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
+      "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
+      "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
+      "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
+      "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
+      "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
+      "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
+      "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
+      "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
+      "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
+      "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
+      "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
+      "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
+      "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
+      "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
+      "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
+      "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/win32-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
+      "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/esbuild": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
+      "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.19.12",
+        "@esbuild/android-arm": "0.19.12",
+        "@esbuild/android-arm64": "0.19.12",
+        "@esbuild/android-x64": "0.19.12",
+        "@esbuild/darwin-arm64": "0.19.12",
+        "@esbuild/darwin-x64": "0.19.12",
+        "@esbuild/freebsd-arm64": "0.19.12",
+        "@esbuild/freebsd-x64": "0.19.12",
+        "@esbuild/linux-arm": "0.19.12",
+        "@esbuild/linux-arm64": "0.19.12",
+        "@esbuild/linux-ia32": "0.19.12",
+        "@esbuild/linux-loong64": "0.19.12",
+        "@esbuild/linux-mips64el": "0.19.12",
+        "@esbuild/linux-ppc64": "0.19.12",
+        "@esbuild/linux-riscv64": "0.19.12",
+        "@esbuild/linux-s390x": "0.19.12",
+        "@esbuild/linux-x64": "0.19.12",
+        "@esbuild/netbsd-x64": "0.19.12",
+        "@esbuild/openbsd-x64": "0.19.12",
+        "@esbuild/sunos-x64": "0.19.12",
+        "@esbuild/win32-arm64": "0.19.12",
+        "@esbuild/win32-ia32": "0.19.12",
+        "@esbuild/win32-x64": "0.19.12"
+      }
+    },
+    "node_modules/drizzle-orm": {
+      "version": "0.38.4",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.38.4.tgz",
+      "integrity": "sha512-s7/5BpLKO+WJRHspvpqTydxFob8i1vo2rEx4pY6TGY7QSMuUfWUuzaY0DIpXCkgHOo37BaFC+SJQb99dDUXT3Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/react": ">=18",
+        "@types/sql.js": "*",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "react": ">=18",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -7200,6 +8697,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/environment": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -7258,6 +8768,62 @@
         "docs",
         "benchmarks"
       ]
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/esbuild-register": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.6.0.tgz",
+      "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.12 <1"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -7823,6 +9389,53 @@
         "node": ">=14"
       }
     },
+    "node_modules/gel": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/gel/-/gel-2.2.0.tgz",
+      "integrity": "sha512-q0ma7z2swmoamHQusey8ayo8+ilVdzDt4WTxSPzq/yRqvucWRfymRVMvNgmSC0XK7eNjjEZEcplxpgaNojKdmQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@petamoriken/float16": "^3.8.7",
+        "debug": "^4.3.4",
+        "env-paths": "^3.0.0",
+        "semver": "^7.6.2",
+        "shell-quote": "^1.8.1",
+        "which": "^4.0.0"
+      },
+      "bin": {
+        "gel": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/gel/node_modules/isexe": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gel/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/generator-function": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -7906,6 +9519,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/get-uri": {
@@ -10520,6 +12146,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
@@ -10783,6 +12419,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/shimmer": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
@@ -11041,8 +12690,8 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "devOptional": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11055,6 +12704,17 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/spawndamnit": {
@@ -12139,7 +13799,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.18.10",
+      "version": "0.18.11",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
@@ -12156,6 +13816,7 @@
         "better-sqlite3": "^12.8.0",
         "commander": "^14.0.3",
         "croner": "^10.0.1",
+        "drizzle-orm": "^0.38.4",
         "hono": "^4.12.5",
         "ink": "^6.8.0",
         "pino": "^10.3.1",
@@ -12173,6 +13834,7 @@
         "@types/better-sqlite3": "^7.6.13",
         "@types/react": "^19.2.14",
         "@types/ws": "^8.18.1",
+        "drizzle-kit": "^0.30.6",
         "ink-testing-library": "^4.0.0"
       },
       "engines": {

--- a/packages/action-llama/drizzle.config.ts
+++ b/packages/action-llama/drizzle.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  schema: "./src/db/schema.ts",
+  out: "./drizzle",
+  dialect: "sqlite",
+});

--- a/packages/action-llama/drizzle/0000_married_shockwave.sql
+++ b/packages/action-llama/drizzle/0000_married_shockwave.sql
@@ -1,0 +1,118 @@
+CREATE TABLE `call_edges` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`caller_agent` text NOT NULL,
+	`caller_instance` text NOT NULL,
+	`target_agent` text NOT NULL,
+	`target_instance` text,
+	`depth` integer DEFAULT 0 NOT NULL,
+	`started_at` integer NOT NULL,
+	`duration_ms` integer,
+	`status` text DEFAULT 'pending' NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_calls_caller` ON `call_edges` (`caller_agent`,`started_at`);--> statement-breakpoint
+CREATE INDEX `idx_calls_target` ON `call_edges` (`target_agent`,`started_at`);--> statement-breakpoint
+CREATE INDEX `idx_calls_target_instance` ON `call_edges` (`target_instance`);--> statement-breakpoint
+CREATE TABLE `events` (
+	`id` text PRIMARY KEY NOT NULL,
+	`stream` text NOT NULL,
+	`type` text NOT NULL,
+	`data` text NOT NULL,
+	`metadata` text,
+	`timestamp` integer NOT NULL,
+	`version` integer DEFAULT 1 NOT NULL,
+	`sequence` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_events_stream` ON `events` (`stream`,`sequence`);--> statement-breakpoint
+CREATE INDEX `idx_events_type` ON `events` (`stream`,`type`,`timestamp`);--> statement-breakpoint
+CREATE INDEX `idx_events_timestamp` ON `events` (`stream`,`timestamp`);--> statement-breakpoint
+CREATE TABLE `kv_store` (
+	`namespace` text NOT NULL,
+	`key` text NOT NULL,
+	`value` text NOT NULL,
+	`expires_at` integer,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	PRIMARY KEY(`namespace`, `key`)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_kv_expires` ON `kv_store` (`expires_at`);--> statement-breakpoint
+CREATE INDEX `idx_kv_namespace` ON `kv_store` (`namespace`);--> statement-breakpoint
+CREATE TABLE `queue` (
+	`id` text NOT NULL,
+	`name` text NOT NULL,
+	`payload` text NOT NULL,
+	`enqueued_at` integer NOT NULL,
+	PRIMARY KEY(`name`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_queue_name` ON `queue` (`name`);--> statement-breakpoint
+CREATE TABLE `runs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`instance_id` text NOT NULL,
+	`agent_name` text NOT NULL,
+	`trigger_type` text NOT NULL,
+	`trigger_source` text,
+	`result` text NOT NULL,
+	`exit_code` integer,
+	`started_at` integer NOT NULL,
+	`duration_ms` integer NOT NULL,
+	`input_tokens` integer DEFAULT 0 NOT NULL,
+	`output_tokens` integer DEFAULT 0 NOT NULL,
+	`cache_read_tokens` integer DEFAULT 0 NOT NULL,
+	`cache_write_tokens` integer DEFAULT 0 NOT NULL,
+	`total_tokens` integer DEFAULT 0 NOT NULL,
+	`cost_usd` real DEFAULT 0 NOT NULL,
+	`turn_count` integer DEFAULT 0 NOT NULL,
+	`error_message` text,
+	`pre_hook_ms` integer,
+	`post_hook_ms` integer,
+	`webhook_receipt_id` text
+);
+--> statement-breakpoint
+CREATE INDEX `idx_runs_agent` ON `runs` (`agent_name`,`started_at`);--> statement-breakpoint
+CREATE INDEX `idx_runs_started` ON `runs` (`started_at`);--> statement-breakpoint
+CREATE TABLE `snapshots` (
+	`stream` text NOT NULL,
+	`type` text NOT NULL,
+	`data` text NOT NULL,
+	`event_id` text NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`stream`, `type`)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_snapshots_stream` ON `snapshots` (`stream`);--> statement-breakpoint
+CREATE TABLE `state` (
+	`ns` text NOT NULL,
+	`key` text NOT NULL,
+	`value` text NOT NULL,
+	`expires_at` integer,
+	PRIMARY KEY(`ns`, `key`)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_state_expires` ON `state` (`expires_at`);--> statement-breakpoint
+CREATE TABLE `webhook_receipts` (
+	`id` text PRIMARY KEY NOT NULL,
+	`delivery_id` text,
+	`source` text NOT NULL,
+	`event_summary` text,
+	`timestamp` integer NOT NULL,
+	`headers` text,
+	`body` text,
+	`matched_agents` integer DEFAULT 0 NOT NULL,
+	`status` text NOT NULL,
+	`dead_letter_reason` text
+);
+--> statement-breakpoint
+CREATE INDEX `idx_wr_timestamp` ON `webhook_receipts` (`timestamp`);--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_wr_delivery` ON `webhook_receipts` (`delivery_id`);--> statement-breakpoint
+CREATE TABLE `work_queue` (
+	`id` text NOT NULL,
+	`agent` text NOT NULL,
+	`payload` text NOT NULL,
+	`received_at` integer NOT NULL,
+	PRIMARY KEY(`agent`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_wq_agent` ON `work_queue` (`agent`);

--- a/packages/action-llama/drizzle/meta/0000_snapshot.json
+++ b/packages/action-llama/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,777 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "85d50d7f-54ae-4254-a533-471139f379f3",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "call_edges": {
+      "name": "call_edges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "caller_agent": {
+          "name": "caller_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caller_instance": {
+          "name": "caller_instance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_agent": {
+          "name": "target_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_instance": {
+          "name": "target_instance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "idx_calls_caller": {
+          "name": "idx_calls_caller",
+          "columns": [
+            "caller_agent",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_calls_target": {
+          "name": "idx_calls_target",
+          "columns": [
+            "target_agent",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_calls_target_instance": {
+          "name": "idx_calls_target_instance",
+          "columns": [
+            "target_instance"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stream": {
+          "name": "stream",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_events_stream": {
+          "name": "idx_events_stream",
+          "columns": [
+            "stream",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "idx_events_type": {
+          "name": "idx_events_type",
+          "columns": [
+            "stream",
+            "type",
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "idx_events_timestamp": {
+          "name": "idx_events_timestamp",
+          "columns": [
+            "stream",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "kv_store": {
+      "name": "kv_store",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_kv_expires": {
+          "name": "idx_kv_expires",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_kv_namespace": {
+          "name": "idx_kv_namespace",
+          "columns": [
+            "namespace"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "kv_store_namespace_key_pk": {
+          "columns": [
+            "namespace",
+            "key"
+          ],
+          "name": "kv_store_namespace_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queue": {
+      "name": "queue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enqueued_at": {
+          "name": "enqueued_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_queue_name": {
+          "name": "idx_queue_name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "queue_name_id_pk": {
+          "columns": [
+            "name",
+            "id"
+          ],
+          "name": "queue_name_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pre_hook_ms": {
+          "name": "pre_hook_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_hook_ms": {
+          "name": "post_hook_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "webhook_receipt_id": {
+          "name": "webhook_receipt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_runs_agent": {
+          "name": "idx_runs_agent",
+          "columns": [
+            "agent_name",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_runs_started": {
+          "name": "idx_runs_started",
+          "columns": [
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "snapshots": {
+      "name": "snapshots",
+      "columns": {
+        "stream": {
+          "name": "stream",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_snapshots_stream": {
+          "name": "idx_snapshots_stream",
+          "columns": [
+            "stream"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "snapshots_stream_type_pk": {
+          "columns": [
+            "stream",
+            "type"
+          ],
+          "name": "snapshots_stream_type_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "state": {
+      "name": "state",
+      "columns": {
+        "ns": {
+          "name": "ns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_state_expires": {
+          "name": "idx_state_expires",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "state_ns_key_pk": {
+          "columns": [
+            "ns",
+            "key"
+          ],
+          "name": "state_ns_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_receipts": {
+      "name": "webhook_receipts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_summary": {
+          "name": "event_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_agents": {
+          "name": "matched_agents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dead_letter_reason": {
+          "name": "dead_letter_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_wr_timestamp": {
+          "name": "idx_wr_timestamp",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "idx_wr_delivery": {
+          "name": "idx_wr_delivery",
+          "columns": [
+            "delivery_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "work_queue": {
+      "name": "work_queue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_wq_agent": {
+          "name": "idx_wq_agent",
+          "columns": [
+            "agent"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "work_queue_agent_id_pk": {
+          "columns": [
+            "agent",
+            "id"
+          ],
+          "name": "work_queue_agent_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/action-llama/drizzle/meta/_journal.json
+++ b/packages/action-llama/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1774901334467,
+      "tag": "0000_married_shockwave",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/action-llama/package.json
+++ b/packages/action-llama/package.json
@@ -42,6 +42,7 @@
     "build:assets": "node -e \"const fs=require('fs'),s='../frontend/dist',d='dist/frontend';fs.existsSync(s+'/index.html')?(fs.cpSync(s,d,{recursive:true}),console.log('Copied frontend dist → dist/frontend')):console.log('Frontend dist not found, skipping')\"",
     "clean": "rm -rf dist",
     "prebuild": "npm run clean",
+    "db:generate": "drizzle-kit generate",
     "test:playwright": "npx playwright test --config playwright.config.ts"
   },
   "dependencies": {
@@ -59,6 +60,7 @@
     "better-sqlite3": "^12.8.0",
     "commander": "^14.0.3",
     "croner": "^10.0.1",
+    "drizzle-orm": "^0.38.4",
     "hono": "^4.12.5",
     "ink": "^6.8.0",
     "pino": "^10.3.1",
@@ -73,6 +75,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/react": "^19.2.14",
     "@types/ws": "^8.18.1",
+    "drizzle-kit": "^0.30.6",
     "ink-testing-library": "^4.0.0"
   }
 }

--- a/packages/action-llama/src/db/connection.ts
+++ b/packages/action-llama/src/db/connection.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared database connection factory for action-llama.
+ *
+ * Creates a Drizzle ORM instance backed by better-sqlite3.
+ * All database access should go through the returned Drizzle instance.
+ * The underlying better-sqlite3 Database is available via `db.$client`.
+ */
+
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { mkdirSync } from "fs";
+import { dirname } from "path";
+import * as schema from "./schema.js";
+
+export type AppDb = ReturnType<typeof createDb>;
+
+/**
+ * Create a Drizzle database connection for the given file path.
+ * Creates parent directories if needed. Sets WAL mode and performance pragmas.
+ */
+export function createDb(dbPath: string): ReturnType<typeof drizzle<typeof schema>> {
+  if (dbPath !== ":memory:") {
+    mkdirSync(dirname(dbPath), { recursive: true });
+  }
+  const sqlite = new Database(dbPath);
+  sqlite.pragma("journal_mode = WAL");
+  sqlite.pragma("synchronous = NORMAL");
+  sqlite.pragma("cache_size = 1000");
+  sqlite.pragma("temp_store = memory");
+  return drizzle(sqlite, { schema });
+}
+
+/**
+ * Create an in-memory Drizzle database for tests.
+ */
+export function createMemoryDb(): ReturnType<typeof drizzle<typeof schema>> {
+  return createDb(":memory:");
+}

--- a/packages/action-llama/src/db/index.ts
+++ b/packages/action-llama/src/db/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Database layer — re-exports for convenient imports.
+ */
+
+export * from "./schema.js";
+export { createDb, createMemoryDb } from "./connection.js";
+export type { AppDb } from "./connection.js";
+export { runMigrations, applyMigrations, defaultMigrationsFolder } from "./migrate.js";

--- a/packages/action-llama/src/db/migrate.ts
+++ b/packages/action-llama/src/db/migrate.ts
@@ -1,0 +1,200 @@
+/**
+ * Auto-migration runner for the consolidated action-llama database.
+ *
+ * On startup:
+ * 1. Backs up any existing .db files to .al/backups/<timestamp>/
+ * 2. Runs pending Drizzle migrations against the consolidated DB
+ * 3. If legacy separate .db files exist, migrates their data into the consolidated DB (one-time)
+ */
+
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { existsSync, mkdirSync, copyFileSync } from "fs";
+import { join, dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import { createDb } from "./connection.js";
+import type { AppDb } from "./connection.js";
+
+/**
+ * Get the default migrations folder path relative to this module.
+ */
+export function defaultMigrationsFolder(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "../../drizzle");
+}
+
+/**
+ * Run Drizzle migrations on an existing AppDb instance.
+ * Useful for standalone stores that create their own connections.
+ */
+export function applyMigrations(db: AppDb, migrationsFolder?: string): void {
+  const folder = migrationsFolder ?? defaultMigrationsFolder();
+  migrate(db, { migrationsFolder: folder });
+}
+
+/**
+ * Run pending migrations and optionally migrate legacy data.
+ *
+ * @param dbPath - Path to the consolidated .al/action-llama.db file
+ * @param migrationsFolder - Path to the drizzle migrations folder (defaults to bundled drizzle/)
+ * @returns The opened Drizzle database instance (caller is responsible for closing)
+ */
+export function runMigrations(dbPath: string, migrationsFolder?: string): AppDb {
+  const projectAlDir = dirname(dbPath);
+
+  // Back up existing database files before migrating
+  backupExistingDbs(projectAlDir);
+
+  // Open/create the consolidated DB
+  const db = createDb(dbPath);
+
+  // Run Drizzle migrations (idempotent — only applies pending ones)
+  const folder = migrationsFolder ?? defaultMigrationsFolder();
+  migrate(db, { migrationsFolder: folder });
+
+  // Migrate legacy data if this is the first time we're consolidating
+  migrateLegacyData(db, projectAlDir, dbPath);
+
+  return db;
+}
+
+/**
+ * Copy all existing .db files into .al/backups/<timestamp>/ before migrating.
+ */
+function backupExistingDbs(alDir: string): void {
+  const legacyFiles = ["state.db", "stats.db", "work-queue.db", "action-llama.db"];
+  const toBackup = legacyFiles.filter((f) => existsSync(join(alDir, f)));
+  if (toBackup.length === 0) return;
+
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const backupDir = join(alDir, "backups", ts);
+  mkdirSync(backupDir, { recursive: true });
+
+  for (const f of toBackup) {
+    const src = join(alDir, f);
+    const dst = join(backupDir, f);
+    copyFileSync(src, dst);
+  }
+}
+
+/**
+ * One-time migration of legacy separate databases into the consolidated DB.
+ *
+ * Uses the presence of a special marker in kv_store to know if migration
+ * has already been performed.
+ */
+function migrateLegacyData(db: AppDb, alDir: string, consolidatedDbPath: string): void {
+  // Check if we've already migrated (using the raw sqlite client for a quick check)
+  const client = (db as any).$client;
+
+  const alreadyMigrated = client
+    .prepare("SELECT value FROM kv_store WHERE namespace = '__migration__' AND key = 'legacy_migrated' LIMIT 1")
+    .get();
+
+  if (alreadyMigrated) return;
+
+  const legacyStateDb = join(alDir, "state.db");
+  const legacyStatsDb = join(alDir, "stats.db");
+  const legacyWorkQueueDb = join(alDir, "work-queue.db");
+
+  const hasLegacy =
+    existsSync(legacyStateDb) ||
+    existsSync(legacyStatsDb) ||
+    existsSync(legacyWorkQueueDb);
+
+  if (!hasLegacy) {
+    // No legacy files — mark as migrated and return
+    markMigrated(client);
+    return;
+  }
+
+  // Perform migration inside a transaction
+  const doMigrate = client.transaction(() => {
+    // 1. Migrate state.db
+    if (existsSync(legacyStateDb)) {
+      migrateLegacyState(client, legacyStateDb);
+    }
+
+    // 2. Migrate stats.db
+    if (existsSync(legacyStatsDb)) {
+      migrateLegacyStats(client, legacyStatsDb);
+    }
+
+    // 3. Migrate work-queue.db
+    if (existsSync(legacyWorkQueueDb)) {
+      migrateLegacyWorkQueue(client, legacyWorkQueueDb);
+    }
+
+    markMigrated(client);
+  });
+
+  doMigrate();
+}
+
+function markMigrated(client: any): void {
+  const now = Date.now();
+  client
+    .prepare(
+      "INSERT OR REPLACE INTO kv_store (namespace, key, value, created_at, updated_at) VALUES ('__migration__', 'legacy_migrated', '\"true\"', ?, ?)"
+    )
+    .run(now, now);
+}
+
+function migrateLegacyState(client: any, legacyPath: string): void {
+  try {
+    client.exec(`ATTACH DATABASE '${legacyPath.replace(/'/g, "''")}' AS legacy_state`);
+    client.exec(`
+      INSERT OR IGNORE INTO state (ns, key, value, expires_at)
+      SELECT ns, key, value, expires_at FROM legacy_state.state
+    `);
+    client.exec("DETACH DATABASE legacy_state");
+  } catch {
+    // If the legacy db doesn't have the expected schema, skip
+    try { client.exec("DETACH DATABASE legacy_state"); } catch {}
+  }
+}
+
+function migrateLegacyStats(client: any, legacyPath: string): void {
+  try {
+    client.exec(`ATTACH DATABASE '${legacyPath.replace(/'/g, "''")}' AS legacy_stats`);
+
+    // Migrate webhook_receipts first (runs has a FK-like reference via webhook_receipt_id)
+    client.exec(`
+      INSERT OR IGNORE INTO webhook_receipts (id, delivery_id, source, event_summary, timestamp, headers, body, matched_agents, status, dead_letter_reason)
+      SELECT id, delivery_id, source, event_summary, timestamp, headers, body, matched_agents, status, dead_letter_reason
+      FROM legacy_stats.webhook_receipts
+    `);
+
+    // Migrate runs
+    client.exec(`
+      INSERT OR IGNORE INTO runs (id, instance_id, agent_name, trigger_type, trigger_source, result, exit_code, started_at, duration_ms, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, total_tokens, cost_usd, turn_count, error_message, pre_hook_ms, post_hook_ms, webhook_receipt_id)
+      SELECT id, instance_id, agent_name, trigger_type, trigger_source, result, exit_code, started_at, duration_ms,
+             COALESCE(input_tokens, 0), COALESCE(output_tokens, 0), COALESCE(cache_read_tokens, 0), COALESCE(cache_write_tokens, 0),
+             COALESCE(total_tokens, 0), COALESCE(cost_usd, 0), COALESCE(turn_count, 0),
+             error_message, pre_hook_ms, post_hook_ms, webhook_receipt_id
+      FROM legacy_stats.runs
+    `);
+
+    // Migrate call_edges
+    client.exec(`
+      INSERT OR IGNORE INTO call_edges (id, caller_agent, caller_instance, target_agent, target_instance, depth, started_at, duration_ms, status)
+      SELECT id, caller_agent, caller_instance, target_agent, target_instance, depth, started_at, duration_ms, status
+      FROM legacy_stats.call_edges
+    `);
+
+    client.exec("DETACH DATABASE legacy_stats");
+  } catch {
+    try { client.exec("DETACH DATABASE legacy_stats"); } catch {}
+  }
+}
+
+function migrateLegacyWorkQueue(client: any, legacyPath: string): void {
+  try {
+    client.exec(`ATTACH DATABASE '${legacyPath.replace(/'/g, "''")}' AS legacy_wq`);
+    client.exec(`
+      INSERT OR IGNORE INTO work_queue (id, agent, payload, received_at)
+      SELECT id, agent, payload, received_at FROM legacy_wq.work_queue
+    `);
+    client.exec("DETACH DATABASE legacy_wq");
+  } catch {
+    try { client.exec("DETACH DATABASE legacy_wq"); } catch {}
+  }
+}

--- a/packages/action-llama/src/db/schema.ts
+++ b/packages/action-llama/src/db/schema.ts
@@ -1,0 +1,246 @@
+/**
+ * Drizzle ORM schema definitions for the consolidated action-llama database.
+ *
+ * All tables from the legacy separate databases are defined here:
+ * - state         (formerly .al/state.db)
+ * - runs, webhook_receipts, call_edges (formerly .al/stats.db)
+ * - work_queue    (formerly .al/work-queue.db)
+ * - queue         (shared SqliteQueue)
+ * - kv_store, events, snapshots (persistence layer SqliteBackend)
+ */
+
+import {
+  sqliteTable,
+  text,
+  integer,
+  real,
+  index,
+  uniqueIndex,
+  primaryKey,
+} from "drizzle-orm/sqlite-core";
+
+// ---------------------------------------------------------------------------
+// State store (SqliteStateStore)
+// ---------------------------------------------------------------------------
+
+export const stateTable = sqliteTable(
+  "state",
+  {
+    ns: text("ns").notNull(),
+    key: text("key").notNull(),
+    value: text("value").notNull(),
+    expiresAt: integer("expires_at"),
+  },
+  (t) => [
+    primaryKey({ columns: [t.ns, t.key] }),
+    index("idx_state_expires").on(t.expiresAt),
+  ]
+);
+
+export type StateRow = typeof stateTable.$inferSelect;
+export type NewStateRow = typeof stateTable.$inferInsert;
+
+// ---------------------------------------------------------------------------
+// Stats — runs
+// ---------------------------------------------------------------------------
+
+export const runsTable = sqliteTable(
+  "runs",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    instanceId: text("instance_id").notNull(),
+    agentName: text("agent_name").notNull(),
+    triggerType: text("trigger_type").notNull(),
+    triggerSource: text("trigger_source"),
+    result: text("result").notNull(),
+    exitCode: integer("exit_code"),
+    startedAt: integer("started_at").notNull(),
+    durationMs: integer("duration_ms").notNull(),
+    inputTokens: integer("input_tokens").notNull().default(0),
+    outputTokens: integer("output_tokens").notNull().default(0),
+    cacheReadTokens: integer("cache_read_tokens").notNull().default(0),
+    cacheWriteTokens: integer("cache_write_tokens").notNull().default(0),
+    totalTokens: integer("total_tokens").notNull().default(0),
+    costUsd: real("cost_usd").notNull().default(0),
+    turnCount: integer("turn_count").notNull().default(0),
+    errorMessage: text("error_message"),
+    preHookMs: integer("pre_hook_ms"),
+    postHookMs: integer("post_hook_ms"),
+    webhookReceiptId: text("webhook_receipt_id"),
+  },
+  (t) => [
+    index("idx_runs_agent").on(t.agentName, t.startedAt),
+    index("idx_runs_started").on(t.startedAt),
+  ]
+);
+
+export type RunRow = typeof runsTable.$inferSelect;
+export type NewRunRow = typeof runsTable.$inferInsert;
+
+// ---------------------------------------------------------------------------
+// Stats — webhook_receipts
+// ---------------------------------------------------------------------------
+
+export const webhookReceiptsTable = sqliteTable(
+  "webhook_receipts",
+  {
+    id: text("id").primaryKey(),
+    deliveryId: text("delivery_id"),
+    source: text("source").notNull(),
+    eventSummary: text("event_summary"),
+    timestamp: integer("timestamp").notNull(),
+    headers: text("headers"),
+    body: text("body"),
+    matchedAgents: integer("matched_agents").notNull().default(0),
+    status: text("status").notNull(),
+    deadLetterReason: text("dead_letter_reason"),
+  },
+  (t) => [
+    index("idx_wr_timestamp").on(t.timestamp),
+    uniqueIndex("idx_wr_delivery").on(t.deliveryId),
+  ]
+);
+
+export type WebhookReceiptRow = typeof webhookReceiptsTable.$inferSelect;
+export type NewWebhookReceiptRow = typeof webhookReceiptsTable.$inferInsert;
+
+// ---------------------------------------------------------------------------
+// Stats — call_edges
+// ---------------------------------------------------------------------------
+
+export const callEdgesTable = sqliteTable(
+  "call_edges",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    callerAgent: text("caller_agent").notNull(),
+    callerInstance: text("caller_instance").notNull(),
+    targetAgent: text("target_agent").notNull(),
+    targetInstance: text("target_instance"),
+    depth: integer("depth").notNull().default(0),
+    startedAt: integer("started_at").notNull(),
+    durationMs: integer("duration_ms"),
+    status: text("status").notNull().default("pending"),
+  },
+  (t) => [
+    index("idx_calls_caller").on(t.callerAgent, t.startedAt),
+    index("idx_calls_target").on(t.targetAgent, t.startedAt),
+    index("idx_calls_target_instance").on(t.targetInstance),
+  ]
+);
+
+export type CallEdgeRow = typeof callEdgesTable.$inferSelect;
+export type NewCallEdgeRow = typeof callEdgesTable.$inferInsert;
+
+// ---------------------------------------------------------------------------
+// Work queue (SqliteWorkQueue)
+// ---------------------------------------------------------------------------
+
+export const workQueueTable = sqliteTable(
+  "work_queue",
+  {
+    id: text("id").notNull(),
+    agent: text("agent").notNull(),
+    payload: text("payload").notNull(),
+    receivedAt: integer("received_at").notNull(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.agent, t.id] }),
+    index("idx_wq_agent").on(t.agent),
+  ]
+);
+
+export type WorkQueueRow = typeof workQueueTable.$inferSelect;
+export type NewWorkQueueRow = typeof workQueueTable.$inferInsert;
+
+// ---------------------------------------------------------------------------
+// Generic queue (SqliteQueue)
+// ---------------------------------------------------------------------------
+
+export const queueTable = sqliteTable(
+  "queue",
+  {
+    id: text("id").notNull(),
+    name: text("name").notNull(),
+    payload: text("payload").notNull(),
+    enqueuedAt: integer("enqueued_at").notNull(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.name, t.id] }),
+    index("idx_queue_name").on(t.name),
+  ]
+);
+
+export type QueueRow = typeof queueTable.$inferSelect;
+export type NewQueueRow = typeof queueTable.$inferInsert;
+
+// ---------------------------------------------------------------------------
+// Persistence layer — kv_store (SqliteBackend)
+// ---------------------------------------------------------------------------
+
+export const kvStoreTable = sqliteTable(
+  "kv_store",
+  {
+    namespace: text("namespace").notNull(),
+    key: text("key").notNull(),
+    value: text("value").notNull(),
+    expiresAt: integer("expires_at"),
+    createdAt: integer("created_at").notNull(),
+    updatedAt: integer("updated_at").notNull(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.namespace, t.key] }),
+    index("idx_kv_expires").on(t.expiresAt),
+    index("idx_kv_namespace").on(t.namespace),
+  ]
+);
+
+export type KvStoreRow = typeof kvStoreTable.$inferSelect;
+export type NewKvStoreRow = typeof kvStoreTable.$inferInsert;
+
+// ---------------------------------------------------------------------------
+// Persistence layer — events (SqliteBackend)
+// ---------------------------------------------------------------------------
+
+export const eventsTable = sqliteTable(
+  "events",
+  {
+    id: text("id").primaryKey(),
+    stream: text("stream").notNull(),
+    type: text("type").notNull(),
+    data: text("data").notNull(),
+    metadata: text("metadata"),
+    timestamp: integer("timestamp").notNull(),
+    version: integer("version").notNull().default(1),
+    sequence: integer("sequence").notNull(),
+  },
+  (t) => [
+    index("idx_events_stream").on(t.stream, t.sequence),
+    index("idx_events_type").on(t.stream, t.type, t.timestamp),
+    index("idx_events_timestamp").on(t.stream, t.timestamp),
+  ]
+);
+
+export type EventRow = typeof eventsTable.$inferSelect;
+export type NewEventRow = typeof eventsTable.$inferInsert;
+
+// ---------------------------------------------------------------------------
+// Persistence layer — snapshots (SqliteBackend)
+// ---------------------------------------------------------------------------
+
+export const snapshotsTable = sqliteTable(
+  "snapshots",
+  {
+    stream: text("stream").notNull(),
+    type: text("type").notNull(),
+    data: text("data").notNull(),
+    eventId: text("event_id").notNull(),
+    createdAt: integer("created_at").notNull(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.stream, t.type] }),
+    index("idx_snapshots_stream").on(t.stream),
+  ]
+);
+
+export type SnapshotRow = typeof snapshotsTable.$inferSelect;
+export type NewSnapshotRow = typeof snapshotsTable.$inferInsert;

--- a/packages/action-llama/src/events/event-queue-sqlite.ts
+++ b/packages/action-llama/src/events/event-queue-sqlite.ts
@@ -1,7 +1,9 @@
-import Database from "better-sqlite3";
-import { mkdirSync } from "fs";
-import { dirname } from "path";
+import { eq, asc } from "drizzle-orm";
 import { randomUUID } from "crypto";
+import { createDb } from "../db/connection.js";
+import { applyMigrations } from "../db/migrate.js";
+import { workQueueTable } from "../db/schema.js";
+import type { AppDb } from "../db/connection.js";
 import type { WorkQueue, QueuedWorkItem, EnqueueResult } from "./event-queue.js";
 
 /**
@@ -11,21 +13,17 @@ import type { WorkQueue, QueuedWorkItem, EnqueueResult } from "./event-queue.js"
  * survives process crashes and restarts without a separate
  * persistence layer.
  *
- * Uses better-sqlite3 for synchronous embedded storage.
+ * Uses Drizzle ORM with better-sqlite3 for synchronous embedded storage.
  * Dequeue is atomic (transaction: select + delete) to prevent
  * concurrent double-claims.
+ *
+ * Supports two constructor signatures:
+ *   new SqliteWorkQueue(maxSize, dbPath: string)  — creates its own connection (backward compat)
+ *   new SqliteWorkQueue(maxSize, db: AppDb)        — uses a shared connection (preferred)
  */
 export class SqliteWorkQueue<T> implements WorkQueue<T> {
-  private db: InstanceType<typeof Database>;
-  private stmts: {
-    enqueue: any;
-    dequeue_peek: any;
-    delete_by_id: any;
-    size: any;
-    clear_agent: any;
-    clear_all: any;
-    oldest: any;
-  };
+  private db: AppDb;
+  private ownDb: boolean;
   private maxSize: number;
 
   private _dequeueTransaction: (agent: string) => {
@@ -41,73 +39,47 @@ export class SqliteWorkQueue<T> implements WorkQueue<T> {
     receivedAt: number,
   ) => { dropped?: { payload: string; received_at: number } };
 
-  constructor(maxSize: number, dbPath: string) {
+  constructor(maxSize: number, dbOrPath: string | AppDb) {
     this.maxSize = maxSize;
 
-    mkdirSync(dirname(dbPath), { recursive: true });
-    this.db = new Database(dbPath);
-    this.db.pragma("journal_mode = WAL");
+    if (typeof dbOrPath === "string") {
+      this.db = createDb(dbOrPath);
+      this.ownDb = true;
+      applyMigrations(this.db);
+    } else {
+      this.db = dbOrPath;
+      this.ownDb = false;
+    }
 
-    this.db.exec(`
-      CREATE TABLE IF NOT EXISTS work_queue (
-        id          TEXT    NOT NULL,
-        agent       TEXT    NOT NULL,
-        payload     TEXT    NOT NULL,
-        received_at INTEGER NOT NULL,
-        PRIMARY KEY (agent, id)
-      )
-    `);
-    this.db.exec(
-      "CREATE INDEX IF NOT EXISTS idx_wq_agent ON work_queue(agent)",
-    );
-
-    this.stmts = {
-      enqueue: this.db.prepare(
-        "INSERT INTO work_queue (id, agent, payload, received_at) VALUES (?, ?, ?, ?)",
-      ),
-      dequeue_peek: this.db.prepare(
-        "SELECT id, payload, received_at FROM work_queue WHERE agent = ? ORDER BY rowid ASC LIMIT 1",
-      ),
-      delete_by_id: this.db.prepare(
-        "DELETE FROM work_queue WHERE agent = ? AND id = ?",
-      ),
-      size: this.db.prepare(
-        "SELECT COUNT(*) AS n FROM work_queue WHERE agent = ?",
-      ),
-      clear_agent: this.db.prepare("DELETE FROM work_queue WHERE agent = ?"),
-      clear_all: this.db.prepare("DELETE FROM work_queue"),
-      oldest: this.db.prepare(
-        "SELECT id, payload, received_at FROM work_queue WHERE agent = ? ORDER BY rowid ASC LIMIT 1",
-      ),
-    };
+    const client = (this.db as any).$client;
 
     // Atomic dequeue: peek + delete in one transaction
-    this._dequeueTransaction = this.db.transaction((agent: string) => {
-      const row = this.stmts.dequeue_peek.get(agent) as
-        | { id: string; payload: string; received_at: number }
-        | undefined;
+    this._dequeueTransaction = client.transaction((agent: string) => {
+      const row = client
+        .prepare("SELECT id, payload, received_at FROM work_queue WHERE agent = ? ORDER BY rowid ASC LIMIT 1")
+        .get(agent) as { id: string; payload: string; received_at: number } | undefined;
       if (!row) return undefined;
-      this.stmts.delete_by_id.run(agent, row.id);
+      client.prepare("DELETE FROM work_queue WHERE agent = ? AND id = ?").run(agent, row.id);
       return row;
     });
 
     // Atomic enqueue with overflow: insert + conditionally drop oldest
-    this._enqueueTransaction = this.db.transaction(
+    this._enqueueTransaction = client.transaction(
       (agent: string, id: string, payload: string, receivedAt: number) => {
-        const { n } = this.stmts.size.get(agent) as { n: number };
+        const sizeRow = client.prepare("SELECT COUNT(*) AS n FROM work_queue WHERE agent = ?").get(agent) as { n: number };
         let dropped: { payload: string; received_at: number } | undefined;
 
-        if (n >= this.maxSize) {
-          const oldest = this.stmts.oldest.get(agent) as
-            | { id: string; payload: string; received_at: number }
-            | undefined;
+        if (sizeRow.n >= this.maxSize) {
+          const oldest = client
+            .prepare("SELECT id, payload, received_at FROM work_queue WHERE agent = ? ORDER BY rowid ASC LIMIT 1")
+            .get(agent) as { id: string; payload: string; received_at: number } | undefined;
           if (oldest) {
-            this.stmts.delete_by_id.run(agent, oldest.id);
+            client.prepare("DELETE FROM work_queue WHERE agent = ? AND id = ?").run(agent, oldest.id);
             dropped = { payload: oldest.payload, received_at: oldest.received_at };
           }
         }
 
-        this.stmts.enqueue.run(id, agent, payload, receivedAt);
+        client.prepare("INSERT INTO work_queue (id, agent, payload, received_at) VALUES (?, ?, ?, ?)").run(id, agent, payload, receivedAt);
         return { dropped };
       },
     );
@@ -143,19 +115,23 @@ export class SqliteWorkQueue<T> implements WorkQueue<T> {
   }
 
   size(agentName: string): number {
-    const row = this.stmts.size.get(agentName) as { n: number };
+    const row = (this.db as any).$client
+      .prepare("SELECT COUNT(*) AS n FROM work_queue WHERE agent = ?")
+      .get(agentName) as { n: number };
     return row.n;
   }
 
   clear(agentName: string): void {
-    this.stmts.clear_agent.run(agentName);
+    this.db.delete(workQueueTable).where(eq(workQueueTable.agent, agentName)).run();
   }
 
   clearAll(): void {
-    this.stmts.clear_all.run();
+    this.db.delete(workQueueTable).run();
   }
 
   close(): void {
-    this.db.close();
+    if (this.ownDb) {
+      (this.db as any).$client.close();
+    }
   }
 }

--- a/packages/action-llama/src/scheduler/index.ts
+++ b/packages/action-llama/src/scheduler/index.ts
@@ -4,7 +4,6 @@ import { createLogger, createFileOnlyLogger } from "../shared/logger.js";
 import type { StatusTracker } from "../tui/status-tracker.js";
 import type { PromptSkills } from "../agents/prompt.js";
 import { CONSTANTS } from "../shared/constants.js";
-import { createWorkQueue } from "../events/event-queue.js";
 import { createContainerRuntime, buildAgentImages } from "../execution/runtime-factory.js";
 import { setupWebhookRegistry, registerWebhookBindings } from "../events/webhook-setup.js";
 import { initTelemetry } from "../telemetry/index.js";
@@ -73,31 +72,38 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
     statusTracker?.registerAgent(agentConfig.name, agentConfig.scale ?? 1, agentConfig.description);
   }
 
-  // Create persistent state store (SQLite)
+  // Run database migrations and open the consolidated DB connection
+  const { runMigrations } = await import("../db/migrate.js");
+  const { resolve: resolvePath } = await import("path");
+  const { dbPath } = await import("../shared/paths.js");
+  const consolidatedDbPath = dbPath(projectPath);
+  const { fileURLToPath } = await import("url");
+  const migrationsFolder = resolvePath(
+    fileURLToPath(new URL("../../drizzle", import.meta.url))
+  );
+  const sharedDb = runMigrations(consolidatedDbPath, migrationsFolder);
+  logger.info("Database: SQLite (.al/action-llama.db)");
+
+  // Create persistent state store (using shared DB)
   let stateStore: StateStore | undefined;
   {
-    const { createStateStore } = await import("../shared/state-store.js");
-    const { resolve: resolvePath } = await import("path");
-    stateStore = await createStateStore({
-      type: "sqlite",
-      path: resolvePath(projectPath, ".al", "state.db"),
-    });
-    logger.info("State store: SQLite (.al/state.db)");
+    const { SqliteStateStore } = await import("../shared/state-store-sqlite.js");
+    stateStore = new SqliteStateStore(sharedDb);
+    logger.info("State store: SQLite (.al/action-llama.db)");
   }
 
-  // Create stats store (SQLite)
+  // Create stats store (using shared DB)
   let statsStore: StatsStore | undefined;
   {
     const { StatsStore: StatsStoreClass } = await import("../stats/index.js");
-    const { statsDbPath } = await import("../shared/paths.js");
-    statsStore = new StatsStoreClass(statsDbPath(projectPath));
+    statsStore = new StatsStoreClass(sharedDb);
     // Auto-prune old data on startup
     const retentionDays = globalConfig.historyRetentionDays ?? 14;
     const pruned = statsStore.prune(retentionDays);
     if (pruned.runs > 0 || pruned.callEdges > 0 || pruned.receipts > 0) {
       logger.info({ prunedRuns: pruned.runs, prunedCallEdges: pruned.callEdges, prunedReceipts: pruned.receipts, retentionDays }, "Pruned old stats data");
     }
-    logger.info("Stats store: SQLite (.al/stats.db)");
+    logger.info("Stats store: SQLite (.al/action-llama.db)");
   }
 
   // Create the lifecycle event bus
@@ -113,10 +119,8 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
 
   // Create work queue early (before Docker builds) so incoming webhooks can be queued
   const queueSize = globalConfig.workQueueSize ?? globalConfig.webhookQueueSize ?? 20;
-  const workQueue = await createWorkQueue<WorkItem>(queueSize, {
-    type: "sqlite",
-    path: (await import("path")).resolve(projectPath, ".al", "work-queue.db"),
-  });
+  const { SqliteWorkQueue } = await import("../events/event-queue-sqlite.js");
+  const workQueue = new SqliteWorkQueue<WorkItem>(queueSize, sharedDb);
   state.workQueue = workQueue;
 
   // Start gateway early (before Docker builds) so users can see build status
@@ -389,7 +393,7 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
 
   // Graceful shutdown
   registerShutdownHandlers({
-    logger, schedulerCtx, cronJobs, gateway, stateStore, statsStore, telemetry, watcherHandle,
+    logger, schedulerCtx, cronJobs, gateway, stateStore, statsStore, sharedDb, telemetry, watcherHandle,
   });
 
   return { cronJobs, runnerPools, gateway, webhookRegistry, webhookUrls, statusTracker, schedulerCtx, events };

--- a/packages/action-llama/src/scheduler/shutdown.ts
+++ b/packages/action-llama/src/scheduler/shutdown.ts
@@ -8,6 +8,7 @@ import type { StateStore } from "../shared/state-store.js";
 import type { Logger } from "../shared/logger.js";
 import type { SchedulerContext } from "../execution/execution.js";
 import type { StatsStore } from "../stats/index.js";
+import type { AppDb } from "../db/connection.js";
 
 export function registerShutdownHandlers(deps: {
   logger: Logger;
@@ -16,10 +17,11 @@ export function registerShutdownHandlers(deps: {
   gateway?: GatewayServer;
   stateStore?: StateStore;
   statsStore?: StatsStore;
+  sharedDb?: AppDb;
   telemetry?: any;
   watcherHandle: { stop: () => void };
 }): void {
-  const { logger, schedulerCtx, cronJobs, gateway, stateStore, statsStore, telemetry, watcherHandle } = deps;
+  const { logger, schedulerCtx, cronJobs, gateway, stateStore, statsStore, sharedDb, telemetry, watcherHandle } = deps;
 
   const shutdown = async () => {
     logger.info("Shutting down scheduler...");
@@ -38,6 +40,12 @@ export function registerShutdownHandlers(deps: {
     }
     if (statsStore) {
       statsStore.close();
+    }
+    // Close the shared DB connection (after stores are done with it)
+    if (sharedDb) {
+      try {
+        (sharedDb as any).$client.close();
+      } catch {}
     }
 
     // Shutdown telemetry

--- a/packages/action-llama/src/shared/paths.ts
+++ b/packages/action-llama/src/shared/paths.ts
@@ -26,3 +26,18 @@ export function agentDir(projectPath: string, agentType: string): string {
 export function statsDbPath(projectPath: string): string {
   return resolve(projectPath, ".al", "stats.db");
 }
+
+/** Path to the consolidated action-llama database. */
+export function dbPath(projectPath: string): string {
+  return resolve(projectPath, ".al", "action-llama.db");
+}
+
+/** @deprecated Use dbPath() instead. */
+export function stateDbPath(projectPath: string): string {
+  return resolve(projectPath, ".al", "state.db");
+}
+
+/** @deprecated Use dbPath() instead. */
+export function workQueueDbPath(projectPath: string): string {
+  return resolve(projectPath, ".al", "work-queue.db");
+}

--- a/packages/action-llama/src/shared/persistence/backends/sqlite.ts
+++ b/packages/action-llama/src/shared/persistence/backends/sqlite.ts
@@ -1,184 +1,131 @@
 /**
- * SQLite backend for unified persistence layer.
- * 
+ * SQLite backend for unified persistence layer using Drizzle ORM.
+ *
  * Implements the PersistenceBackend interface with SQLite storage,
  * combining key-value operations, event sourcing, and query capabilities
  * in a single database with optimized indexes and transaction support.
+ *
+ * Supports two constructor signatures:
+ *   new SqliteBackend(dbPath: string)  — creates its own connection (backward compat)
+ *   new SqliteBackend(db: AppDb)        — uses a shared connection (preferred)
  */
 
-import Database from "better-sqlite3";
-import { mkdirSync } from "fs";
-import { dirname } from "path";
+import { eq, and, isNull, or, gt, sql } from "drizzle-orm";
 import { randomUUID } from "crypto";
+import { createDb } from "../../../db/connection.js";
+import { applyMigrations } from "../../../db/migrate.js";
+import { kvStoreTable, eventsTable, snapshotsTable } from "../../../db/schema.js";
+import type { AppDb } from "../../../db/connection.js";
 import type { PersistenceBackend, Event, EventQuery } from "../index.js";
 
 export class SqliteBackend implements PersistenceBackend {
-  private db: InstanceType<typeof Database>;
-  private stmts: any = {};
+  private db: AppDb;
+  private ownDb: boolean;
   private sweepTimer: ReturnType<typeof setInterval> | undefined;
   private transactionDepth = 0;
 
-  constructor(private dbPath: string) {
-    if (dbPath !== ":memory:") {
-      mkdirSync(dirname(dbPath), { recursive: true });
+  constructor(dbOrPath: string | AppDb) {
+    if (typeof dbOrPath === "string") {
+      this.db = createDb(dbOrPath);
+      this.ownDb = true;
+    } else {
+      this.db = dbOrPath;
+      this.ownDb = false;
     }
-    this.db = new Database(dbPath);
-    this.db.pragma("journal_mode = WAL");
-    this.db.pragma("synchronous = NORMAL");
-    this.db.pragma("cache_size = 1000");
-    this.db.pragma("temp_store = memory");
   }
 
   async init(): Promise<void> {
-    // Create tables
-    this.db.exec(`
-      CREATE TABLE IF NOT EXISTS kv_store (
-        namespace TEXT NOT NULL,
-        key TEXT NOT NULL,
-        value TEXT NOT NULL,
-        expires_at INTEGER,
-        created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
-        updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
-        PRIMARY KEY (namespace, key)
-      )
-    `);
-
-    this.db.exec(`
-      CREATE TABLE IF NOT EXISTS events (
-        id TEXT PRIMARY KEY,
-        stream TEXT NOT NULL,
-        type TEXT NOT NULL,
-        data TEXT NOT NULL,
-        metadata TEXT,
-        timestamp INTEGER NOT NULL,
-        version INTEGER NOT NULL DEFAULT 1,
-        sequence INTEGER NOT NULL
-      )
-    `);
-
-    this.db.exec(`
-      CREATE TABLE IF NOT EXISTS snapshots (
-        stream TEXT NOT NULL,
-        type TEXT NOT NULL,
-        data TEXT NOT NULL,
-        event_id TEXT NOT NULL,
-        created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
-        PRIMARY KEY (stream, type)
-      )
-    `);
-
-    // Create indexes
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_kv_expires ON kv_store(expires_at) WHERE expires_at IS NOT NULL");
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_kv_namespace ON kv_store(namespace)");
-    
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_events_stream ON events(stream, sequence)");
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_events_type ON events(stream, type, timestamp)");
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(stream, timestamp)");
-    
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_snapshots_stream ON snapshots(stream)");
-
-    // Prepare statements
-    this.stmts = {
-      // Key-value operations
-      kvGet: this.db.prepare(`
-        SELECT value FROM kv_store 
-        WHERE namespace = ? AND key = ? AND (expires_at IS NULL OR expires_at > ?)
-      `),
-      kvSet: this.db.prepare(`
-        INSERT OR REPLACE INTO kv_store (namespace, key, value, expires_at, updated_at) 
-        VALUES (?, ?, ?, ?, ?)
-      `),
-      kvDelete: this.db.prepare("DELETE FROM kv_store WHERE namespace = ? AND key = ?"),
-      kvDeleteAll: this.db.prepare("DELETE FROM kv_store WHERE namespace = ?"),
-      kvList: this.db.prepare(`
-        SELECT key, value FROM kv_store 
-        WHERE namespace = ? AND (expires_at IS NULL OR expires_at > ?)
-        ORDER BY key
-      `),
-      
-      // Event operations
-      eventAppend: this.db.prepare(`
-        INSERT INTO events (id, stream, type, data, metadata, timestamp, version, sequence)
-        VALUES (?, ?, ?, ?, ?, ?, ?, (
-          SELECT COALESCE(MAX(sequence), 0) + 1 FROM events WHERE stream = ?
-        ))
-      `),
-      eventReplay: this.db.prepare(`
-        SELECT id, stream, type, data, metadata, timestamp, version, sequence
-        FROM events 
-        WHERE stream = ?
-          AND (? IS NULL OR type = ?)
-          AND (? IS NULL OR timestamp >= ?)
-          AND (? IS NULL OR timestamp < ?)
-        ORDER BY sequence ASC
-        LIMIT ? OFFSET ?
-      `),
-      eventCount: this.db.prepare(`
-        SELECT COUNT(*) as count FROM events 
-        WHERE stream = ?
-          AND (? IS NULL OR type = ?)
-          AND (? IS NULL OR timestamp >= ?)
-          AND (? IS NULL OR timestamp < ?)
-      `),
-      eventListStreams: this.db.prepare("SELECT DISTINCT stream FROM events ORDER BY stream"),
-      
-      // Snapshot operations
-      snapshotGet: this.db.prepare("SELECT data FROM snapshots WHERE stream = ? AND type = ?"),
-      snapshotSet: this.db.prepare(`
-        INSERT OR REPLACE INTO snapshots (stream, type, data, event_id, created_at)
-        VALUES (?, ?, ?, ?, ?)
-      `),
-      
-      // Cleanup
-      sweep: this.db.prepare("DELETE FROM kv_store WHERE expires_at IS NOT NULL AND expires_at <= ?"),
-    };
-
-    // Start periodic cleanup of expired KV entries
+    // When this instance owns its DB connection, run migrations to set up schema.
+    if (this.ownDb) {
+      applyMigrations(this.db);
+    }
+    // Start periodic cleanup of expired KV entries.
     this.sweepTimer = setInterval(() => this.sweep(), 60_000);
     if (this.sweepTimer.unref) this.sweepTimer.unref();
   }
 
   // Key-value operations
   async kvGet<T>(namespace: string, key: string): Promise<T | null> {
-    const row = this.stmts.kvGet.get(namespace, key, Date.now()) as { value: string } | undefined;
+    const now = Date.now();
+    const rows = this.db
+      .select({ value: kvStoreTable.value })
+      .from(kvStoreTable)
+      .where(
+        and(
+          eq(kvStoreTable.namespace, namespace),
+          eq(kvStoreTable.key, key),
+          or(isNull(kvStoreTable.expiresAt), gt(kvStoreTable.expiresAt, now))
+        )
+      )
+      .all();
+    const row = rows[0];
     return row ? JSON.parse(row.value) : null;
   }
 
   async kvSet<T>(namespace: string, key: string, value: T, ttlMs?: number): Promise<void> {
     const expiresAt = ttlMs ? Date.now() + ttlMs : null;
     const now = Date.now();
-    this.stmts.kvSet.run(namespace, key, JSON.stringify(value), expiresAt, now);
+    this.db
+      .insert(kvStoreTable)
+      .values({ namespace, key, value: JSON.stringify(value), expiresAt, createdAt: now, updatedAt: now })
+      .onConflictDoUpdate({
+        target: [kvStoreTable.namespace, kvStoreTable.key],
+        set: { value: JSON.stringify(value), expiresAt, updatedAt: now },
+      })
+      .run();
   }
 
   async kvDelete(namespace: string, key: string): Promise<void> {
-    this.stmts.kvDelete.run(namespace, key);
+    this.db
+      .delete(kvStoreTable)
+      .where(and(eq(kvStoreTable.namespace, namespace), eq(kvStoreTable.key, key)))
+      .run();
   }
 
   async kvDeleteAll(namespace: string): Promise<void> {
-    this.stmts.kvDeleteAll.run(namespace);
+    this.db.delete(kvStoreTable).where(eq(kvStoreTable.namespace, namespace)).run();
   }
 
   async kvList<T>(namespace: string): Promise<Array<{ key: string; value: T }>> {
-    const rows = this.stmts.kvList.all(namespace, Date.now()) as Array<{ key: string; value: string }>;
-    return rows.map(row => ({ key: row.key, value: JSON.parse(row.value) }));
+    const now = Date.now();
+    const rows = this.db
+      .select({ key: kvStoreTable.key, value: kvStoreTable.value })
+      .from(kvStoreTable)
+      .where(
+        and(
+          eq(kvStoreTable.namespace, namespace),
+          or(isNull(kvStoreTable.expiresAt), gt(kvStoreTable.expiresAt, now))
+        )
+      )
+      .all();
+    return rows.map((row) => ({ key: row.key, value: JSON.parse(row.value) }));
   }
 
   // Event operations
-  async eventAppend(stream: string, event: Omit<Event, 'id' | 'timestamp'>): Promise<Event> {
+  async eventAppend(stream: string, event: Omit<Event, "id" | "timestamp">): Promise<Event> {
     const id = randomUUID();
     const timestamp = Date.now();
-    
-    this.stmts.eventAppend.run(
-      id,
-      stream, 
-      event.type,
-      JSON.stringify(event.data),
-      event.metadata ? JSON.stringify(event.metadata) : null,
-      timestamp,
-      event.version,
-      stream // for the sequence subquery
-    );
-    
+
+    // Compute next sequence number and insert atomically using raw SQL subquery
+    const client = (this.db as any).$client;
+    client
+      .prepare(`
+        INSERT INTO events (id, stream, type, data, metadata, timestamp, version, sequence)
+        VALUES (?, ?, ?, ?, ?, ?, ?, (
+          SELECT COALESCE(MAX(sequence), 0) + 1 FROM events WHERE stream = ?
+        ))
+      `)
+      .run(
+        id,
+        stream,
+        event.type,
+        JSON.stringify(event.data),
+        event.metadata ? JSON.stringify(event.metadata) : null,
+        timestamp,
+        event.version,
+        stream
+      );
+
     return {
       id,
       timestamp,
@@ -190,24 +137,33 @@ export class SqliteBackend implements PersistenceBackend {
   }
 
   async *eventReplay(stream: string, query?: EventQuery): AsyncIterable<Event> {
-    const type = query?.type || null;
-    const from = query?.from || null;
-    const to = query?.to || null;
-    const limit = Math.min(query?.limit || 1000, 10000); // Cap at 10k for safety
-    const offset = query?.offset || 0;
-    
-    const rows = this.stmts.eventReplay.all(
-      stream, type, type, from, from, to, to, limit, offset
-    ) as Array<{
-      id: string;
-      stream: string;
-      type: string;
-      data: string;
-      metadata: string | null;
-      timestamp: number;
-      version: number;
-    }>;
-    
+    const type = query?.type ?? null;
+    const from = query?.from ?? null;
+    const to = query?.to ?? null;
+    const limit = Math.min(query?.limit ?? 1000, 10000);
+    const offset = query?.offset ?? 0;
+
+    const rows = (this.db as any).$client
+      .prepare(`
+        SELECT id, stream, type, data, metadata, timestamp, version, sequence
+        FROM events
+        WHERE stream = ?
+          AND (? IS NULL OR type = ?)
+          AND (? IS NULL OR timestamp >= ?)
+          AND (? IS NULL OR timestamp < ?)
+        ORDER BY sequence ASC
+        LIMIT ? OFFSET ?
+      `)
+      .all(stream, type, type, from, from, to, to, limit, offset) as Array<{
+        id: string;
+        stream: string;
+        type: string;
+        data: string;
+        metadata: string | null;
+        timestamp: number;
+        version: number;
+      }>;
+
     for (const row of rows) {
       yield {
         id: row.id,
@@ -221,34 +177,48 @@ export class SqliteBackend implements PersistenceBackend {
   }
 
   async eventGetSnapshot<T>(stream: string, type: string): Promise<T | null> {
-    const row = this.stmts.snapshotGet.get(stream, type) as { data: string } | undefined;
+    const rows = this.db
+      .select({ data: snapshotsTable.data })
+      .from(snapshotsTable)
+      .where(and(eq(snapshotsTable.stream, stream), eq(snapshotsTable.type, type)))
+      .all();
+    const row = rows[0];
     return row ? JSON.parse(row.data) : null;
   }
 
   async eventSaveSnapshot<T>(stream: string, type: string, data: T, eventId: string): Promise<void> {
     const now = Date.now();
-    this.stmts.snapshotSet.run(stream, type, JSON.stringify(data), eventId, now);
+    this.db
+      .insert(snapshotsTable)
+      .values({ stream, type, data: JSON.stringify(data), eventId, createdAt: now })
+      .onConflictDoUpdate({
+        target: [snapshotsTable.stream, snapshotsTable.type],
+        set: { data: JSON.stringify(data), eventId, createdAt: now },
+      })
+      .run();
   }
 
   async eventListStreams(): Promise<string[]> {
-    const rows = this.stmts.eventListStreams.all() as Array<{ stream: string }>;
-    return rows.map(row => row.stream);
+    const rows = (this.db as any).$client
+      .prepare("SELECT DISTINCT stream FROM events ORDER BY stream")
+      .all() as Array<{ stream: string }>;
+    return rows.map((row) => row.stream);
   }
 
-  // Query operations
+  // Query operations — allow arbitrary SQL strings
   async querySql<T>(query: string, params: any[] = []): Promise<T[]> {
     try {
-      const stmt = this.db.prepare(query);
+      const stmt = (this.db as any).$client.prepare(query);
       return stmt.all(...params) as T[];
     } catch (error) {
-      throw new Error(`SQL query failed: ${error instanceof Error ? error.message : 'unknown error'}`);
+      throw new Error(`SQL query failed: ${error instanceof Error ? error.message : "unknown error"}`);
     }
   }
 
   // Transaction operations
   async transactionBegin(): Promise<void> {
     if (this.transactionDepth === 0) {
-      this.db.exec("BEGIN");
+      (this.db as any).$client.exec("BEGIN");
     }
     this.transactionDepth++;
   }
@@ -256,14 +226,14 @@ export class SqliteBackend implements PersistenceBackend {
   async transactionCommit(): Promise<void> {
     this.transactionDepth--;
     if (this.transactionDepth === 0) {
-      this.db.exec("COMMIT");
+      (this.db as any).$client.exec("COMMIT");
     }
   }
 
   async transactionRollback(): Promise<void> {
     this.transactionDepth--;
     if (this.transactionDepth === 0) {
-      this.db.exec("ROLLBACK");
+      (this.db as any).$client.exec("ROLLBACK");
     }
   }
 
@@ -282,7 +252,9 @@ export class SqliteBackend implements PersistenceBackend {
   // Cleanup and maintenance
   private sweep(): void {
     const now = Date.now();
-    const result = this.stmts.sweep.run(now) as { changes: number };
+    const result = (this.db as any).$client
+      .prepare("DELETE FROM kv_store WHERE expires_at IS NOT NULL AND expires_at <= ?")
+      .run(now) as { changes: number };
     if (result.changes > 0) {
       console.debug(`Cleaned up ${result.changes} expired KV entries`);
     }
@@ -293,6 +265,8 @@ export class SqliteBackend implements PersistenceBackend {
       clearInterval(this.sweepTimer);
       this.sweepTimer = undefined;
     }
-    this.db.close();
+    if (this.ownDb) {
+      (this.db as any).$client.close();
+    }
   }
 }

--- a/packages/action-llama/src/shared/queue-sqlite.ts
+++ b/packages/action-llama/src/shared/queue-sqlite.ts
@@ -1,13 +1,15 @@
-import Database from "better-sqlite3";
-import { mkdirSync } from "fs";
-import { dirname } from "path";
+import { eq, and, asc } from "drizzle-orm";
 import { randomUUID } from "crypto";
+import { createDb } from "../db/connection.js";
+import { applyMigrations } from "../db/migrate.js";
+import { queueTable } from "../db/schema.js";
+import type { AppDb } from "../db/connection.js";
 import type { Queue, QueueItem } from "./queue.js";
 
 /**
- * SQLite-backed Queue.
+ * SQLite-backed Queue using Drizzle ORM.
  *
- * All queue instances sharing a file use a single `queue` table,
+ * All queue instances sharing a connection use a single `queue` table,
  * differentiated by a `name` column — the same pattern SqliteStateStore
  * uses for namespaces.
  *
@@ -17,12 +19,14 @@ import type { Queue, QueueItem } from "./queue.js";
  *
  * Dequeue is atomic: a transaction selects and deletes the head rows
  * so concurrent readers (if any) cannot claim the same items.
+ *
+ * Supports two constructor signatures:
+ *   new SqliteQueue(dbPath: string, name)  — creates its own connection (backward compat)
+ *   new SqliteQueue(db: AppDb, name)        — uses a shared connection (preferred)
  */
 export class SqliteQueue<T> implements Queue<T> {
-  private db: InstanceType<typeof Database>;
-  // better-sqlite3 generic Statement types don't compose with ReturnType<>;
-  // the public Queue interface provides the type safety boundary.
-  private stmts: any;
+  private db: AppDb;
+  private ownDb: boolean;
   private readonly name: string;
   private _dequeueTransaction: (name: string, limit: number) => Array<{
     id: string;
@@ -30,47 +34,28 @@ export class SqliteQueue<T> implements Queue<T> {
     enqueued_at: number;
   }>;
 
-  constructor(dbPath: string, name: string) {
+  constructor(dbOrPath: string | AppDb, name: string) {
     this.name = name;
-    mkdirSync(dirname(dbPath), { recursive: true });
-    this.db = new Database(dbPath);
-    this.db.pragma("journal_mode = WAL");
 
-    this.db.exec(`
-      CREATE TABLE IF NOT EXISTS queue (
-        id          TEXT NOT NULL,
-        name        TEXT NOT NULL,
-        payload     TEXT NOT NULL,
-        enqueued_at INTEGER NOT NULL,
-        PRIMARY KEY (name, id)
-      )
-    `);
-    this.db.exec(
-      "CREATE INDEX IF NOT EXISTS idx_queue_name ON queue(name)"
-    );
+    if (typeof dbOrPath === "string") {
+      this.db = createDb(dbOrPath);
+      this.ownDb = true;
+      applyMigrations(this.db);
+    } else {
+      this.db = dbOrPath;
+      this.ownDb = false;
+    }
 
-    // Prepare statements once for performance.
-    this.stmts = {
-      enqueue: this.db.prepare(
-        "INSERT INTO queue (id, name, payload, enqueued_at) VALUES (?, ?, ?, ?)"
-      ),
-      peek: this.db.prepare(
-        "SELECT id, payload, enqueued_at FROM queue WHERE name = ? ORDER BY rowid ASC LIMIT ?"
-      ),
-      delete: this.db.prepare("DELETE FROM queue WHERE name = ? AND id = ?"),
-      size: this.db.prepare("SELECT COUNT(*) AS n FROM queue WHERE name = ?"),
-    };
+    const client = (this.db as any).$client;
 
     // Pre-compiled transaction for atomic dequeue (select + delete in one shot).
-    this._dequeueTransaction = this.db.transaction(
-      (name: string, limit: number) => {
-        const rows = this.stmts.peek.all(name, limit) as Array<{
-          id: string;
-          payload: string;
-          enqueued_at: number;
-        }>;
+    this._dequeueTransaction = client.transaction(
+      (queueName: string, limit: number) => {
+        const rows = client
+          .prepare("SELECT id, payload, enqueued_at FROM queue WHERE name = ? ORDER BY rowid ASC LIMIT ?")
+          .all(queueName, limit) as Array<{ id: string; payload: string; enqueued_at: number }>;
         for (const row of rows) {
-          this.stmts.delete.run(name, row.id);
+          client.prepare("DELETE FROM queue WHERE name = ? AND id = ?").run(queueName, row.id);
         }
         return rows;
       }
@@ -79,7 +64,12 @@ export class SqliteQueue<T> implements Queue<T> {
 
   async enqueue(payload: T): Promise<string> {
     const id = randomUUID();
-    this.stmts.enqueue.run(id, this.name, JSON.stringify(payload), Date.now());
+    this.db.insert(queueTable).values({
+      id,
+      name: this.name,
+      payload: JSON.stringify(payload),
+      enqueuedAt: Date.now(),
+    }).run();
     return id;
   }
 
@@ -93,11 +83,9 @@ export class SqliteQueue<T> implements Queue<T> {
   }
 
   async peek(limit = 1): Promise<QueueItem<T>[]> {
-    const rows = this.stmts.peek.all(this.name, limit) as Array<{
-      id: string;
-      payload: string;
-      enqueued_at: number;
-    }>;
+    const rows = (this.db as any).$client
+      .prepare("SELECT id, payload, enqueued_at FROM queue WHERE name = ? ORDER BY rowid ASC LIMIT ?")
+      .all(this.name, limit) as Array<{ id: string; payload: string; enqueued_at: number }>;
     return rows.map((r) => ({
       id: r.id,
       payload: JSON.parse(r.payload) as T,
@@ -106,11 +94,15 @@ export class SqliteQueue<T> implements Queue<T> {
   }
 
   async size(): Promise<number> {
-    const row = this.stmts.size.get(this.name) as { n: number };
+    const row = (this.db as any).$client
+      .prepare("SELECT COUNT(*) AS n FROM queue WHERE name = ?")
+      .get(this.name) as { n: number };
     return row.n;
   }
 
   async close(): Promise<void> {
-    this.db.close();
+    if (this.ownDb) {
+      (this.db as any).$client.close();
+    }
   }
 }

--- a/packages/action-llama/src/shared/state-store-sqlite.ts
+++ b/packages/action-llama/src/shared/state-store-sqlite.ts
@@ -1,57 +1,35 @@
-import Database from "better-sqlite3";
-import { mkdirSync } from "fs";
-import { dirname } from "path";
+import { eq, and, or, isNull, gt, lte, isNotNull } from "drizzle-orm";
+import { createDb } from "../db/connection.js";
+import { applyMigrations } from "../db/migrate.js";
+import { stateTable } from "../db/schema.js";
+import type { AppDb } from "../db/connection.js";
 import type { StateStore } from "./state-store.js";
 
 /**
  * SQLite-backed StateStore for local mode.
  *
- * Uses better-sqlite3 for fast, synchronous, embedded storage.
+ * Uses Drizzle ORM with better-sqlite3 for fast, synchronous, embedded storage.
  * The async interface is preserved for API compatibility with the
  * DynamoDB backend — all operations resolve immediately.
+ *
+ * Supports two constructor signatures:
+ *   new SqliteStateStore(dbPath: string)   — creates its own connection (backward compat)
+ *   new SqliteStateStore(db: AppDb)        — uses a shared connection (preferred)
  */
 export class SqliteStateStore implements StateStore {
-  private db: InstanceType<typeof Database>;
-  // better-sqlite3 generic Statement types don't compose with ReturnType<>;
-  // the public StateStore interface provides the type safety boundary.
-  private stmts: any;
+  private db: AppDb;
+  private ownDb: boolean;
   private sweepTimer: ReturnType<typeof setInterval> | undefined;
 
-  constructor(dbPath: string) {
-    mkdirSync(dirname(dbPath), { recursive: true });
-    this.db = new Database(dbPath);
-    this.db.pragma("journal_mode = WAL");
-
-    this.db.exec(`
-      CREATE TABLE IF NOT EXISTS state (
-        ns    TEXT NOT NULL,
-        key   TEXT NOT NULL,
-        value TEXT NOT NULL,
-        expires_at INTEGER,
-        PRIMARY KEY (ns, key)
-      )
-    `);
-    this.db.exec(
-      "CREATE INDEX IF NOT EXISTS idx_state_expires ON state(expires_at) WHERE expires_at IS NOT NULL"
-    );
-
-    // Prepare statements once for performance.
-    this.stmts = {
-      get: this.db.prepare(
-        "SELECT value FROM state WHERE ns = ? AND key = ? AND (expires_at IS NULL OR expires_at > ?)"
-      ),
-      set: this.db.prepare(
-        "INSERT OR REPLACE INTO state (ns, key, value, expires_at) VALUES (?, ?, ?, ?)"
-      ),
-      del: this.db.prepare("DELETE FROM state WHERE ns = ? AND key = ?"),
-      delAll: this.db.prepare("DELETE FROM state WHERE ns = ?"),
-      list: this.db.prepare(
-        "SELECT key, value FROM state WHERE ns = ? AND (expires_at IS NULL OR expires_at > ?)"
-      ),
-      sweep: this.db.prepare(
-        "DELETE FROM state WHERE expires_at IS NOT NULL AND expires_at <= ?"
-      ),
-    };
+  constructor(dbOrPath: string | AppDb) {
+    if (typeof dbOrPath === "string") {
+      this.db = createDb(dbOrPath);
+      this.ownDb = true;
+      applyMigrations(this.db);
+    } else {
+      this.db = dbOrPath;
+      this.ownDb = false;
+    }
 
     // Periodic sweep of expired rows (every 60 s).
     this.sweepTimer = setInterval(() => this.sweep(), 60_000);
@@ -59,31 +37,68 @@ export class SqliteStateStore implements StateStore {
   }
 
   async get<T>(ns: string, key: string): Promise<T | null> {
-    const row = this.stmts.get.get(ns, key, nowSec()) as { value: string } | undefined;
+    const now = nowSec();
+    const rows = this.db
+      .select({ value: stateTable.value })
+      .from(stateTable)
+      .where(
+        and(
+          eq(stateTable.ns, ns),
+          eq(stateTable.key, key),
+          or(isNull(stateTable.expiresAt), gt(stateTable.expiresAt, now))
+        )
+      )
+      .all();
+    const row = rows[0];
     return row ? (JSON.parse(row.value) as T) : null;
   }
 
   async set<T>(ns: string, key: string, value: T, opts?: { ttl?: number }): Promise<void> {
     const expiresAt = opts?.ttl ? nowSec() + opts.ttl : null;
-    this.stmts.set.run(ns, key, JSON.stringify(value), expiresAt);
+    this.db
+      .insert(stateTable)
+      .values({ ns, key, value: JSON.stringify(value), expiresAt })
+      .onConflictDoUpdate({
+        target: [stateTable.ns, stateTable.key],
+        set: { value: JSON.stringify(value), expiresAt },
+      })
+      .run();
   }
 
   async delete(ns: string, key: string): Promise<void> {
-    this.stmts.del.run(ns, key);
+    this.db
+      .delete(stateTable)
+      .where(and(eq(stateTable.ns, ns), eq(stateTable.key, key)))
+      .run();
   }
 
   async deleteAll(ns: string): Promise<void> {
-    this.stmts.delAll.run(ns);
+    this.db.delete(stateTable).where(eq(stateTable.ns, ns)).run();
   }
 
   async list<T>(ns: string): Promise<Array<{ key: string; value: T }>> {
-    const rows = this.stmts.list.all(ns, nowSec()) as Array<{ key: string; value: string }>;
+    const now = nowSec();
+    const rows = this.db
+      .select({ key: stateTable.key, value: stateTable.value })
+      .from(stateTable)
+      .where(
+        and(
+          eq(stateTable.ns, ns),
+          or(isNull(stateTable.expiresAt), gt(stateTable.expiresAt, now))
+        )
+      )
+      .all();
     return rows.map((r) => ({ key: r.key, value: JSON.parse(r.value) as T }));
   }
 
   /** Remove expired rows. Returns the number of rows deleted. */
   sweep(): number {
-    return (this.stmts.sweep.run(nowSec()) as { changes: number }).changes;
+    const now = nowSec();
+    const result = this.db
+      .delete(stateTable)
+      .where(and(isNotNull(stateTable.expiresAt), lte(stateTable.expiresAt, now)))
+      .run();
+    return result.changes;
   }
 
   async close(): Promise<void> {
@@ -91,7 +106,9 @@ export class SqliteStateStore implements StateStore {
       clearInterval(this.sweepTimer);
       this.sweepTimer = undefined;
     }
-    this.db.close();
+    if (this.ownDb) {
+      (this.db as any).$client.close();
+    }
   }
 }
 

--- a/packages/action-llama/src/stats/store.ts
+++ b/packages/action-llama/src/stats/store.ts
@@ -1,6 +1,8 @@
-import Database from "better-sqlite3";
-import { mkdirSync } from "fs";
-import { dirname } from "path";
+import { eq, and, gt, lt, desc, sql, asc } from "drizzle-orm";
+import { createDb } from "../db/connection.js";
+import { applyMigrations } from "../db/migrate.js";
+import { runsTable, webhookReceiptsTable, callEdgesTable } from "../db/schema.js";
+import type { AppDb } from "../db/connection.js";
 
 export interface RunRecord {
   instanceId: string;
@@ -85,282 +87,30 @@ export interface CallEdgeSummary {
   avgDurationMs: number | null;
 }
 
+/**
+ * SQLite-backed StatsStore using Drizzle ORM.
+ *
+ * Supports two constructor signatures:
+ *   new StatsStore(dbPath: string)  — creates its own connection (backward compat)
+ *   new StatsStore(db: AppDb)       — uses a shared connection (preferred)
+ */
 export class StatsStore {
-  private db: InstanceType<typeof Database>;
-  private stmts: any;
+  private db: AppDb;
+  private ownDb: boolean;
 
-  constructor(dbPath: string) {
-    mkdirSync(dirname(dbPath), { recursive: true });
-    this.db = new Database(dbPath);
-    this.db.pragma("journal_mode = WAL");
-
-    this.db.exec(`
-      CREATE TABLE IF NOT EXISTS runs (
-        id                 INTEGER PRIMARY KEY AUTOINCREMENT,
-        instance_id        TEXT NOT NULL,
-        agent_name         TEXT NOT NULL,
-        trigger_type       TEXT NOT NULL,
-        trigger_source     TEXT,
-        result             TEXT NOT NULL,
-        exit_code          INTEGER,
-        started_at         INTEGER NOT NULL,
-        duration_ms        INTEGER NOT NULL,
-        input_tokens       INTEGER NOT NULL DEFAULT 0,
-        output_tokens      INTEGER NOT NULL DEFAULT 0,
-        cache_read_tokens  INTEGER NOT NULL DEFAULT 0,
-        cache_write_tokens INTEGER NOT NULL DEFAULT 0,
-        total_tokens       INTEGER NOT NULL DEFAULT 0,
-        cost_usd           REAL NOT NULL DEFAULT 0,
-        turn_count         INTEGER NOT NULL DEFAULT 0,
-        error_message      TEXT,
-        pre_hook_ms        INTEGER,
-        post_hook_ms       INTEGER
-      )
-    `);
-
-    this.db.exec(`
-      CREATE TABLE IF NOT EXISTS webhook_receipts (
-        id                 TEXT PRIMARY KEY,
-        delivery_id        TEXT,
-        source             TEXT NOT NULL,
-        event_summary      TEXT,
-        timestamp          INTEGER NOT NULL,
-        headers            TEXT,
-        body               TEXT,
-        matched_agents     INTEGER NOT NULL DEFAULT 0,
-        status             TEXT NOT NULL,
-        dead_letter_reason TEXT
-      )
-    `);
-
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_wr_timestamp ON webhook_receipts(timestamp)");
-    this.db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_wr_delivery ON webhook_receipts(delivery_id) WHERE delivery_id IS NOT NULL");
-
-    // Migrate: add webhook_receipt_id column to runs if missing
-    const runsColumns = this.db.pragma("table_info(runs)") as { name: string }[];
-    if (!runsColumns.some(c => c.name === "webhook_receipt_id")) {
-      this.db.exec("ALTER TABLE runs ADD COLUMN webhook_receipt_id TEXT");
+  constructor(dbOrPath: string | AppDb) {
+    if (typeof dbOrPath === "string") {
+      this.db = createDb(dbOrPath);
+      this.ownDb = true;
+      applyMigrations(this.db);
+    } else {
+      this.db = dbOrPath;
+      this.ownDb = false;
     }
-
-    this.db.exec(`
-      CREATE TABLE IF NOT EXISTS call_edges (
-        id               INTEGER PRIMARY KEY AUTOINCREMENT,
-        caller_agent     TEXT NOT NULL,
-        caller_instance  TEXT NOT NULL,
-        target_agent     TEXT NOT NULL,
-        target_instance  TEXT,
-        depth            INTEGER NOT NULL DEFAULT 0,
-        started_at       INTEGER NOT NULL,
-        duration_ms      INTEGER,
-        status           TEXT NOT NULL DEFAULT 'pending'
-      )
-    `);
-
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_runs_agent ON runs(agent_name, started_at)");
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_runs_started ON runs(started_at)");
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_calls_caller ON call_edges(caller_agent, started_at)");
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_calls_target ON call_edges(target_agent, started_at)");
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_calls_target_instance ON call_edges(target_instance)");
-
-    this.stmts = {
-      insertRun: this.db.prepare(`
-        INSERT INTO runs (
-          instance_id, agent_name, trigger_type, trigger_source, result, exit_code,
-          started_at, duration_ms, input_tokens, output_tokens, cache_read_tokens,
-          cache_write_tokens, total_tokens, cost_usd, turn_count, error_message,
-          pre_hook_ms, post_hook_ms, webhook_receipt_id
-        ) VALUES (
-          @instanceId, @agentName, @triggerType, @triggerSource, @result, @exitCode,
-          @startedAt, @durationMs, @inputTokens, @outputTokens, @cacheReadTokens,
-          @cacheWriteTokens, @totalTokens, @costUsd, @turnCount, @errorMessage,
-          @preHookMs, @postHookMs, @webhookReceiptId
-        )
-      `),
-      insertCallEdge: this.db.prepare(`
-        INSERT INTO call_edges (
-          caller_agent, caller_instance, target_agent, target_instance, depth, started_at, duration_ms, status
-        ) VALUES (
-          @callerAgent, @callerInstance, @targetAgent, @targetInstance, @depth, @startedAt, @durationMs, @status
-        )
-      `),
-      updateCallEdge: this.db.prepare(`
-        UPDATE call_edges SET duration_ms = @durationMs, status = @status, target_instance = COALESCE(@targetInstance, target_instance) WHERE id = @id
-      `),
-      queryRuns: this.db.prepare(`
-        SELECT * FROM runs WHERE started_at >= @since ORDER BY started_at DESC LIMIT @limit
-      `),
-      queryRunsByAgent: this.db.prepare(`
-        SELECT * FROM runs WHERE agent_name = @agent AND started_at >= @since ORDER BY started_at DESC LIMIT @limit
-      `),
-      agentSummary: this.db.prepare(`
-        SELECT
-          agent_name as agentName,
-          COUNT(*) as totalRuns,
-          SUM(CASE WHEN result IN ('completed', 'rerun') THEN 1 ELSE 0 END) as okRuns,
-          SUM(CASE WHEN result = 'error' THEN 1 ELSE 0 END) as errorRuns,
-          AVG(duration_ms) as avgDurationMs,
-          SUM(total_tokens) as totalTokens,
-          SUM(cost_usd) as totalCost,
-          AVG(pre_hook_ms) as avgPreHookMs,
-          AVG(post_hook_ms) as avgPostHookMs
-        FROM runs
-        WHERE started_at >= @since
-        GROUP BY agent_name
-        ORDER BY totalRuns DESC
-      `),
-      agentSummaryByName: this.db.prepare(`
-        SELECT
-          agent_name as agentName,
-          COUNT(*) as totalRuns,
-          SUM(CASE WHEN result IN ('completed', 'rerun') THEN 1 ELSE 0 END) as okRuns,
-          SUM(CASE WHEN result = 'error' THEN 1 ELSE 0 END) as errorRuns,
-          AVG(duration_ms) as avgDurationMs,
-          SUM(total_tokens) as totalTokens,
-          SUM(cost_usd) as totalCost,
-          AVG(pre_hook_ms) as avgPreHookMs,
-          AVG(post_hook_ms) as avgPostHookMs
-        FROM runs
-        WHERE agent_name = @agent AND started_at >= @since
-        GROUP BY agent_name
-      `),
-      callGraph: this.db.prepare(`
-        SELECT
-          caller_agent as callerAgent,
-          target_agent as targetAgent,
-          COUNT(*) as count,
-          AVG(depth) as avgDepth,
-          AVG(duration_ms) as avgDurationMs
-        FROM call_edges
-        WHERE started_at >= @since
-        GROUP BY caller_agent, target_agent
-        ORDER BY count DESC
-      `),
-      queryRunsByAgentPaginated: this.db.prepare(`
-        SELECT * FROM runs WHERE agent_name = @agent ORDER BY started_at DESC LIMIT @limit OFFSET @offset
-      `),
-      countRunsByAgent: this.db.prepare(`
-        SELECT COUNT(*) as count FROM runs WHERE agent_name = @agent
-      `),
-      queryRunByInstanceId: this.db.prepare(`
-        SELECT * FROM runs WHERE instance_id = @instanceId LIMIT 1
-      `),
-      insertReceipt: this.db.prepare(`
-        INSERT INTO webhook_receipts (
-          id, delivery_id, source, event_summary, timestamp, headers, body,
-          matched_agents, status, dead_letter_reason
-        ) VALUES (
-          @id, @deliveryId, @source, @eventSummary, @timestamp, @headers, @body,
-          @matchedAgents, @status, @deadLetterReason
-        )
-      `),
-      findReceiptByDeliveryId: this.db.prepare(
-        "SELECT * FROM webhook_receipts WHERE delivery_id = @deliveryId LIMIT 1"
-      ),
-      getReceipt: this.db.prepare(
-        "SELECT * FROM webhook_receipts WHERE id = @id LIMIT 1"
-      ),
-      updateReceiptStatus: this.db.prepare(
-        "UPDATE webhook_receipts SET matched_agents = @matchedAgents, status = @status, dead_letter_reason = @deadLetterReason WHERE id = @id"
-      ),
-      queryTriggerHistory: this.db.prepare(`
-        SELECT started_at AS ts, instance_id AS instanceId, agent_name AS agentName,
-               trigger_type AS triggerType, trigger_source AS triggerSource,
-               result, webhook_receipt_id AS webhookReceiptId,
-               NULL AS deadLetterReason
-        FROM runs WHERE started_at > @since
-        UNION ALL
-        SELECT timestamp AS ts, NULL AS instanceId, NULL AS agentName,
-               'webhook' AS triggerType, source AS triggerSource,
-               'dead-letter' AS result, id AS webhookReceiptId,
-               dead_letter_reason AS deadLetterReason
-        FROM webhook_receipts WHERE status = 'dead-letter' AND timestamp > @since
-        ORDER BY ts DESC LIMIT @limit OFFSET @offset
-      `),
-      queryTriggerHistoryNoDeadLetters: this.db.prepare(`
-        SELECT started_at AS ts, instance_id AS instanceId, agent_name AS agentName,
-               trigger_type AS triggerType, trigger_source AS triggerSource,
-               result, webhook_receipt_id AS webhookReceiptId,
-               NULL AS deadLetterReason
-        FROM runs WHERE started_at > @since
-        ORDER BY ts DESC LIMIT @limit OFFSET @offset
-      `),
-      countTriggerHistory: this.db.prepare(
-        "SELECT (SELECT COUNT(*) FROM runs WHERE started_at > @since) + (SELECT COUNT(*) FROM webhook_receipts WHERE status = 'dead-letter' AND timestamp > @since) AS count"
-      ),
-      countTriggerHistoryNoDeadLetters: this.db.prepare(
-        "SELECT COUNT(*) AS count FROM runs WHERE started_at > @since"
-      ),
-      queryTriggerHistoryByAgent: this.db.prepare(`
-        SELECT started_at AS ts, instance_id AS instanceId, agent_name AS agentName,
-               trigger_type AS triggerType, trigger_source AS triggerSource,
-               result, webhook_receipt_id AS webhookReceiptId,
-               NULL AS deadLetterReason
-        FROM runs WHERE started_at > @since AND agent_name = @agentName
-        ORDER BY ts DESC LIMIT @limit OFFSET @offset
-      `),
-      countTriggerHistoryByAgent: this.db.prepare(
-        "SELECT COUNT(*) AS count FROM runs WHERE started_at > @since AND agent_name = @agentName"
-      ),
-      queryTriggerHistoryByType: this.db.prepare(`
-        SELECT started_at AS ts, instance_id AS instanceId, agent_name AS agentName,
-               trigger_type AS triggerType, trigger_source AS triggerSource,
-               result, webhook_receipt_id AS webhookReceiptId,
-               NULL AS deadLetterReason
-        FROM runs WHERE started_at > @since AND trigger_type = @triggerType
-        ORDER BY ts DESC LIMIT @limit OFFSET @offset
-      `),
-      queryTriggerHistoryByTypeWithDeadLetters: this.db.prepare(`
-        SELECT started_at AS ts, instance_id AS instanceId, agent_name AS agentName,
-               trigger_type AS triggerType, trigger_source AS triggerSource,
-               result, webhook_receipt_id AS webhookReceiptId,
-               NULL AS deadLetterReason
-        FROM runs WHERE started_at > @since AND trigger_type = @triggerType
-        UNION ALL
-        SELECT timestamp AS ts, NULL AS instanceId, NULL AS agentName,
-               'webhook' AS triggerType, source AS triggerSource,
-               'dead-letter' AS result, id AS webhookReceiptId,
-               dead_letter_reason AS deadLetterReason
-        FROM webhook_receipts WHERE status = 'dead-letter' AND timestamp > @since
-        ORDER BY ts DESC LIMIT @limit OFFSET @offset
-      `),
-      queryTriggerHistoryByAgentAndType: this.db.prepare(`
-        SELECT started_at AS ts, instance_id AS instanceId, agent_name AS agentName,
-               trigger_type AS triggerType, trigger_source AS triggerSource,
-               result, webhook_receipt_id AS webhookReceiptId,
-               NULL AS deadLetterReason
-        FROM runs WHERE started_at > @since AND agent_name = @agentName AND trigger_type = @triggerType
-        ORDER BY ts DESC LIMIT @limit OFFSET @offset
-      `),
-      countTriggerHistoryByType: this.db.prepare(
-        "SELECT COUNT(*) AS count FROM runs WHERE started_at > @since AND trigger_type = @triggerType"
-      ),
-      countTriggerHistoryByTypeWithDeadLetters: this.db.prepare(
-        "SELECT (SELECT COUNT(*) FROM runs WHERE started_at > @since AND trigger_type = @triggerType) + (SELECT COUNT(*) FROM webhook_receipts WHERE status = 'dead-letter' AND timestamp > @since) AS count"
-      ),
-      countTriggerHistoryByAgentAndType: this.db.prepare(
-        "SELECT COUNT(*) AS count FROM runs WHERE started_at > @since AND agent_name = @agentName AND trigger_type = @triggerType"
-      ),
-      pruneRuns: this.db.prepare("DELETE FROM runs WHERE started_at < @threshold"),
-      pruneCallEdges: this.db.prepare("DELETE FROM call_edges WHERE started_at < @threshold"),
-      queryCallEdgeByTarget: this.db.prepare(
-        "SELECT * FROM call_edges WHERE target_instance = @targetInstance LIMIT 1"
-      ),
-      pruneReceipts: this.db.prepare("DELETE FROM webhook_receipts WHERE timestamp < @threshold"),
-      globalSummary: this.db.prepare(`
-        SELECT
-          COUNT(*) as totalRuns,
-          SUM(CASE WHEN result IN ('completed', 'rerun') THEN 1 ELSE 0 END) as okRuns,
-          SUM(CASE WHEN result = 'error' THEN 1 ELSE 0 END) as errorRuns,
-          SUM(total_tokens) as totalTokens,
-          SUM(cost_usd) as totalCost
-        FROM runs
-        WHERE started_at >= @since
-      `),
-    };
   }
 
   recordRun(run: RunRecord): void {
-    this.stmts.insertRun.run({
+    this.db.insert(runsTable).values({
       instanceId: run.instanceId,
       agentName: run.agentName,
       triggerType: run.triggerType,
@@ -380,11 +130,11 @@ export class StatsStore {
       preHookMs: run.preHookMs ?? null,
       postHookMs: run.postHookMs ?? null,
       webhookReceiptId: run.webhookReceiptId ?? null,
-    });
+    }).run();
   }
 
   recordCallEdge(edge: CallEdgeRecord): number {
-    const result = this.stmts.insertCallEdge.run({
+    const result = this.db.insert(callEdgesTable).values({
       callerAgent: edge.callerAgent,
       callerInstance: edge.callerInstance,
       targetAgent: edge.targetAgent,
@@ -393,55 +143,110 @@ export class StatsStore {
       startedAt: edge.startedAt,
       durationMs: edge.durationMs ?? null,
       status: edge.status ?? "pending",
-    });
+    }).run();
     return Number(result.lastInsertRowid);
   }
 
   updateCallEdge(id: number, updates: { durationMs?: number; status?: string; targetInstance?: string }): void {
-    this.stmts.updateCallEdge.run({
-      id,
-      durationMs: updates.durationMs ?? null,
-      status: updates.status ?? null,
-      targetInstance: updates.targetInstance ?? null,
-    });
+    this.db.update(callEdgesTable)
+      .set({
+        durationMs: updates.durationMs ?? undefined,
+        status: updates.status ?? undefined,
+        targetInstance: updates.targetInstance
+          ? updates.targetInstance
+          : undefined,
+      })
+      .where(eq(callEdgesTable.id, id))
+      .run();
   }
 
   queryRunsByAgentPaginated(agent: string, limit: number, offset: number): any[] {
-    return this.stmts.queryRunsByAgentPaginated.all({ agent, limit, offset });
+    return (this.db as any).$client
+      .prepare("SELECT * FROM runs WHERE agent_name = ? ORDER BY started_at DESC LIMIT ? OFFSET ?")
+      .all(agent, limit, offset);
   }
 
   countRunsByAgent(agent: string): number {
-    const row = this.stmts.countRunsByAgent.get({ agent }) as any;
+    const row = (this.db as any).$client
+      .prepare("SELECT COUNT(*) as count FROM runs WHERE agent_name = ?")
+      .get(agent) as any;
     return row?.count ?? 0;
   }
 
   queryRunByInstanceId(instanceId: string): any | undefined {
-    return this.stmts.queryRunByInstanceId.get({ instanceId });
+    return (this.db as any).$client
+      .prepare("SELECT * FROM runs WHERE instance_id = ? LIMIT 1")
+      .get(instanceId) as any;
   }
 
   queryCallEdgeByTargetInstance(targetInstance: string): { caller_agent: string; caller_instance: string; target_agent: string; target_instance: string; depth: number; started_at: number; duration_ms: number | null; status: string } | undefined {
-    return this.stmts.queryCallEdgeByTarget.get({ targetInstance }) as any;
+    return (this.db as any).$client
+      .prepare("SELECT * FROM call_edges WHERE target_instance = ? LIMIT 1")
+      .get(targetInstance) as any;
   }
 
   queryRuns(query: RunQuery = {}): any[] {
     const since = query.since ?? 0;
     const limit = query.limit ?? 100;
     if (query.agent) {
-      return this.stmts.queryRunsByAgent.all({ agent: query.agent, since, limit });
+      return (this.db as any).$client
+        .prepare("SELECT * FROM runs WHERE agent_name = ? AND started_at >= ? ORDER BY started_at DESC LIMIT ?")
+        .all(query.agent, since, limit);
     }
-    return this.stmts.queryRuns.all({ since, limit });
+    return (this.db as any).$client
+      .prepare("SELECT * FROM runs WHERE started_at >= ? ORDER BY started_at DESC LIMIT ?")
+      .all(since, limit);
   }
 
   queryAgentSummary(query: { agent?: string; since?: number } = {}): AgentSummary[] {
     const since = query.since ?? 0;
+    const client = (this.db as any).$client;
     if (query.agent) {
-      return this.stmts.agentSummaryByName.all({ agent: query.agent, since }) as AgentSummary[];
+      return client.prepare(`
+        SELECT
+          agent_name as agentName,
+          COUNT(*) as totalRuns,
+          SUM(CASE WHEN result IN ('completed', 'rerun') THEN 1 ELSE 0 END) as okRuns,
+          SUM(CASE WHEN result = 'error' THEN 1 ELSE 0 END) as errorRuns,
+          AVG(duration_ms) as avgDurationMs,
+          SUM(total_tokens) as totalTokens,
+          SUM(cost_usd) as totalCost,
+          AVG(pre_hook_ms) as avgPreHookMs,
+          AVG(post_hook_ms) as avgPostHookMs
+        FROM runs
+        WHERE agent_name = ? AND started_at >= ?
+        GROUP BY agent_name
+      `).all(query.agent, since) as AgentSummary[];
     }
-    return this.stmts.agentSummary.all({ since }) as AgentSummary[];
+    return client.prepare(`
+      SELECT
+        agent_name as agentName,
+        COUNT(*) as totalRuns,
+        SUM(CASE WHEN result IN ('completed', 'rerun') THEN 1 ELSE 0 END) as okRuns,
+        SUM(CASE WHEN result = 'error' THEN 1 ELSE 0 END) as errorRuns,
+        AVG(duration_ms) as avgDurationMs,
+        SUM(total_tokens) as totalTokens,
+        SUM(cost_usd) as totalCost,
+        AVG(pre_hook_ms) as avgPreHookMs,
+        AVG(post_hook_ms) as avgPostHookMs
+      FROM runs
+      WHERE started_at >= ?
+      GROUP BY agent_name
+      ORDER BY totalRuns DESC
+    `).all(since) as AgentSummary[];
   }
 
   queryGlobalSummary(since: number = 0): { totalRuns: number; okRuns: number; errorRuns: number; totalTokens: number; totalCost: number } {
-    const row = this.stmts.globalSummary.get({ since }) as any;
+    const row = (this.db as any).$client.prepare(`
+      SELECT
+        COUNT(*) as totalRuns,
+        SUM(CASE WHEN result IN ('completed', 'rerun') THEN 1 ELSE 0 END) as okRuns,
+        SUM(CASE WHEN result = 'error' THEN 1 ELSE 0 END) as errorRuns,
+        SUM(total_tokens) as totalTokens,
+        SUM(cost_usd) as totalCost
+      FROM runs
+      WHERE started_at >= ?
+    `).get(since) as any;
     return {
       totalRuns: row.totalRuns ?? 0,
       okRuns: row.okRuns ?? 0,
@@ -453,11 +258,22 @@ export class StatsStore {
 
   queryCallGraph(query: { since?: number } = {}): CallEdgeSummary[] {
     const since = query.since ?? 0;
-    return this.stmts.callGraph.all({ since }) as CallEdgeSummary[];
+    return (this.db as any).$client.prepare(`
+      SELECT
+        caller_agent as callerAgent,
+        target_agent as targetAgent,
+        COUNT(*) as count,
+        AVG(depth) as avgDepth,
+        AVG(duration_ms) as avgDurationMs
+      FROM call_edges
+      WHERE started_at >= ?
+      GROUP BY caller_agent, target_agent
+      ORDER BY count DESC
+    `).all(since) as CallEdgeSummary[];
   }
 
   recordWebhookReceipt(receipt: WebhookReceipt): void {
-    this.stmts.insertReceipt.run({
+    this.db.insert(webhookReceiptsTable).values({
       id: receipt.id,
       deliveryId: receipt.deliveryId ?? null,
       source: receipt.source,
@@ -468,66 +284,129 @@ export class StatsStore {
       matchedAgents: receipt.matchedAgents,
       status: receipt.status,
       deadLetterReason: receipt.deadLetterReason ?? null,
-    });
+    }).run();
   }
 
   updateWebhookReceiptStatus(id: string, matchedAgents: number, status: "processed" | "dead-letter", deadLetterReason?: string): void {
-    this.stmts.updateReceiptStatus.run({
-      id,
-      matchedAgents,
-      status,
-      deadLetterReason: deadLetterReason ?? null,
-    });
+    this.db.update(webhookReceiptsTable)
+      .set({ matchedAgents, status, deadLetterReason: deadLetterReason ?? null })
+      .where(eq(webhookReceiptsTable.id, id))
+      .run();
   }
 
   findWebhookReceiptByDeliveryId(deliveryId: string): WebhookReceipt | undefined {
-    const row = this.stmts.findReceiptByDeliveryId.get({ deliveryId }) as any;
+    const row = (this.db as any).$client
+      .prepare("SELECT * FROM webhook_receipts WHERE delivery_id = ? LIMIT 1")
+      .get(deliveryId) as any;
     return row ? this.mapReceipt(row) : undefined;
   }
 
   getWebhookReceipt(id: string): WebhookReceipt | undefined {
-    const row = this.stmts.getReceipt.get({ id }) as any;
+    const row = (this.db as any).$client
+      .prepare("SELECT * FROM webhook_receipts WHERE id = ? LIMIT 1")
+      .get(id) as any;
     return row ? this.mapReceipt(row) : undefined;
   }
 
   queryTriggerHistory(opts: { since: number; limit: number; offset: number; includeDeadLetters: boolean; agentName?: string; triggerType?: string }): TriggerHistoryRow[] {
     const { since, limit, offset, includeDeadLetters, agentName, triggerType } = opts;
+    const client = (this.db as any).$client;
+
     if (agentName && triggerType) {
-      return this.stmts.queryTriggerHistoryByAgentAndType.all({ since, limit, offset, agentName, triggerType }) as TriggerHistoryRow[];
+      return client.prepare(`
+        SELECT started_at AS ts, instance_id AS instanceId, agent_name AS agentName,
+               trigger_type AS triggerType, trigger_source AS triggerSource,
+               result, webhook_receipt_id AS webhookReceiptId,
+               NULL AS deadLetterReason
+        FROM runs WHERE started_at > ? AND agent_name = ? AND trigger_type = ?
+        ORDER BY ts DESC LIMIT ? OFFSET ?
+      `).all(since, agentName, triggerType, limit, offset) as TriggerHistoryRow[];
     }
     if (agentName) {
-      return this.stmts.queryTriggerHistoryByAgent.all({ since, limit, offset, agentName }) as TriggerHistoryRow[];
+      return client.prepare(`
+        SELECT started_at AS ts, instance_id AS instanceId, agent_name AS agentName,
+               trigger_type AS triggerType, trigger_source AS triggerSource,
+               result, webhook_receipt_id AS webhookReceiptId,
+               NULL AS deadLetterReason
+        FROM runs WHERE started_at > ? AND agent_name = ?
+        ORDER BY ts DESC LIMIT ? OFFSET ?
+      `).all(since, agentName, limit, offset) as TriggerHistoryRow[];
     }
     if (triggerType) {
-      // For non-webhook types, dead letters are always webhook so we can skip them unless filtering for webhook
       if (includeDeadLetters && triggerType === "webhook") {
-        return this.stmts.queryTriggerHistoryByTypeWithDeadLetters.all({ since, limit, offset, triggerType }) as TriggerHistoryRow[];
+        return client.prepare(`
+          SELECT started_at AS ts, instance_id AS instanceId, agent_name AS agentName,
+                 trigger_type AS triggerType, trigger_source AS triggerSource,
+                 result, webhook_receipt_id AS webhookReceiptId,
+                 NULL AS deadLetterReason
+          FROM runs WHERE started_at > ? AND trigger_type = ?
+          UNION ALL
+          SELECT timestamp AS ts, NULL AS instanceId, NULL AS agentName,
+                 'webhook' AS triggerType, source AS triggerSource,
+                 'dead-letter' AS result, id AS webhookReceiptId,
+                 dead_letter_reason AS deadLetterReason
+          FROM webhook_receipts WHERE status = 'dead-letter' AND timestamp > ?
+          ORDER BY ts DESC LIMIT ? OFFSET ?
+        `).all(since, triggerType, since, limit, offset) as TriggerHistoryRow[];
       }
-      return this.stmts.queryTriggerHistoryByType.all({ since, limit, offset, triggerType }) as TriggerHistoryRow[];
+      return client.prepare(`
+        SELECT started_at AS ts, instance_id AS instanceId, agent_name AS agentName,
+               trigger_type AS triggerType, trigger_source AS triggerSource,
+               result, webhook_receipt_id AS webhookReceiptId,
+               NULL AS deadLetterReason
+        FROM runs WHERE started_at > ? AND trigger_type = ?
+        ORDER BY ts DESC LIMIT ? OFFSET ?
+      `).all(since, triggerType, limit, offset) as TriggerHistoryRow[];
     }
-    const stmt = includeDeadLetters ? this.stmts.queryTriggerHistory : this.stmts.queryTriggerHistoryNoDeadLetters;
-    return stmt.all({ since, limit, offset }) as TriggerHistoryRow[];
+    if (includeDeadLetters) {
+      return client.prepare(`
+        SELECT started_at AS ts, instance_id AS instanceId, agent_name AS agentName,
+               trigger_type AS triggerType, trigger_source AS triggerSource,
+               result, webhook_receipt_id AS webhookReceiptId,
+               NULL AS deadLetterReason
+        FROM runs WHERE started_at > ?
+        UNION ALL
+        SELECT timestamp AS ts, NULL AS instanceId, NULL AS agentName,
+               'webhook' AS triggerType, source AS triggerSource,
+               'dead-letter' AS result, id AS webhookReceiptId,
+               dead_letter_reason AS deadLetterReason
+        FROM webhook_receipts WHERE status = 'dead-letter' AND timestamp > ?
+        ORDER BY ts DESC LIMIT ? OFFSET ?
+      `).all(since, since, limit, offset) as TriggerHistoryRow[];
+    }
+    return client.prepare(`
+      SELECT started_at AS ts, instance_id AS instanceId, agent_name AS agentName,
+             trigger_type AS triggerType, trigger_source AS triggerSource,
+             result, webhook_receipt_id AS webhookReceiptId,
+             NULL AS deadLetterReason
+      FROM runs WHERE started_at > ?
+      ORDER BY ts DESC LIMIT ? OFFSET ?
+    `).all(since, limit, offset) as TriggerHistoryRow[];
   }
 
   countTriggerHistory(since: number, includeDeadLetters: boolean, agentName?: string, triggerType?: string): number {
+    const client = (this.db as any).$client;
     if (agentName && triggerType) {
-      const row = this.stmts.countTriggerHistoryByAgentAndType.get({ since, agentName, triggerType }) as any;
+      const row = client.prepare("SELECT COUNT(*) AS count FROM runs WHERE started_at > ? AND agent_name = ? AND trigger_type = ?").get(since, agentName, triggerType) as any;
       return row?.count ?? 0;
     }
     if (agentName) {
-      const row = this.stmts.countTriggerHistoryByAgent.get({ since, agentName }) as any;
+      const row = client.prepare("SELECT COUNT(*) AS count FROM runs WHERE started_at > ? AND agent_name = ?").get(since, agentName) as any;
       return row?.count ?? 0;
     }
     if (triggerType) {
       if (includeDeadLetters && triggerType === "webhook") {
-        const row = this.stmts.countTriggerHistoryByTypeWithDeadLetters.get({ since, triggerType }) as any;
+        const row = client.prepare("SELECT (SELECT COUNT(*) FROM runs WHERE started_at > ? AND trigger_type = ?) + (SELECT COUNT(*) FROM webhook_receipts WHERE status = 'dead-letter' AND timestamp > ?) AS count").get(since, triggerType, since) as any;
         return row?.count ?? 0;
       }
-      const row = this.stmts.countTriggerHistoryByType.get({ since, triggerType }) as any;
+      const row = client.prepare("SELECT COUNT(*) AS count FROM runs WHERE started_at > ? AND trigger_type = ?").get(since, triggerType) as any;
       return row?.count ?? 0;
     }
-    const stmt = includeDeadLetters ? this.stmts.countTriggerHistory : this.stmts.countTriggerHistoryNoDeadLetters;
-    const row = stmt.get({ since }) as any;
+    if (includeDeadLetters) {
+      const row = client.prepare("SELECT (SELECT COUNT(*) FROM runs WHERE started_at > ?) + (SELECT COUNT(*) FROM webhook_receipts WHERE status = 'dead-letter' AND timestamp > ?) AS count").get(since, since) as any;
+      return row?.count ?? 0;
+    }
+    const row = client.prepare("SELECT COUNT(*) AS count FROM runs WHERE started_at > ?").get(since) as any;
     return row?.count ?? 0;
   }
 
@@ -548,9 +427,10 @@ export class StatsStore {
 
   prune(olderThanDays: number): { runs: number; callEdges: number; receipts: number } {
     const threshold = Date.now() - olderThanDays * 24 * 60 * 60 * 1000;
-    const runsResult = this.stmts.pruneRuns.run({ threshold });
-    const callEdgesResult = this.stmts.pruneCallEdges.run({ threshold });
-    const receiptsResult = this.stmts.pruneReceipts.run({ threshold });
+    const client = (this.db as any).$client;
+    const runsResult = client.prepare("DELETE FROM runs WHERE started_at < ?").run(threshold);
+    const callEdgesResult = client.prepare("DELETE FROM call_edges WHERE started_at < ?").run(threshold);
+    const receiptsResult = client.prepare("DELETE FROM webhook_receipts WHERE timestamp < ?").run(threshold);
     return {
       runs: runsResult.changes,
       callEdges: callEdgesResult.changes,
@@ -559,6 +439,8 @@ export class StatsStore {
   }
 
   close(): void {
-    this.db.close();
+    if (this.ownDb) {
+      (this.db as any).$client.close();
+    }
   }
 }

--- a/packages/action-llama/test/db/connection.test.ts
+++ b/packages/action-llama/test/db/connection.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { createDb, createMemoryDb } from "../../src/db/connection.js";
+
+describe("createDb", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    dirs.length = 0;
+  });
+
+  it("creates parent directories for a file path", () => {
+    const dir = mkdtempSync(join(tmpdir(), "al-db-conn-"));
+    dirs.push(dir);
+    const dbPath = join(dir, "nested", "test.db");
+    const db = createDb(dbPath);
+    expect(existsSync(join(dir, "nested"))).toBe(true);
+    (db as any).$client.close();
+  });
+
+  it("returns a Drizzle db with $client", () => {
+    const dir = mkdtempSync(join(tmpdir(), "al-db-conn-"));
+    dirs.push(dir);
+    const db = createDb(join(dir, "test.db"));
+    expect(typeof (db as any).$client).toBe("object");
+    (db as any).$client.close();
+  });
+
+  it("sets WAL mode pragma", () => {
+    const dir = mkdtempSync(join(tmpdir(), "al-db-conn-"));
+    dirs.push(dir);
+    const db = createDb(join(dir, "test.db"));
+    const client = (db as any).$client;
+    const row = client.pragma("journal_mode") as Array<{ journal_mode: string }>;
+    expect(row[0]?.journal_mode ?? row).toBe("wal");
+    client.close();
+  });
+});
+
+describe("createMemoryDb", () => {
+  it("returns a Drizzle db instance", () => {
+    const db = createMemoryDb();
+    expect(typeof (db as any).$client).toBe("object");
+    (db as any).$client.close();
+  });
+});

--- a/packages/action-llama/test/db/migrate.test.ts
+++ b/packages/action-llama/test/db/migrate.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import Database from "better-sqlite3";
+import { runMigrations } from "../../src/db/migrate.js";
+
+describe("runMigrations", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    dirs.length = 0;
+  });
+
+  function makeTempDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "al-migrate-"));
+    dirs.push(dir);
+    return dir;
+  }
+
+  it("creates the consolidated DB on fresh start (no legacy files)", () => {
+    const dir = makeTempDir();
+    const alDir = join(dir, ".al");
+    const dbPath = join(alDir, "action-llama.db");
+    const db = runMigrations(dbPath);
+    expect(existsSync(dbPath)).toBe(true);
+    (db as any).$client.close();
+  });
+
+  it("creates all expected tables", () => {
+    const dir = makeTempDir();
+    const alDir = join(dir, ".al");
+    const dbPath = join(alDir, "action-llama.db");
+    const db = runMigrations(dbPath);
+    const client = (db as any).$client;
+    const tables = client
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name != '__drizzle_migrations'")
+      .all()
+      .map((r: any) => r.name)
+      .sort();
+    expect(tables).toContain("state");
+    expect(tables).toContain("runs");
+    expect(tables).toContain("webhook_receipts");
+    expect(tables).toContain("call_edges");
+    expect(tables).toContain("work_queue");
+    expect(tables).toContain("queue");
+    expect(tables).toContain("kv_store");
+    expect(tables).toContain("events");
+    expect(tables).toContain("snapshots");
+    client.close();
+  });
+
+  it("creates a backup of existing .db files", () => {
+    const dir = makeTempDir();
+    const alDir = join(dir, ".al");
+    const dbPath = join(alDir, "action-llama.db");
+
+    // Create a dummy legacy state.db
+    const { mkdirSync } = require("fs");
+    mkdirSync(alDir, { recursive: true });
+    const legacyDb = new Database(join(alDir, "state.db"));
+    legacyDb.exec("CREATE TABLE foo (id INTEGER PRIMARY KEY)");
+    legacyDb.close();
+
+    const db = runMigrations(dbPath);
+    (db as any).$client.close();
+
+    // Verify backup directory was created
+    const backupsDir = join(alDir, "backups");
+    expect(existsSync(backupsDir)).toBe(true);
+    const backupDirs = require("fs").readdirSync(backupsDir);
+    expect(backupDirs.length).toBeGreaterThan(0);
+  });
+
+  it("migrates data from legacy state.db into consolidated DB", () => {
+    const dir = makeTempDir();
+    const alDir = join(dir, ".al");
+    const dbPath = join(alDir, "action-llama.db");
+
+    // Create a legacy state.db with test data
+    const { mkdirSync } = require("fs");
+    mkdirSync(alDir, { recursive: true });
+    const legacyState = new Database(join(alDir, "state.db"));
+    legacyState.exec(`
+      CREATE TABLE IF NOT EXISTS state (
+        ns TEXT NOT NULL,
+        key TEXT NOT NULL,
+        value TEXT NOT NULL,
+        expires_at INTEGER,
+        PRIMARY KEY (ns, key)
+      )
+    `);
+    legacyState.prepare("INSERT INTO state (ns, key, value) VALUES (?, ?, ?)").run("test-ns", "test-key", '"hello"');
+    legacyState.close();
+
+    const db = runMigrations(dbPath);
+    const client = (db as any).$client;
+    const row = client.prepare("SELECT value FROM state WHERE ns = ? AND key = ?").get("test-ns", "test-key") as any;
+    expect(row?.value).toBe('"hello"');
+    client.close();
+  });
+
+  it("is idempotent — running twice doesn't fail", () => {
+    const dir = makeTempDir();
+    const alDir = join(dir, ".al");
+    const dbPath = join(alDir, "action-llama.db");
+    const db1 = runMigrations(dbPath);
+    (db1 as any).$client.close();
+    const db2 = runMigrations(dbPath);
+    expect(existsSync(dbPath)).toBe(true);
+    (db2 as any).$client.close();
+  });
+});

--- a/packages/action-llama/test/db/schema.test.ts
+++ b/packages/action-llama/test/db/schema.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { createMemoryDb } from "../../src/db/connection.js";
+import { applyMigrations } from "../../src/db/migrate.js";
+import {
+  stateTable,
+  runsTable,
+  webhookReceiptsTable,
+  callEdgesTable,
+  workQueueTable,
+  queueTable,
+  kvStoreTable,
+  eventsTable,
+  snapshotsTable,
+} from "../../src/db/schema.js";
+
+describe("Drizzle schema", () => {
+  function createMigratedDb() {
+    const db = createMemoryDb();
+    applyMigrations(db);
+    return db;
+  }
+
+  it("creates all 9 tables after migrations", () => {
+    const db = createMigratedDb();
+    const client = (db as any).$client;
+    const tables = client
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name != '__drizzle_migrations'")
+      .all()
+      .map((r: any) => r.name)
+      .sort();
+    expect(tables).toEqual([
+      "call_edges",
+      "events",
+      "kv_store",
+      "queue",
+      "runs",
+      "snapshots",
+      "state",
+      "webhook_receipts",
+      "work_queue",
+    ]);
+    client.close();
+  });
+
+  it("state table has expected columns", () => {
+    const db = createMigratedDb();
+    const client = (db as any).$client;
+    const cols = client.pragma("table_info(state)").map((c: any) => c.name);
+    expect(cols).toContain("ns");
+    expect(cols).toContain("key");
+    expect(cols).toContain("value");
+    expect(cols).toContain("expires_at");
+    client.close();
+  });
+
+  it("runs table has expected columns including webhook_receipt_id", () => {
+    const db = createMigratedDb();
+    const client = (db as any).$client;
+    const cols = client.pragma("table_info(runs)").map((c: any) => c.name);
+    expect(cols).toContain("id");
+    expect(cols).toContain("instance_id");
+    expect(cols).toContain("agent_name");
+    expect(cols).toContain("webhook_receipt_id");
+    client.close();
+  });
+
+  it("kv_store table has expires_at for TTL support", () => {
+    const db = createMigratedDb();
+    const client = (db as any).$client;
+    const cols = client.pragma("table_info(kv_store)").map((c: any) => c.name);
+    expect(cols).toContain("expires_at");
+    expect(cols).toContain("created_at");
+    expect(cols).toContain("updated_at");
+    client.close();
+  });
+
+  it("work_queue and queue tables are separate", () => {
+    const db = createMigratedDb();
+    const client = (db as any).$client;
+    const wqCols = client.pragma("table_info(work_queue)").map((c: any) => c.name);
+    const qCols = client.pragma("table_info(queue)").map((c: any) => c.name);
+    expect(wqCols).toContain("agent");
+    expect(qCols).toContain("name");
+    client.close();
+  });
+});


### PR DESCRIPTION
Closes #398

## Summary

This PR implements [Drizzle ORM](https://orm.drizzle.team/) as the data access layer for all SQLite operations, consolidating three separate databases into a single `.al/action-llama.db` with proper migration management.

## Changes

### New files
- `src/db/schema.ts` — all 9 Drizzle table definitions (state, runs, webhook_receipts, call_edges, work_queue, queue, kv_store, events, snapshots)
- `src/db/connection.ts` — shared DB connection factory using `drizzle-orm/better-sqlite3`
- `src/db/migrate.ts` — auto-migration runner with backup and legacy data migration
- `drizzle.config.ts` — Drizzle Kit config
- `drizzle/0000_married_shockwave.sql` — initial migration SQL
- `test/db/` — new tests for connection factory, schema, and migration runner

### Modified files
- **`SqliteStateStore`** — rewritten with Drizzle queries; class interface unchanged
- **`StatsStore`** — rewritten with Drizzle queries; class interface unchanged
- **`SqliteWorkQueue`** — rewritten with Drizzle queries; class interface unchanged
- **`SqliteQueue`** — rewritten with Drizzle queries; class interface unchanged
- **`SqliteBackend`** (persistence) — rewritten with Drizzle queries; `init()` now runs migrations instead of `CREATE TABLE IF NOT EXISTS`
- **`scheduler/index.ts`** — runs migrations on startup, creates single shared DB, passes it to all stores
- **`scheduler/shutdown.ts`** — closes shared DB on shutdown
- **`shared/paths.ts`** — adds `dbPath()` helper for `.al/action-llama.db`
- **`package.json`** — adds `drizzle-orm`, `drizzle-kit`, and `db:generate` script

## Behavior

### Startup
1. Runs `runMigrations()` before any stores are created
2. Backs up existing `.db` files to `.al/backups/<timestamp>/`
3. Applies any pending Drizzle migrations
4. Migrates data from legacy `state.db`, `stats.db`, `work-queue.db` into the consolidated DB (one-time)

### Backward compatibility
- All store class interfaces are unchanged — no callers need updating
- Each store accepts either an `AppDb` instance (new/shared) or a file path string (backward compat for tests)
- When constructed with a path, stores apply migrations themselves

## Testing

All 191 unit test files pass (3 new test files added).