### PR TITLE
fix: prevent ghost runner leak and queue manual triggers when all runners busy

### DIFF
--- a/.changeset/fix-runner-ghost-and-queue-fallback.md
+++ b/.changeset/fix-runner-ghost-and-queue-fallback.md
@@ -1,0 +1,13 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fix ghost runner leak and manual trigger queuing when all runners are busy.
+
+When `withSpan` threw before `_runInternalContainer` ran, the `ContainerAgentRunner` would be permanently stuck with `isRunning === true`, causing the runner pool to show "all busy" even though the status tracker had no record of it. The `run()` method now wraps the `withSpan` call in a try/catch and resets `_running` on failure.
+
+Manual triggers via the control API now queue when all runners are busy (matching webhook/schedule behavior) instead of returning an error string. This means pressing Run in the dashboard while an agent is running will queue the request and return an instanceId.
+
+Frontend API errors with JSON bodies (e.g. `{"error":"..."}`) now display the human-readable message instead of raw JSON.
+
+Closes #404

--- a/packages/action-llama/src/agents/container-runner.ts
+++ b/packages/action-llama/src/agents/container-runner.ts
@@ -316,26 +316,34 @@ export class ContainerAgentRunner {
     this.instanceId = instanceId ?? `${this.agentConfig.name}-${randomBytes(4).toString("hex")}`;
     this.logger = this.baseLogger.child({ instance: this.instanceId });
 
-    return await withSpan(
-      "container_agent.run",
-      async (span) => {
-        span.setAttributes({
-          "agent.name": this.agentConfig.name,
-          "agent.run_id": this.instanceId,
-          "agent.trigger_type": triggerInfo?.type || "manual",
-          "agent.trigger_source": triggerInfo?.source || "",
-          "agent.model_provider": this.agentConfig.models[0]?.provider,
-          "agent.model_name": this.agentConfig.models[0]?.model,
-          "execution.environment": "container",
-          "runtime.type": this.runtime.constructor.name,
-          "container.image": this.image,
-        });
+    try {
+      return await withSpan(
+        "container_agent.run",
+        async (span) => {
+          span.setAttributes({
+            "agent.name": this.agentConfig.name,
+            "agent.run_id": this.instanceId,
+            "agent.trigger_type": triggerInfo?.type || "manual",
+            "agent.trigger_source": triggerInfo?.source || "",
+            "agent.model_provider": this.agentConfig.models[0]?.provider,
+            "agent.model_name": this.agentConfig.models[0]?.model,
+            "execution.environment": "container",
+            "runtime.type": this.runtime.constructor.name,
+            "container.image": this.image,
+          });
 
-        return this._runInternalContainer(prompt, triggerInfo, span);
-      },
-      {},
-      SpanKind.INTERNAL
-    );
+          return this._runInternalContainer(prompt, triggerInfo, span);
+        },
+        {},
+        SpanKind.INTERNAL
+      );
+    } catch (err: any) {
+      // withSpan failed before _runInternalContainer could run its cleanup.
+      // Reset _running to avoid a permanent ghost runner state.
+      this._running = false;
+      this.logger.error({ err }, "container run setup failed");
+      return { result: "error", triggers: [] };
+    }
   }
 
   private async _runInternalContainer(prompt: string, triggerInfo?: { type: 'schedule' | 'manual' | 'webhook' | 'agent'; source?: string }, parentSpan?: any): Promise<RunOutcome> {

--- a/packages/action-llama/src/scheduler/gateway-setup.ts
+++ b/packages/action-llama/src/scheduler/gateway-setup.ts
@@ -149,7 +149,13 @@ export async function setupGateway(opts: {
           return { instanceId };
         }
         const runner = pool.getAvailableRunner();
-        if (!runner) return `Agent "${name}" has no available runners (all busy)`;
+        if (!runner) {
+          const { dropped } = state.workQueue!.enqueue(name, { type: 'manual', prompt });
+          if (dropped) logger.warn({ agent: name }, "queue full, oldest event dropped");
+          const instanceId = `${name}-${randomBytes(4).toString("hex")}`;
+          logger.info({ agent: name, hasPrompt: !!prompt, instanceId, queued: true }, "manual trigger queued (all runners busy)");
+          return { instanceId };
+        }
         const instanceId = `${name}-${randomBytes(4).toString("hex")}`;
         logger.info({ agent: name, hasPrompt: !!prompt, instanceId }, "manual trigger via control API");
         runWithReruns(runner, config, 0, state.schedulerCtx, prompt, instanceId).catch((err) => {

--- a/packages/action-llama/test/agents/container-runner.test.ts
+++ b/packages/action-llama/test/agents/container-runner.test.ts
@@ -127,6 +127,20 @@ describe("ContainerAgentRunner", () => {
       expect(result.result).toBe("error");
       expect(runner.isRunning).toBe(false);
     });
+
+    it("resets _running when withSpan setup fails before _runInternalContainer runs", async () => {
+      const mockTelemetryModule = await import("../../src/telemetry/index.js");
+      const spy = vi.spyOn(mockTelemetryModule, "withSpan")
+        .mockRejectedValueOnce(new Error("span setup failed"));
+
+      const runner = createRunner();
+      const result = await runner.run("test prompt");
+
+      expect(result.result).toBe("error");
+      expect(runner.isRunning).toBe(false); // Must not be stuck as ghost runner
+
+      spy.mockRestore();
+    });
   });
 
   // ── setImage / setAgentConfig accessors ─────────────────────────────────

--- a/packages/action-llama/test/scheduler/gateway-setup.test.ts
+++ b/packages/action-llama/test/scheduler/gateway-setup.test.ts
@@ -376,19 +376,23 @@ describe("setupGateway", () => {
       expect(mockWorkQueue.enqueue).toHaveBeenCalledWith("dev", { type: 'manual', prompt: undefined });
     });
 
-    it("returns error string when no available runner", async () => {
+    it("queues manual trigger when all runners are busy", async () => {
       const gatewayResult = makeGatewayResult();
       const statusTracker = { isPaused: vi.fn().mockReturnValue(false) };
       const pool = { getAvailableRunner: vi.fn().mockReturnValue(null) };
-      const schedulerCtx = { workQueue: { size: vi.fn().mockReturnValue(0) } } as any;
-      const state = makeSchedulerState({ runnerPools: { dev: pool }, schedulerCtx });
+      const mockWorkQueue = { enqueue: vi.fn().mockReturnValue({ dropped: false }), size: vi.fn().mockReturnValue(1) };
+      const schedulerCtx = { workQueue: mockWorkQueue } as any;
+      const state = makeSchedulerState({ runnerPools: { dev: pool }, schedulerCtx, workQueue: mockWorkQueue });
       const opts = { ...makeBaseOpts(state, gatewayResult), statusTracker: statusTracker as any };
 
       await setupGateway(opts);
 
       const { controlDeps } = mockStartGateway.mock.calls[0][0];
-      const result = await controlDeps.triggerAgent("dev");
-      expect(result).toBe('Agent "dev" has no available runners (all busy)');
+      const result = await controlDeps.triggerAgent("dev", "do something");
+
+      expect(result).toHaveProperty("instanceId");
+      expect((result as any).instanceId).toMatch(/^dev-[0-9a-f]{8}$/);
+      expect(mockWorkQueue.enqueue).toHaveBeenCalledWith("dev", { type: 'manual', prompt: "do something" });
     });
 
     it("returns error string when scheduler context is not ready", async () => {

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -11,7 +11,13 @@ async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
   }
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(text || `HTTP ${res.status}`);
+    let message = text || `HTTP ${res.status}`;
+    try {
+      const json = JSON.parse(text);
+      if (typeof json.error === "string") message = json.error;
+      else if (typeof json.message === "string") message = json.message;
+    } catch { /* not JSON — use raw text */ }
+    throw new Error(message);
   }
   return res.json();
 }


### PR DESCRIPTION
Closes #404

## Summary

This PR fixes three bugs that together caused the 'Runner unable to start' error.

### Bug 1: Ghost runner leak in ContainerAgentRunner.run()

When `withSpan` threw before `_runInternalContainer` ran, `_running` was permanently stuck as `true`. The runner pool saw all runners as busy while the status tracker showed fewer running instances.

**Fix:** Wrap the `withSpan` call in try/catch that resets `_running = false` on failure.

### Bug 2: Manual triggers rejected instead of queued when all runners busy

The `triggerAgent` control endpoint returned an error string when `getAvailableRunner()` returned null, instead of queuing the work (inconsistent with webhooks/schedules).

**Fix:** Enqueue the manual trigger via `state.workQueue` and return an instanceId.

### Bug 3: Raw JSON error displayed in frontend

`fetchJSON` showed raw JSON body like `{"error":"..."}` to the user.

**Fix:** Parse the JSON body and extract the `error` or `message` field.

## Files Changed

- `packages/action-llama/src/agents/container-runner.ts` - wrap withSpan in try/catch
- `packages/action-llama/src/scheduler/gateway-setup.ts` - queue manual triggers when all runners busy
- `packages/frontend/src/lib/api.ts` - parse JSON error responses
- `packages/action-llama/test/agents/container-runner.test.ts` - test withSpan failure
- `packages/action-llama/test/scheduler/gateway-setup.test.ts` - test queuing behavior
- `.changeset/fix-runner-ghost-and-queue-fallback.md` - changeset