### PR TITLE
refactor: Break gateway into composition root + route packs + middleware

### DIFF
--- a/packages/action-llama/src/gateway/frontend.ts
+++ b/packages/action-llama/src/gateway/frontend.ts
@@ -1,0 +1,83 @@
+import { createRequire } from "module";
+import { dirname, resolve, extname } from "path";
+import { fileURLToPath } from "url";
+import { existsSync, readFileSync } from "fs";
+import type { Hono } from "hono";
+import type { Logger } from "../shared/logger.js";
+
+export const MIME_TYPES: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".ico": "image/x-icon",
+  ".woff2": "font/woff2",
+  ".woff": "font/woff",
+  ".ttf": "font/ttf",
+  ".map": "application/json",
+};
+
+/**
+ * Attempt to resolve the @action-llama/frontend dist directory.
+ * Checks (in order):
+ *  1. Bundled frontend at dist/frontend/ (works after npm install)
+ *  2. Workspace-linked @action-llama/frontend package (works in monorepo)
+ */
+export function resolveFrontendDist(): string | null {
+  // Check bundled frontend (copied during build:assets)
+  const bundled = resolve(dirname(fileURLToPath(import.meta.url)), "..", "frontend");
+  if (existsSync(resolve(bundled, "index.html"))) {
+    return bundled;
+  }
+  // Fall back to workspace-linked package
+  try {
+    const require = createRequire(import.meta.url);
+    const pkgPath = require.resolve("@action-llama/frontend/package.json");
+    const distDir = resolve(dirname(pkgPath), "dist");
+    if (existsSync(resolve(distDir, "index.html"))) {
+      return distDir;
+    }
+  } catch {
+    // Package not available
+  }
+  return null;
+}
+
+/**
+ * Register all frontend SPA serving routes:
+ * - /assets/* — Vite-built assets with long-term caching headers
+ * - SPA fallback routes for /login, /dashboard, /triggers, /chat
+ *
+ * Reads index.html once and reuses it for all SPA routes, eliminating
+ * the previous duplication where it was read separately for dashboard and chat.
+ */
+export function registerSpaRoutes(app: Hono, frontendDist: string, logger: Logger): void {
+  const indexHtml = readFileSync(resolve(frontendDist, "index.html"), "utf-8");
+
+  logger.info({ path: frontendDist }, "Serving frontend from @action-llama/frontend");
+
+  // Serve Vite-built assets (JS, CSS, images) with long-term caching
+  app.get("/assets/*", (c) => {
+    const filePath = resolve(frontendDist, c.req.path.slice(1));
+    if (!filePath.startsWith(frontendDist + "/")) return c.notFound();
+    try {
+      const content = readFileSync(filePath);
+      const mime = MIME_TYPES[extname(filePath)] || "application/octet-stream";
+      return new Response(content, {
+        headers: { "Content-Type": mime, "Cache-Control": "public, max-age=31536000, immutable" },
+      });
+    } catch {
+      return c.notFound();
+    }
+  });
+
+  // SPA fallback routes — all serve index.html for client-side routing
+  app.get("/login", (c) => c.html(indexHtml));
+  app.get("/dashboard", (c) => c.html(indexHtml));
+  app.get("/dashboard/*", (c) => c.html(indexHtml));
+  app.get("/triggers", (c) => c.html(indexHtml));
+  app.get("/chat", (c) => c.html(indexHtml));
+  app.get("/chat/*", (c) => c.html(indexHtml));
+}

--- a/packages/action-llama/src/gateway/index.ts
+++ b/packages/action-llama/src/gateway/index.ts
@@ -1,324 +1,126 @@
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
 import type { Server } from "http";
-import { createRequire } from "module";
-import { dirname, resolve, extname } from "path";
-import { fileURLToPath } from "url";
-import { existsSync, readFileSync } from "fs";
-import { registerShutdownRoute } from "../execution/routes/shutdown.js";
-import { registerLockRoutes } from "../execution/routes/locks.js";
-import { registerCallRoutes, type CallDispatcher } from "../execution/routes/calls.js";
-import { registerWebhookRoutes } from "../events/routes/webhooks.js";
-import { registerDashboardDataRoutes } from "../control/routes/dashboard.js";
-import { registerAuthApiRoutes, registerDashboardApiRoutes } from "../control/routes/dashboard-api.js";
-import { registerSignalRoutes, type SignalContext } from "../execution/routes/signals.js";
-import { LockStore } from "../execution/lock-store.js";
-import { CallStore } from "../execution/call-store.js";
-import { ContainerRegistry } from "../execution/container-registry.js";
-import { SessionStore } from "../control/session-store.js";
+
+// Re-export public API for external consumers (scheduler, tests)
+export type { GatewayOptions, GatewayServer, ContainerRegistration } from "./types.js";
+export { resolveFrontendDist } from "./frontend.js";
+
+import type { GatewayOptions, GatewayServer } from "./types.js";
+import { createGatewayStores } from "./stores.js";
+import { applyTelemetryMiddleware } from "./middleware/telemetry.js";
+import { applyRequestLoggingMiddleware } from "./middleware/request-logging.js";
+import { applyAuthMiddleware } from "./middleware/auth.js";
+import { registerSystemRoutes } from "./routes/system.js";
+import { registerExecutionRoutes } from "./routes/execution.js";
+import { registerGatewayWebhookRoutes } from "./routes/webhooks.js";
+import { registerDashboardRoutes } from "./routes/dashboard.js";
+import { registerChatRoutes, attachChatWebSocketToServer } from "./routes/chat.js";
+import { resolveFrontendDist, registerSpaRoutes } from "./frontend.js";
+import type { CallDispatcher } from "../execution/routes/calls.js";
 import type { ContainerRegistration } from "../execution/types.js";
-import type { StateStore } from "../shared/state-store.js";
-import type { WebhookRegistry } from "../webhooks/registry.js";
-import type { Logger } from "../shared/logger.js";
-import type { StatusTracker } from "../tui/status-tracker.js";
-import type { WebhookSourceConfig } from "../shared/config.js";
-import type { ControlRoutesDeps } from "../control/routes/control.js";
-import { withSpan, getTelemetry } from "../telemetry/index.js";
-import { SpanKind } from "@opentelemetry/api";
-import { authMiddleware, type ApiKeySource } from "../control/auth.js";
-import type { SchedulerEventBus } from "../scheduler/events.js";
-import type { StatsStore } from "../stats/store.js";
-import { ChatSessionManager } from "../chat/session-manager.js";
-import { attachChatWebSocket, type ChatWebSocketState } from "../chat/ws-handler.js";
-import { registerChatApiRoutes, type LaunchChatCallback, type StopChatCallback } from "../chat/routes.js";
-
-const MIME_TYPES: Record<string, string> = {
-  ".html": "text/html; charset=utf-8",
-  ".js": "text/javascript; charset=utf-8",
-  ".css": "text/css; charset=utf-8",
-  ".json": "application/json",
-  ".svg": "image/svg+xml",
-  ".png": "image/png",
-  ".ico": "image/x-icon",
-  ".woff2": "font/woff2",
-  ".woff": "font/woff",
-  ".ttf": "font/ttf",
-  ".map": "application/json",
-};
-
-/**
- * Attempt to resolve the @action-llama/frontend dist directory.
- * Checks (in order):
- *  1. Bundled frontend at dist/frontend/ (works after npm install)
- *  2. Workspace-linked @action-llama/frontend package (works in monorepo)
- */
-export function resolveFrontendDist(): string | null {
-  // Check bundled frontend (copied during build:assets)
-  const bundled = resolve(dirname(fileURLToPath(import.meta.url)), "..", "frontend");
-  if (existsSync(resolve(bundled, "index.html"))) {
-    return bundled;
-  }
-  // Fall back to workspace-linked package
-  try {
-    const require = createRequire(import.meta.url);
-    const pkgPath = require.resolve("@action-llama/frontend/package.json");
-    const distDir = resolve(dirname(pkgPath), "dist");
-    if (existsSync(resolve(distDir, "index.html"))) {
-      return distDir;
-    }
-  } catch {
-    // Package not available
-  }
-  return null;
-}
-
-export type { ContainerRegistration } from "../execution/types.js";
-
-export interface GatewayOptions {
-  port: number;
-  hostname?: string;
-  logger: Logger;
-  killContainer?: (name: string) => Promise<void>;
-  webhookRegistry?: WebhookRegistry;
-  webhookSecrets?: Record<string, Record<string, string>>;
-  webhookConfigs?: Record<string, WebhookSourceConfig>;
-  statusTracker?: StatusTracker;
-  projectPath?: string;
-  webUI?: boolean;
-  lockTimeout?: number;
-  signalContext?: SignalContext;
-  controlDeps?: ControlRoutesDeps;
-  /** Static API key string or an async provider that re-reads the key from disk on every auth check, enabling hot-reload of rotated credentials. */
-  apiKey?: ApiKeySource;
-  stateStore?: StateStore;
-  skipStatusEndpoint?: boolean;
-  /** Optional path to the pre-built frontend dist directory (overrides resolveFrontendDist; useful for testing). */
-  frontendDistPath?: string;
-  /** Optional event bus for lifecycle instrumentation. */
-  events?: SchedulerEventBus;
-  /** Optional stats store for dashboard aggregate stats. */
-  statsStore?: StatsStore;
-  /** Max concurrent chat sessions (default: 5). */
-  maxChatSessions?: number;
-  /** Callback to launch a chat container for a session. */
-  launchChatContainer?: LaunchChatCallback;
-  /** Callback to stop a chat container for a session. */
-  stopChatContainer?: StopChatCallback;
-}
-
-export interface GatewayServer {
-  server: Server;
-  containerRegistry: ContainerRegistry;
-  registerContainer: (secret: string, reg: ContainerRegistration) => Promise<void>;
-  unregisterContainer: (secret: string) => Promise<void>;
-  lockStore: LockStore;
-  callStore: CallStore;
-  setCallDispatcher: (dispatcher: CallDispatcher) => void;
-  close: () => Promise<void>;
-  chatSessionManager?: ChatSessionManager;
-  chatWebSocketState?: ChatWebSocketState;
-}
+import type { ChatWebSocketState } from "../chat/ws-handler.js";
+import type { ChatSessionManager } from "../chat/session-manager.js";
 
 export async function startGateway(opts: GatewayOptions): Promise<GatewayServer> {
-  const { port, logger, killContainer, webhookRegistry, webhookSecrets, statusTracker, projectPath, webUI, lockTimeout, signalContext, stateStore } = opts;
   const app = new Hono();
-
-  // Create stores backed by the persistent StateStore (if provided).
-  const containerRegistry = new ContainerRegistry(stateStore);
-  const lockStore = new LockStore(lockTimeout, undefined, stateStore, {
-    isHolderAlive: (holder) => containerRegistry.hasInstance(holder),
-  });
-  const callStore = new CallStore(undefined, stateStore);
   let callDispatcher: CallDispatcher | undefined;
 
-  // Hydrate in-memory caches from the persistent store.
-  await containerRegistry.init();
-  await lockStore.init();
-  await callStore.init();
+  // 1. Create and hydrate stores
+  const { containerRegistry, lockStore, callStore, sessionStore } = await createGatewayStores({
+    lockTimeout: opts.lockTimeout,
+    stateStore: opts.stateStore,
+  });
 
-  // Add telemetry middleware for HTTP requests
-  const telemetry = getTelemetry();
-  if (telemetry) {
-    app.use("*", async (c, next) => {
-      const spanName = `gateway.${c.req.method.toLowerCase()}_${c.req.path.replace(/\/+/g, "_").replace(/^_|_$/g, "") || "root"}`;
+  // 2. Apply middleware (order matters: telemetry → logging)
+  applyTelemetryMiddleware(app);
+  applyRequestLoggingMiddleware(app, opts.logger);
 
-      await withSpan(
-        spanName,
-        async (span) => {
-          span.setAttributes({
-            "http.method": c.req.method,
-            "http.url": c.req.url,
-            "http.path": c.req.path,
-            "http.user_agent": c.req.header("user-agent") || "",
-            "gateway.component": "http_server",
-          });
+  // 3. Apply auth (if API key configured)
+  if (opts.apiKey) {
+    applyAuthMiddleware(app, opts.apiKey, sessionStore, opts.hostname);
+  }
 
-          await next();
+  // 4. Register system routes (health, shutdown, control)
+  registerSystemRoutes(app, {
+    containerRegistry,
+    killContainer: opts.killContainer,
+    logger: opts.logger,
+    controlDeps: opts.controlDeps,
+  });
 
-          span.setAttributes({
-            "http.status_code": c.res.status,
-          });
-        },
-        {},
-        SpanKind.SERVER
-      );
+  // 5. Register execution routes (locks, calls, signals)
+  registerExecutionRoutes(app, {
+    containerRegistry,
+    lockStore,
+    callStore,
+    callDispatcherProvider: () => callDispatcher,
+    logger: opts.logger,
+    statusTracker: opts.statusTracker,
+    signalContext: opts.signalContext,
+    skipStatusEndpoint: opts.skipStatusEndpoint,
+    events: opts.events,
+  });
+
+  // 6. Register webhook routes
+  if (opts.webhookRegistry) {
+    registerGatewayWebhookRoutes(app, {
+      webhookRegistry: opts.webhookRegistry,
+      webhookSecrets: opts.webhookSecrets || {},
+      webhookConfigs: opts.webhookConfigs || {},
+      logger: opts.logger,
+      statusTracker: opts.statusTracker,
+      statsStore: opts.statsStore,
     });
   }
 
-  // Request/response logging middleware for command routes.
-  // Skips /health to avoid noise; logs method, path, status, and duration.
-  app.use("*", async (c, next) => {
-    if (c.req.path === "/health") {
-      await next();
-      return;
-    }
-    const start = Date.now();
-    logger.debug({ method: c.req.method, path: c.req.path }, "request received");
-    await next();
-    const duration = Date.now() - start;
-    const status = c.res.status;
-    const logData = { method: c.req.method, path: c.req.path, status, duration };
-    if (status >= 400) {
-      logger.warn(logData, "request completed with error");
-    } else {
-      logger.debug(logData, "request completed");
-    }
-  });
-
-  // Health check
-  app.get("/health", (c) => c.json({ status: "ok" }));
-
-  // Container management routes
-  const killFn = killContainer || (async () => {});
-  registerShutdownRoute(app, containerRegistry, killFn, logger);
-
-  // Apply auth middleware to protected routes when an API key is configured
-  if (opts.apiKey) {
-    const sessionStore = stateStore ? new SessionStore(stateStore) : undefined;
-    const auth = authMiddleware(opts.apiKey, sessionStore);
-    app.use("/control/*", auth);
-    app.use("/dashboard/api/*", auth);
-    app.use("/locks/status", auth);
-    app.use("/api/logs/*", auth);
-    app.use("/api/stats/*", auth);
-    app.use("/api/dashboard/*", auth);
-    app.use("/api/auth/check", auth);
-    app.use("/api/webhooks/*", auth);
-
-    // JSON auth endpoints for the SPA (login is unprotected, check is protected)
-    registerAuthApiRoutes(app, opts.apiKey, sessionStore, opts.hostname);
-  }
-
-  registerLockRoutes(app, containerRegistry, lockStore, logger, { skipStatusEndpoint: opts.skipStatusEndpoint, events: opts.events });
-  registerCallRoutes(app, containerRegistry, callStore, () => callDispatcher, logger, opts.events);
-
-  // Signal routes
-  registerSignalRoutes(app, containerRegistry, logger, statusTracker, signalContext, opts.events);
-
-  // Webhook routes
-  if (webhookRegistry) {
-    registerWebhookRoutes(app, webhookRegistry, webhookSecrets || {}, opts.webhookConfigs || {}, logger, statusTracker, opts.statsStore);
-  }
-
-  // Dashboard routes
-  if (webUI && statusTracker) {
+  // 7. Dashboard routes (requires webUI + statusTracker + apiKey)
+  if (opts.webUI && opts.statusTracker) {
     if (!opts.apiKey) {
-      logger.error("Dashboard UI requested but no API key configured. Dashboard will not be enabled for security.");
+      opts.logger.error("Dashboard UI requested but no API key configured. Dashboard will not be enabled for security.");
     } else {
-      // Data routes (SSE stream, locks)
-      registerDashboardDataRoutes(app, statusTracker);
-
-      // JSON API routes for the React SPA
-      registerDashboardApiRoutes(app, statusTracker, projectPath, opts.statsStore);
-
-      // Serve the React SPA frontend
-      const frontendDist = opts.frontendDistPath ?? resolveFrontendDist();
-      if (frontendDist) {
-        logger.info({ path: frontendDist }, "Serving frontend from @action-llama/frontend");
-        const indexHtml = readFileSync(resolve(frontendDist, "index.html"), "utf-8");
-
-        // Serve Vite-built assets (JS, CSS, images) with long-term caching
-        app.get("/assets/*", (c) => {
-          const filePath = resolve(frontendDist, c.req.path.slice(1));
-          if (!filePath.startsWith(frontendDist + "/")) return c.notFound();
-          try {
-            const content = readFileSync(filePath);
-            const mime = MIME_TYPES[extname(filePath)] || "application/octet-stream";
-            return new Response(content, {
-              headers: { "Content-Type": mime, "Cache-Control": "public, max-age=31536000, immutable" },
-            });
-          } catch {
-            return c.notFound();
-          }
-        });
-
-        // SPA fallback: serve index.html for all frontend routes
-        app.get("/login", (c) => c.html(indexHtml));
-        app.get("/dashboard", (c) => c.html(indexHtml));
-        app.get("/dashboard/*", (c) => c.html(indexHtml));
-        app.get("/triggers", (c) => c.html(indexHtml));
-      } else {
-        logger.warn("@action-llama/frontend not found — dashboard UI will not be served. API routes are still available.");
-      }
-
-      app.get("/", (c) => c.redirect("/dashboard"));
+      await registerDashboardRoutes(app, {
+        statusTracker: opts.statusTracker,
+        projectPath: opts.projectPath,
+        apiKey: opts.apiKey,
+        statsStore: opts.statsStore,
+        logger: opts.logger,
+      });
     }
-  }
-
-  // Chat WebSocket and API routes
-  let chatSessionManager: ChatSessionManager | undefined;
-  let chatWsState: ChatWebSocketState | undefined;
-  if (webUI && opts.apiKey) {
-    chatSessionManager = new ChatSessionManager(opts.maxChatSessions);
-
-    const noopLaunch: LaunchChatCallback = async () => {};
-    const noopStop: StopChatCallback = async () => {};
-
-    // Apply auth middleware to chat API routes
-    const sessionStore = stateStore ? new SessionStore(stateStore) : undefined;
-    const chatAuth = authMiddleware(opts.apiKey, sessionStore);
-    app.use("/api/chat/*", chatAuth);
-
-    registerChatApiRoutes(
-      app,
-      chatSessionManager,
-      opts.launchChatContainer || noopLaunch,
-      opts.stopChatContainer || noopStop,
-      logger,
-    );
-
-    // SPA fallback for /chat/* routes
-    const frontendDist2 = opts.frontendDistPath ?? resolveFrontendDist();
-    if (frontendDist2) {
-      const indexHtml2 = readFileSync(resolve(frontendDist2, "index.html"), "utf-8");
-      app.get("/chat", (c) => c.html(indexHtml2));
-      app.get("/chat/*", (c) => c.html(indexHtml2));
-    }
-  }
-
-  // Log API routes — only register if auth is configured for security
-  if (projectPath && opts.apiKey) {
+  } else if (opts.projectPath && opts.apiKey) {
+    // Log + stats routes without dashboard UI (edge case: apiKey but no webUI)
     const { registerLogRoutes } = await import("../control/routes/logs.js");
-    registerLogRoutes(app, projectPath);
-  } else if (projectPath && !opts.apiKey) {
-    logger.warn("Log API routes disabled — gateway API key required for security.");
-  }
-
-  // Stats API routes — only register if auth is configured for security
-  if (opts.apiKey) {
+    registerLogRoutes(app, opts.projectPath);
     const { registerStatsRoutes } = await import("../control/routes/stats.js");
     registerStatsRoutes(app, opts.statsStore, opts.statusTracker);
+  } else if (opts.projectPath && !opts.apiKey) {
+    opts.logger.warn("Log API routes disabled — gateway API key required for security.");
   }
 
-  // Control routes (for kill, pause, resume commands)
-  if (opts.controlDeps) {
-    const { registerControlRoutes } = await import("../control/routes/control.js");
-    registerControlRoutes(app, opts.controlDeps);
+  // 8. Chat routes (requires webUI + apiKey)
+  let chatSessionManager: ChatSessionManager | undefined;
+  if (opts.webUI && opts.apiKey) {
+    const chatSetup = registerChatRoutes(app, {
+      maxChatSessions: opts.maxChatSessions,
+      launchChatContainer: opts.launchChatContainer,
+      stopChatContainer: opts.stopChatContainer,
+      logger: opts.logger,
+    });
+    chatSessionManager = chatSetup.chatSessionManager;
   }
 
+  // 9. Frontend SPA serving (resolve once, serve everywhere)
+  const frontendDist = opts.frontendDistPath ?? resolveFrontendDist();
+  if (frontendDist && opts.webUI && opts.apiKey) {
+    registerSpaRoutes(app, frontendDist, opts.logger);
+  } else if (opts.webUI && opts.apiKey && !frontendDist) {
+    opts.logger.warn("@action-llama/frontend not found — dashboard UI will not be served. API routes are still available.");
+  }
+
+  // 10. Start HTTP server
   const server = serve({
     fetch: app.fetch,
-    port,
+    port: opts.port,
     hostname: opts.hostname || "127.0.0.1",
   }) as Server;
 
@@ -326,14 +128,20 @@ export async function startGateway(opts: GatewayOptions): Promise<GatewayServer>
     server.on("listening", resolve);
   });
 
-  // Attach chat WebSocket handler to the raw HTTP server
+  // 11. Attach chat WebSocket to the raw HTTP server (needs live server)
+  let chatWsState: ChatWebSocketState | undefined;
   if (chatSessionManager && opts.apiKey) {
-    const sessionStoreForWs = stateStore ? new SessionStore(stateStore) : undefined;
-    chatWsState = attachChatWebSocket(server, chatSessionManager, opts.apiKey, sessionStoreForWs, logger);
+    chatWsState = attachChatWebSocketToServer(server, {
+      chatSessionManager,
+      apiKey: opts.apiKey,
+      sessionStore,
+      logger: opts.logger,
+    });
   }
 
-  logger.info({ port }, "Gateway server listening");
+  opts.logger.info({ port: opts.port }, "Gateway server listening");
 
+  // Closures over local state for container/call management
   const registerContainer = async (secret: string, reg: ContainerRegistration) => {
     await containerRegistry.register(secret, reg);
   };
@@ -343,11 +151,17 @@ export async function startGateway(opts: GatewayOptions): Promise<GatewayServer>
     if (reg) {
       const released = lockStore.releaseAll(reg.instanceId);
       if (released > 0) {
-        logger.info({ agent: reg.agentName, instance: reg.instanceId, released }, "released locks on container cleanup");
+        opts.logger.info(
+          { agent: reg.agentName, instance: reg.instanceId, released },
+          "released locks on container cleanup",
+        );
       }
       const failedCalls = callStore.failAllByCaller(reg.instanceId);
       if (failedCalls > 0) {
-        logger.info({ agent: reg.agentName, instance: reg.instanceId, failedCalls }, "failed pending calls on container cleanup");
+        opts.logger.info(
+          { agent: reg.agentName, instance: reg.instanceId, failedCalls },
+          "failed pending calls on container cleanup",
+        );
       }
     }
     await containerRegistry.unregister(secret);
@@ -367,5 +181,16 @@ export async function startGateway(opts: GatewayOptions): Promise<GatewayServer>
       server.close(() => resolve());
     });
 
-  return { server, containerRegistry, registerContainer, unregisterContainer, lockStore, callStore, setCallDispatcher, close, chatSessionManager, chatWebSocketState: chatWsState };
+  return {
+    server,
+    containerRegistry,
+    registerContainer,
+    unregisterContainer,
+    lockStore,
+    callStore,
+    setCallDispatcher,
+    close,
+    chatSessionManager,
+    chatWebSocketState: chatWsState,
+  };
 }

--- a/packages/action-llama/src/gateway/middleware/auth.ts
+++ b/packages/action-llama/src/gateway/middleware/auth.ts
@@ -1,0 +1,34 @@
+import type { Hono } from "hono";
+import { authMiddleware, type ApiKeySource } from "../../control/auth.js";
+import { registerAuthApiRoutes } from "../../control/routes/dashboard-api.js";
+import type { SessionStore } from "../../control/session-store.js";
+
+/**
+ * Apply authentication middleware to all protected routes and register
+ * the auth API endpoints (login/logout/check).
+ *
+ * The SessionStore is passed in (created once in stores.ts) and shared
+ * between the auth middleware, chat auth, and chat WebSocket handler.
+ */
+export function applyAuthMiddleware(
+  app: Hono,
+  apiKey: ApiKeySource,
+  sessionStore: SessionStore | undefined,
+  hostname?: string,
+): void {
+  const auth = authMiddleware(apiKey, sessionStore);
+
+  // Protected route patterns — includes chat auth, unified here to avoid duplication
+  app.use("/control/*", auth);
+  app.use("/dashboard/api/*", auth);
+  app.use("/locks/status", auth);
+  app.use("/api/logs/*", auth);
+  app.use("/api/stats/*", auth);
+  app.use("/api/dashboard/*", auth);
+  app.use("/api/auth/check", auth);
+  app.use("/api/webhooks/*", auth);
+  app.use("/api/chat/*", auth);
+
+  // JSON auth endpoints for the SPA (login is unprotected, check is protected)
+  registerAuthApiRoutes(app, apiKey, sessionStore, hostname);
+}

--- a/packages/action-llama/src/gateway/middleware/request-logging.ts
+++ b/packages/action-llama/src/gateway/middleware/request-logging.ts
@@ -1,0 +1,27 @@
+import type { Hono } from "hono";
+import type { Logger } from "../../shared/logger.js";
+
+/**
+ * Apply request/response logging middleware to the Hono app.
+ * Skips /health to avoid noise; logs method, path, status, and duration.
+ * Uses warn for 4xx+ responses, debug otherwise.
+ */
+export function applyRequestLoggingMiddleware(app: Hono, logger: Logger): void {
+  app.use("*", async (c, next) => {
+    if (c.req.path === "/health") {
+      await next();
+      return;
+    }
+    const start = Date.now();
+    logger.debug({ method: c.req.method, path: c.req.path }, "request received");
+    await next();
+    const duration = Date.now() - start;
+    const status = c.res.status;
+    const logData = { method: c.req.method, path: c.req.path, status, duration };
+    if (status >= 400) {
+      logger.warn(logData, "request completed with error");
+    } else {
+      logger.debug(logData, "request completed");
+    }
+  });
+}

--- a/packages/action-llama/src/gateway/middleware/telemetry.ts
+++ b/packages/action-llama/src/gateway/middleware/telemetry.ts
@@ -1,0 +1,37 @@
+import type { Hono } from "hono";
+import { withSpan, getTelemetry } from "../../telemetry/index.js";
+import { SpanKind } from "@opentelemetry/api";
+
+/**
+ * Apply OpenTelemetry HTTP span middleware to the Hono app.
+ * Wraps each request in a span with HTTP metadata.
+ */
+export function applyTelemetryMiddleware(app: Hono): void {
+  const telemetry = getTelemetry();
+  if (!telemetry) return;
+
+  app.use("*", async (c, next) => {
+    const spanName = `gateway.${c.req.method.toLowerCase()}_${c.req.path.replace(/\/+/g, "_").replace(/^_|_$/g, "") || "root"}`;
+
+    await withSpan(
+      spanName,
+      async (span) => {
+        span.setAttributes({
+          "http.method": c.req.method,
+          "http.url": c.req.url,
+          "http.path": c.req.path,
+          "http.user_agent": c.req.header("user-agent") || "",
+          "gateway.component": "http_server",
+        });
+
+        await next();
+
+        span.setAttributes({
+          "http.status_code": c.res.status,
+        });
+      },
+      {},
+      SpanKind.SERVER
+    );
+  });
+}

--- a/packages/action-llama/src/gateway/routes/chat.ts
+++ b/packages/action-llama/src/gateway/routes/chat.ts
@@ -1,0 +1,64 @@
+import type { Server } from "http";
+import type { Hono } from "hono";
+import { ChatSessionManager } from "../../chat/session-manager.js";
+import {
+  registerChatApiRoutes,
+  type LaunchChatCallback,
+  type StopChatCallback,
+} from "../../chat/routes.js";
+import { attachChatWebSocket, type ChatWebSocketState } from "../../chat/ws-handler.js";
+import type { ApiKeySource } from "../../control/auth.js";
+import type { SessionStore } from "../../control/session-store.js";
+import type { Logger } from "../../shared/logger.js";
+
+export interface ChatSetup {
+  chatSessionManager: ChatSessionManager;
+}
+
+/**
+ * Create the chat session manager and register chat API routes.
+ * Returns the session manager so it can be passed to `attachChatWebSocketToServer`.
+ */
+export function registerChatRoutes(
+  app: Hono,
+  opts: {
+    maxChatSessions?: number;
+    launchChatContainer?: LaunchChatCallback;
+    stopChatContainer?: StopChatCallback;
+    logger: Logger;
+  },
+): ChatSetup {
+  const { maxChatSessions, launchChatContainer, stopChatContainer, logger } = opts;
+
+  const chatSessionManager = new ChatSessionManager(maxChatSessions);
+
+  const noopLaunch: LaunchChatCallback = async () => {};
+  const noopStop: StopChatCallback = async () => {};
+
+  registerChatApiRoutes(
+    app,
+    chatSessionManager,
+    launchChatContainer || noopLaunch,
+    stopChatContainer || noopStop,
+    logger,
+  );
+
+  return { chatSessionManager };
+}
+
+/**
+ * Attach the chat WebSocket handler to the raw HTTP server.
+ * Must be called after the server is listening.
+ */
+export function attachChatWebSocketToServer(
+  server: Server,
+  opts: {
+    chatSessionManager: ChatSessionManager;
+    apiKey: ApiKeySource;
+    sessionStore?: SessionStore;
+    logger: Logger;
+  },
+): ChatWebSocketState {
+  const { chatSessionManager, apiKey, sessionStore, logger } = opts;
+  return attachChatWebSocket(server, chatSessionManager, apiKey, sessionStore, logger);
+}

--- a/packages/action-llama/src/gateway/routes/dashboard.ts
+++ b/packages/action-llama/src/gateway/routes/dashboard.ts
@@ -1,0 +1,45 @@
+import type { Hono } from "hono";
+import { registerDashboardDataRoutes } from "../../control/routes/dashboard.js";
+import { registerDashboardApiRoutes } from "../../control/routes/dashboard-api.js";
+import { registerLogRoutes } from "../../control/routes/logs.js";
+import { registerStatsRoutes } from "../../control/routes/stats.js";
+import type { StatusTracker } from "../../tui/status-tracker.js";
+import type { ApiKeySource } from "../../control/auth.js";
+import type { StatsStore } from "../../stats/store.js";
+import type { Logger } from "../../shared/logger.js";
+
+/**
+ * Register all dashboard-related routes: SSE data stream, JSON API,
+ * log API, stats API, and the root redirect.
+ *
+ * Requires webUI + statusTracker + apiKey to be active (enforced by caller).
+ */
+export async function registerDashboardRoutes(
+  app: Hono,
+  opts: {
+    statusTracker: StatusTracker;
+    projectPath?: string;
+    apiKey: ApiKeySource;
+    statsStore?: StatsStore;
+    logger: Logger;
+  },
+): Promise<void> {
+  const { statusTracker, projectPath, statsStore } = opts;
+
+  // SSE stream and locks API
+  registerDashboardDataRoutes(app, statusTracker);
+
+  // JSON API routes for the React SPA
+  registerDashboardApiRoutes(app, statusTracker, projectPath, statsStore);
+
+  // Log API routes (only if projectPath is provided)
+  if (projectPath) {
+    registerLogRoutes(app, projectPath);
+  }
+
+  // Stats API routes
+  registerStatsRoutes(app, statsStore, statusTracker);
+
+  // Root redirect to dashboard
+  app.get("/", (c) => c.redirect("/dashboard"));
+}

--- a/packages/action-llama/src/gateway/routes/execution.ts
+++ b/packages/action-llama/src/gateway/routes/execution.ts
@@ -1,0 +1,44 @@
+import type { Hono } from "hono";
+import { registerLockRoutes } from "../../execution/routes/locks.js";
+import { registerCallRoutes, type CallDispatcher } from "../../execution/routes/calls.js";
+import { registerSignalRoutes, type SignalContext } from "../../execution/routes/signals.js";
+import type { ContainerRegistry } from "../../execution/container-registry.js";
+import type { LockStore } from "../../execution/lock-store.js";
+import type { CallStore } from "../../execution/call-store.js";
+import type { Logger } from "../../shared/logger.js";
+import type { StatusTracker } from "../../tui/status-tracker.js";
+import type { SchedulerEventBus } from "../../scheduler/events.js";
+
+/**
+ * Register execution-plane routes: locks, calls, and signals.
+ */
+export function registerExecutionRoutes(
+  app: Hono,
+  opts: {
+    containerRegistry: ContainerRegistry;
+    lockStore: LockStore;
+    callStore: CallStore;
+    callDispatcherProvider: () => CallDispatcher | undefined;
+    logger: Logger;
+    statusTracker?: StatusTracker;
+    signalContext?: SignalContext;
+    skipStatusEndpoint?: boolean;
+    events?: SchedulerEventBus;
+  },
+): void {
+  const {
+    containerRegistry,
+    lockStore,
+    callStore,
+    callDispatcherProvider,
+    logger,
+    statusTracker,
+    signalContext,
+    skipStatusEndpoint,
+    events,
+  } = opts;
+
+  registerLockRoutes(app, containerRegistry, lockStore, logger, { skipStatusEndpoint, events });
+  registerCallRoutes(app, containerRegistry, callStore, callDispatcherProvider, logger, events);
+  registerSignalRoutes(app, containerRegistry, logger, statusTracker, signalContext, events);
+}

--- a/packages/action-llama/src/gateway/routes/system.ts
+++ b/packages/action-llama/src/gateway/routes/system.ts
@@ -1,0 +1,32 @@
+import type { Hono } from "hono";
+import { registerShutdownRoute } from "../../execution/routes/shutdown.js";
+import { registerControlRoutes, type ControlRoutesDeps } from "../../control/routes/control.js";
+import type { ContainerRegistry } from "../../execution/container-registry.js";
+import type { Logger } from "../../shared/logger.js";
+
+/**
+ * Register system-level routes: health check, shutdown, and control routes.
+ */
+export function registerSystemRoutes(
+  app: Hono,
+  opts: {
+    containerRegistry: ContainerRegistry;
+    killContainer?: (name: string) => Promise<void>;
+    logger: Logger;
+    controlDeps?: ControlRoutesDeps;
+  },
+): void {
+  const { containerRegistry, killContainer, logger, controlDeps } = opts;
+
+  // Health check
+  app.get("/health", (c) => c.json({ status: "ok" }));
+
+  // Container shutdown route
+  const killFn = killContainer || (async () => {});
+  registerShutdownRoute(app, containerRegistry, killFn, logger);
+
+  // Control routes (for kill, pause, resume, trigger commands)
+  if (controlDeps) {
+    registerControlRoutes(app, controlDeps);
+  }
+}

--- a/packages/action-llama/src/gateway/routes/webhooks.ts
+++ b/packages/action-llama/src/gateway/routes/webhooks.ts
@@ -1,0 +1,27 @@
+import type { Hono } from "hono";
+import { registerWebhookRoutes } from "../../events/routes/webhooks.js";
+import type { WebhookRegistry } from "../../webhooks/registry.js";
+import type { WebhookSourceConfig } from "../../shared/config.js";
+import type { Logger } from "../../shared/logger.js";
+import type { StatusTracker } from "../../tui/status-tracker.js";
+import type { StatsStore } from "../../stats/store.js";
+
+/**
+ * Register gateway webhook routes, delegating to the events-plane webhook handler.
+ * Named `registerGatewayWebhookRoutes` to avoid ambiguity with the plane-level
+ * `registerWebhookRoutes` from `events/routes/webhooks.ts` that it wraps.
+ */
+export function registerGatewayWebhookRoutes(
+  app: Hono,
+  opts: {
+    webhookRegistry: WebhookRegistry;
+    webhookSecrets: Record<string, Record<string, string>>;
+    webhookConfigs: Record<string, WebhookSourceConfig>;
+    logger: Logger;
+    statusTracker?: StatusTracker;
+    statsStore?: StatsStore;
+  },
+): void {
+  const { webhookRegistry, webhookSecrets, webhookConfigs, logger, statusTracker, statsStore } = opts;
+  registerWebhookRoutes(app, webhookRegistry, webhookSecrets, webhookConfigs, logger, statusTracker, statsStore);
+}

--- a/packages/action-llama/src/gateway/stores.ts
+++ b/packages/action-llama/src/gateway/stores.ts
@@ -1,0 +1,38 @@
+import { ContainerRegistry } from "../execution/container-registry.js";
+import { LockStore } from "../execution/lock-store.js";
+import { CallStore } from "../execution/call-store.js";
+import { SessionStore } from "../control/session-store.js";
+import type { StateStore } from "../shared/state-store.js";
+
+export interface GatewayStores {
+  containerRegistry: ContainerRegistry;
+  lockStore: LockStore;
+  callStore: CallStore;
+  sessionStore: SessionStore | undefined;
+}
+
+/**
+ * Create and hydrate all stores needed by the gateway.
+ * SessionStore is created once here and shared between auth middleware and
+ * the chat WebSocket handler, eliminating the previous duplication.
+ */
+export async function createGatewayStores(opts: {
+  lockTimeout?: number;
+  stateStore?: StateStore;
+}): Promise<GatewayStores> {
+  const { lockTimeout, stateStore } = opts;
+
+  const containerRegistry = new ContainerRegistry(stateStore);
+  const lockStore = new LockStore(lockTimeout, undefined, stateStore, {
+    isHolderAlive: (holder) => containerRegistry.hasInstance(holder),
+  });
+  const callStore = new CallStore(undefined, stateStore);
+  const sessionStore = stateStore ? new SessionStore(stateStore) : undefined;
+
+  // Hydrate in-memory caches from the persistent store.
+  await containerRegistry.init();
+  await lockStore.init();
+  await callStore.init();
+
+  return { containerRegistry, lockStore, callStore, sessionStore };
+}

--- a/packages/action-llama/src/gateway/types.ts
+++ b/packages/action-llama/src/gateway/types.ts
@@ -1,0 +1,69 @@
+import type { Server } from "http";
+import type { CallDispatcher } from "../execution/routes/calls.js";
+import type { SignalContext } from "../execution/routes/signals.js";
+import type { ContainerRegistry } from "../execution/container-registry.js";
+import type { LockStore } from "../execution/lock-store.js";
+import type { CallStore } from "../execution/call-store.js";
+import type { ContainerRegistration } from "../execution/types.js";
+import type { StateStore } from "../shared/state-store.js";
+import type { WebhookRegistry } from "../webhooks/registry.js";
+import type { Logger } from "../shared/logger.js";
+import type { StatusTracker } from "../tui/status-tracker.js";
+import type { WebhookSourceConfig } from "../shared/config.js";
+import type { ControlRoutesDeps } from "../control/routes/control.js";
+import type { ApiKeySource } from "../control/auth.js";
+import type { SchedulerEventBus } from "../scheduler/events.js";
+import type { StatsStore } from "../stats/store.js";
+import type { ChatSessionManager } from "../chat/session-manager.js";
+import type { ChatWebSocketState } from "../chat/ws-handler.js";
+import type { LaunchChatCallback, StopChatCallback } from "../chat/routes.js";
+
+export type { ContainerRegistration } from "../execution/types.js";
+
+// Re-export SignalContext, CallDispatcher for convenience
+export type { SignalContext, CallDispatcher };
+
+export interface GatewayOptions {
+  port: number;
+  hostname?: string;
+  logger: Logger;
+  killContainer?: (name: string) => Promise<void>;
+  webhookRegistry?: WebhookRegistry;
+  webhookSecrets?: Record<string, Record<string, string>>;
+  webhookConfigs?: Record<string, WebhookSourceConfig>;
+  statusTracker?: StatusTracker;
+  projectPath?: string;
+  webUI?: boolean;
+  lockTimeout?: number;
+  signalContext?: SignalContext;
+  controlDeps?: ControlRoutesDeps;
+  /** Static API key string or an async provider that re-reads the key from disk on every auth check, enabling hot-reload of rotated credentials. */
+  apiKey?: ApiKeySource;
+  stateStore?: StateStore;
+  skipStatusEndpoint?: boolean;
+  /** Optional path to the pre-built frontend dist directory (overrides resolveFrontendDist; useful for testing). */
+  frontendDistPath?: string;
+  /** Optional event bus for lifecycle instrumentation. */
+  events?: SchedulerEventBus;
+  /** Optional stats store for dashboard aggregate stats. */
+  statsStore?: StatsStore;
+  /** Max concurrent chat sessions (default: 5). */
+  maxChatSessions?: number;
+  /** Callback to launch a chat container for a session. */
+  launchChatContainer?: LaunchChatCallback;
+  /** Callback to stop a chat container for a session. */
+  stopChatContainer?: StopChatCallback;
+}
+
+export interface GatewayServer {
+  server: Server;
+  containerRegistry: ContainerRegistry;
+  registerContainer: (secret: string, reg: ContainerRegistration) => Promise<void>;
+  unregisterContainer: (secret: string) => Promise<void>;
+  lockStore: LockStore;
+  callStore: CallStore;
+  setCallDispatcher: (dispatcher: CallDispatcher) => void;
+  close: () => Promise<void>;
+  chatSessionManager?: ChatSessionManager;
+  chatWebSocketState?: ChatWebSocketState;
+}


### PR DESCRIPTION
Closes #402

## Summary

Refactors `gateway/index.ts` from a 371-line monolithic file into a thin composition root (~150 lines) that imports focused sub-modules.

## New files

- `src/gateway/types.ts` — `GatewayOptions`, `GatewayServer` interfaces
- `src/gateway/stores.ts` — store creation + hydration (ContainerRegistry, LockStore, CallStore, SessionStore)
- `src/gateway/middleware/telemetry.ts` — OpenTelemetry HTTP span middleware
- `src/gateway/middleware/request-logging.ts` — request/response logging middleware
- `src/gateway/middleware/auth.ts` — auth middleware wiring (unified path protection + auth API routes)
- `src/gateway/routes/system.ts` — health check + shutdown + control routes
- `src/gateway/routes/execution.ts` — lock, call, and signal routes
- `src/gateway/routes/webhooks.ts` — webhook route registration
- `src/gateway/routes/dashboard.ts` — dashboard data/API + log API + stats API routes
- `src/gateway/routes/chat.ts` — chat session manager + API routes + WebSocket attachment
- `src/gateway/frontend.ts` — `resolveFrontendDist()`, SPA fallback routes + asset serving

## Key improvements

- **SessionStore created once** (was duplicated 3× across auth, chat auth, and chat WS) 
- **`resolveFrontendDist()` called once** (was called twice for dashboard + chat separately)
- **`index.html` read once** (was read twice previously)
- **All SPA routes in one place** (`frontend.ts`) instead of scattered across dashboard and chat blocks
- **Auth path list unified** — `/api/chat/*` protection moved from chat block into `middleware/auth.ts`

## No external API changes

All public exports (`startGateway`, `GatewayOptions`, `GatewayServer`, `resolveFrontendDist`, `ContainerRegistration`) are re-exported from `gateway/index.ts` — no consumer changes needed.

## Tests

All 3804 unit tests pass.