### PR TITLE
feat: add explicit jobs queue with pending counts and trigger detail pages

### DIFF
--- a/.changeset/jobs-queue-explicit.md
+++ b/.changeset/jobs-queue-explicit.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Add explicit Jobs queue to the dashboard. Replaces "Recent Triggers" on agent detail pages with a "Jobs" section showing pending, running, and completed jobs. Adds a new /jobs page with agent filtering and pagination. Adds a trigger detail page at /dashboard/triggers/:instanceId with type-specific info (webhook headers/body, agent caller chain, manual prompt, schedule time). Persists trigger context (prompt for manual triggers, context for agent triggers) in the runs table for traceability. Wires up pending job counts from the work queue to the UI. Closes #408.

--- a/packages/action-llama/drizzle/0001_add_trigger_context.sql
+++ b/packages/action-llama/drizzle/0001_add_trigger_context.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `runs` ADD `trigger_context` text;

--- a/packages/action-llama/drizzle/meta/_journal.json
+++ b/packages/action-llama/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1774901334467,
       "tag": "0000_married_shockwave",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1774906200000,
+      "tag": "0001_add_trigger_context",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/action-llama/src/control/routes/dashboard-api.ts
+++ b/packages/action-llama/src/control/routes/dashboard-api.ts
@@ -176,6 +176,53 @@ export function registerDashboardApiRoutes(
     }
   });
 
+  // Trigger detail by instance ID (unified across all trigger types)
+  app.get("/api/dashboard/triggers/:instanceId", (c) => {
+    const instanceId = c.req.param("instanceId");
+    if (!statsStore) return c.json({ trigger: null }, 404);
+
+    const run = statsStore.queryRunByInstanceId(instanceId);
+    if (!run) return c.json({ trigger: null }, 404);
+
+    const result: Record<string, unknown> = {
+      instanceId: run.instance_id,
+      agentName: run.agent_name,
+      triggerType: run.trigger_type,
+      triggerSource: run.trigger_source ?? null,
+      triggerContext: run.trigger_context ?? null,
+      startedAt: run.started_at,
+    };
+
+    // Enrich with type-specific details
+    if (run.trigger_type === "webhook" && run.webhook_receipt_id) {
+      const receipt = statsStore.getWebhookReceipt(run.webhook_receipt_id);
+      if (receipt) {
+        result.webhook = {
+          receiptId: receipt.id,
+          source: receipt.source,
+          eventSummary: receipt.eventSummary ?? null,
+          deliveryId: receipt.deliveryId ?? null,
+          timestamp: receipt.timestamp,
+          headers: receipt.headers ?? null,
+          body: receipt.body ?? null,
+          matchedAgents: receipt.matchedAgents,
+          status: receipt.status,
+        };
+      }
+    }
+
+    if (run.trigger_type === "agent") {
+      const edge = statsStore.queryCallEdgeByTargetInstance(instanceId);
+      if (edge) {
+        result.callerAgent = edge.caller_agent;
+        result.callerInstance = edge.caller_instance;
+        result.callDepth = edge.depth;
+      }
+    }
+
+    return c.json({ trigger: result });
+  });
+
   // Project config
   app.get("/api/dashboard/config", (c) => {
     const info = statusTracker.getSchedulerInfo();

--- a/packages/action-llama/src/control/routes/stats.ts
+++ b/packages/action-llama/src/control/routes/stats.ts
@@ -70,6 +70,63 @@ export function registerStatsRoutes(app: Hono, statsStore?: StatsStore, statusTr
     return c.json({ triggers: mergedTriggers, total: mergedTotal, limit, offset });
   });
 
+  // Paginated jobs (pending + running + completed, no dead letters)
+  app.get("/api/stats/jobs", (c) => {
+    const limit = Math.min(100, Math.max(1, parseInt(c.req.query("limit") || "50", 10) || 50));
+    const offset = Math.max(0, parseInt(c.req.query("offset") || "0", 10) || 0);
+    const since = parseInt(c.req.query("since") || "0", 10) || 0;
+    const agentFilter = c.req.query("agent") || undefined;
+
+    // Completed/errored jobs from runs table (no dead letters — dead letters aren't jobs)
+    const runs = statsStore
+      ? statsStore.queryTriggerHistory({ since, limit, offset, includeDeadLetters: false, agentName: agentFilter })
+      : [];
+    const total = statsStore ? statsStore.countTriggerHistory(since, false, agentFilter) : 0;
+
+    // Running instances (only on first page)
+    let mergedJobs = runs;
+    let mergedTotal = total;
+    if (statusTracker && offset === 0) {
+      const running = statusTracker.getInstances()
+        .filter((inst) => {
+          if (inst.status !== "running") return false;
+          if (agentFilter && inst.agentName !== agentFilter) return false;
+          return true;
+        })
+        .map((inst) => {
+          const sep = inst.trigger.indexOf(":");
+          return {
+            ts: new Date(inst.startedAt).getTime(),
+            triggerType: sep > -1 ? inst.trigger.slice(0, sep) : inst.trigger,
+            triggerSource: sep > -1 ? inst.trigger.slice(sep + 1).trim() : null,
+            agentName: inst.agentName,
+            instanceId: inst.id,
+            result: "running",
+            webhookReceiptId: null,
+            deadLetterReason: null,
+          };
+        });
+      const runningIds = new Set(runs.map((r: any) => r.instanceId));
+      const uniqueRunning = running.filter((r) => !runningIds.has(r.instanceId));
+      mergedJobs = [...uniqueRunning, ...runs].sort((a: any, b: any) => b.ts - a.ts);
+      mergedTotal = total + uniqueRunning.length;
+    }
+
+    // Pending counts per agent
+    const agents = statusTracker ? statusTracker.getAllAgents() : [];
+    const pending: Record<string, number> = {};
+    for (const a of agents) {
+      if (a.queuedWebhooks > 0) {
+        if (!agentFilter || a.name === agentFilter) {
+          pending[a.name] = a.queuedWebhooks;
+        }
+      }
+    }
+    const totalPending = Object.values(pending).reduce((s, n) => s + n, 0);
+
+    return c.json({ jobs: mergedJobs, total: mergedTotal, pending, totalPending, limit, offset });
+  });
+
   // Single webhook receipt by ID
   app.get("/api/stats/webhooks/:receiptId", (c) => {
     const receiptId = c.req.param("receiptId");

--- a/packages/action-llama/src/db/schema.ts
+++ b/packages/action-llama/src/db/schema.ts
@@ -67,6 +67,7 @@ export const runsTable = sqliteTable(
     preHookMs: integer("pre_hook_ms"),
     postHookMs: integer("post_hook_ms"),
     webhookReceiptId: text("webhook_receipt_id"),
+    triggerContext: text("trigger_context"),
   },
   (t) => [
     index("idx_runs_agent").on(t.agentName, t.startedAt),

--- a/packages/action-llama/src/execution/execution.ts
+++ b/packages/action-llama/src/execution/execution.ts
@@ -79,7 +79,7 @@ export function makeTriggeredPrompt(agentConfig: AgentConfig, sourceAgent: strin
 /** Run a single agent and dispatch any resulting triggers. */
 export async function executeRun(
   runner: PoolRunner, prompt: string,
-  triggerInfo: { type: 'schedule' | 'manual' | 'webhook' | 'agent'; source?: string; receiptId?: string },
+  triggerInfo: { type: 'schedule' | 'manual' | 'webhook' | 'agent'; source?: string; receiptId?: string; context?: string },
   agentName: string, depth: number, ctx: SchedulerContext,
   instanceLifecycle?: InstanceLifecycle,
   instanceId?: string
@@ -149,6 +149,7 @@ export async function executeRun(
         preHookMs: outcome.preHookMs,
         postHookMs: outcome.postHookMs,
         webhookReceiptId: triggerInfo.receiptId,
+        triggerContext: triggerInfo.context,
       });
     } catch (err) {
       ctx.logger.warn({ err, agent: agentName }, "failed to record run stats");
@@ -203,12 +204,14 @@ export function dispatchTriggers(
 
     if (ctx.isAgentEnabled && !ctx.isAgentEnabled(agent)) {
       ctx.workQueue.enqueue(agent, { type: 'agent-trigger', sourceAgent, context, depth });
+      ctx.statusTracker?.setQueuedWebhooks(agent, ctx.workQueue.size(agent));
       ctx.logger.info({ source: sourceAgent, target: agent }, "target agent is paused, trigger queued");
       continue;
     }
     const runner = pool.getAvailableRunner();
     if (!runner) {
       ctx.workQueue.enqueue(agent, { type: 'agent-trigger', sourceAgent, context, depth });
+      ctx.statusTracker?.setQueuedWebhooks(agent, ctx.workQueue.size(agent));
       ctx.logger.info({ source: sourceAgent, target: agent }, "all runners busy, trigger queued");
       continue;
     }
@@ -221,7 +224,7 @@ export function dispatchTriggers(
       ctx.statusTracker.createInstance(runner.instanceId, agent, `agent:${sourceAgent}`) || undefined :
       undefined;
     
-    executeRun(runner, prompt, { type: 'agent', source: sourceAgent }, agent, depth + 1, ctx, instanceLifecycle)
+    executeRun(runner, prompt, { type: 'agent', source: sourceAgent, context }, agent, depth + 1, ctx, instanceLifecycle)
       .then((outcome) => {
         if (callEdgeId != null && ctx.statsStore) {
           try {
@@ -261,6 +264,8 @@ export async function drainQueues(ctx: SchedulerContext): Promise<void> {
       if (!item) break;
       fireQueuedItem(item, runner, agentConfig, ctx);
     }
+    // Update pending count after draining
+    ctx.statusTracker?.setQueuedWebhooks(agentConfig.name, ctx.workQueue.size(agentConfig.name));
   }
 }
 
@@ -295,7 +300,7 @@ function fireQueuedItem(
     
     const prompt = makeTriggeredPrompt(agentConfig, work.sourceAgent, work.context, ctx);
     if (work.callId) ctx.callStore?.setRunning(work.callId);
-    executeRun(runner, prompt, { type: 'agent', source: work.sourceAgent }, agentConfig.name, work.depth + 1, ctx, instanceLifecycle)
+    executeRun(runner, prompt, { type: 'agent', source: work.sourceAgent, context: work.context }, agentConfig.name, work.depth + 1, ctx, instanceLifecycle)
       .then(({ result, returnValue }) => {
         if (work.callId) {
           if (result === "completed" || result === "rerun") ctx.callStore?.complete(work.callId, returnValue);
@@ -338,7 +343,7 @@ export async function runWithReruns(
     : makeScheduledPrompt(agentConfig, ctx);
 
   let { result } = await executeRun(
-    runner, initialPrompt, { type: triggerType, source: prompt ? 'user-prompt' : undefined }, agentConfig.name, depth, ctx, instanceLifecycle, instanceId
+    runner, initialPrompt, { type: triggerType, source: prompt ? 'user-prompt' : undefined, context: prompt }, agentConfig.name, depth, ctx, instanceLifecycle, instanceId
   );
 
   let reruns = 0;

--- a/packages/action-llama/src/gateway/frontend.ts
+++ b/packages/action-llama/src/gateway/frontend.ts
@@ -78,6 +78,7 @@ export function registerSpaRoutes(app: Hono, frontendDist: string, logger: Logge
   app.get("/dashboard", (c) => c.html(indexHtml));
   app.get("/dashboard/*", (c) => c.html(indexHtml));
   app.get("/triggers", (c) => c.html(indexHtml));
+  app.get("/jobs", (c) => c.html(indexHtml));
   app.get("/chat", (c) => c.html(indexHtml));
   app.get("/chat/*", (c) => c.html(indexHtml));
 }

--- a/packages/action-llama/src/scheduler/index.ts
+++ b/packages/action-llama/src/scheduler/index.ts
@@ -92,6 +92,7 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
           if (!pool || !state.schedulerCtx) {
             // Pools or scheduler not ready yet (still building) — queue for later
             const { dropped } = workQueue.enqueue(config.name, { type: 'webhook', context });
+            statusTracker?.setQueuedWebhooks(config.name, workQueue.size(config.name));
             logger.info({ agent: config.name, event: context.event, queueSize: workQueue.size(config.name) }, "webhook queued (agents building)");
             if (dropped) logger.warn({ agent: config.name }, "queue full, oldest event dropped");
             return true;
@@ -99,6 +100,7 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
           const runner = pool.getAvailableRunner();
           if (!runner) {
             const { dropped } = workQueue.enqueue(config.name, { type: 'webhook', context });
+            statusTracker?.setQueuedWebhooks(config.name, workQueue.size(config.name));
             logger.info({ agent: config.name, event: context.event, queueSize: workQueue.size(config.name) }, "webhook queued");
             if (dropped) logger.warn({ agent: config.name }, "queue full, oldest event dropped");
             return true;
@@ -196,6 +198,7 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
       const availableRunner = pool.getAvailableRunner();
       if (!availableRunner) {
         const { dropped } = schedulerCtx.workQueue.enqueue(agentConfig.name, { type: 'schedule' });
+        schedulerCtx.statusTracker?.setQueuedWebhooks(agentConfig.name, schedulerCtx.workQueue.size(agentConfig.name));
         logger.info({ agent: agentConfig.name, running: pool.runningJobCount, scale: pool.size }, "all runners busy, scheduled run queued");
         if (dropped) logger.warn({ agent: agentConfig.name }, "queue full, oldest event dropped");
         return;

--- a/packages/action-llama/src/stats/store.ts
+++ b/packages/action-llama/src/stats/store.ts
@@ -24,6 +24,7 @@ export interface RunRecord {
   preHookMs?: number;
   postHookMs?: number;
   webhookReceiptId?: string;
+  triggerContext?: string;
 }
 
 export interface WebhookReceipt {
@@ -130,6 +131,7 @@ export class StatsStore {
       preHookMs: run.preHookMs ?? null,
       postHookMs: run.postHookMs ?? null,
       webhookReceiptId: run.webhookReceiptId ?? null,
+      triggerContext: run.triggerContext ?? null,
     }).run();
   }
 

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -5,6 +5,8 @@ import { DashboardPage } from "./pages/DashboardPage";
 import { AgentDetailPage } from "./pages/AgentDetailPage";
 import { InstanceDetailPage } from "./pages/InstanceDetailPage";
 import { TriggerHistoryPage } from "./pages/TriggerHistoryPage";
+import { JobsPage } from "./pages/JobsPage";
+import { TriggerDetailPage } from "./pages/TriggerDetailPage";
 import { ProjectConfigPage } from "./pages/ProjectConfigPage";
 import { AgentSkillPage } from "./pages/AgentSkillPage";
 import { ChatPage } from "./pages/ChatPage";
@@ -38,6 +40,8 @@ export function App() {
         />
         <Route path="/dashboard/triggers" element={<Navigate to="/triggers" replace />} />
         <Route path="/triggers" element={<TriggerHistoryPage />} />
+        <Route path="/jobs" element={<JobsPage />} />
+        <Route path="/dashboard/triggers/:instanceId" element={<TriggerDetailPage />} />
         <Route path="/dashboard/webhooks/:receiptId" element={<WebhookReceiptPage />} />
         <Route path="/dashboard/config" element={<ProjectConfigPage />} />
       </Route>

--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -33,6 +33,7 @@ function Navbar() {
 
   const isSettings = location.pathname === "/dashboard/config";
   const isTriggers = location.pathname === "/triggers";
+  const isJobs = location.pathname === "/jobs";
 
   return (
     <header className="border-b border-slate-200 dark:border-slate-800 px-4 sm:px-6 py-3">
@@ -56,6 +57,19 @@ function Navbar() {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
             </svg>
             Triggers
+          </Link>
+          <Link
+            to="/jobs"
+            className={`flex items-center gap-1.5 text-sm transition-colors ${
+              isJobs
+                ? "text-blue-600 dark:text-blue-400"
+                : "text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
+            }`}
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+            </svg>
+            Jobs
           </Link>
           <Link
             to="/dashboard/config"

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -116,6 +116,40 @@ export interface TriggerHistoryRow {
   deadLetterReason?: string | null;
 }
 
+export interface JobRow {
+  ts: number;
+  triggerType: string;
+  triggerSource?: string | null;
+  agentName?: string | null;
+  instanceId?: string | null;
+  result: string;
+  webhookReceiptId?: string | null;
+  deadLetterReason?: string | null;
+}
+
+export interface TriggerDetailData {
+  instanceId: string;
+  agentName: string;
+  triggerType: string;
+  triggerSource?: string | null;
+  triggerContext?: string | null;
+  startedAt: number;
+  webhook?: {
+    receiptId: string;
+    source: string;
+    eventSummary?: string | null;
+    deliveryId?: string | null;
+    timestamp: number;
+    headers?: string | null;
+    body?: string | null;
+    matchedAgents: number;
+    status: string;
+  };
+  callerAgent?: string;
+  callerInstance?: string;
+  callDepth?: number;
+}
+
 export interface WebhookReceiptDetail {
   id: string;
   deliveryId?: string;
@@ -257,6 +291,20 @@ export function getTriggerHistory(
   if (agent) url += `&agent=${encodeURIComponent(agent)}`;
   if (triggerType) url += `&triggerType=${encodeURIComponent(triggerType)}`;
   return fetchJSON(url);
+}
+
+export function getJobs(
+  limit: number,
+  offset: number,
+  agent?: string,
+): Promise<{ jobs: JobRow[]; total: number; pending: Record<string, number>; totalPending: number }> {
+  let url = `/api/stats/jobs?limit=${limit}&offset=${offset}`;
+  if (agent) url += `&agent=${encodeURIComponent(agent)}`;
+  return fetchJSON(url);
+}
+
+export function getTriggerDetail(instanceId: string): Promise<{ trigger: TriggerDetailData | null }> {
+  return fetchJSON(`/api/dashboard/triggers/${encodeURIComponent(instanceId)}`);
 }
 
 export function getInstanceDetail(

--- a/packages/frontend/src/pages/AgentDetailPage.tsx
+++ b/packages/frontend/src/pages/AgentDetailPage.tsx
@@ -7,7 +7,7 @@ import { StateBadge, TriggerTypeBadge, ResultBadge } from "../components/Badge";
 import {
   getAgentDetail,
   getAgentLogs,
-  getTriggerHistory,
+  getJobs,
   triggerAgent,
   killAgentInstances,
   killInstance,
@@ -17,7 +17,7 @@ import {
 } from "../lib/api";
 import type {
   AgentDetailData,
-  TriggerHistoryRow,
+  JobRow,
   LogEntry,
   AgentInstance,
 } from "../lib/api";
@@ -63,8 +63,9 @@ export function AgentDetailPage() {
   const { agents, instances } = useStatusStream();
   const agentNames = agents.map((a) => a.name);
   const [detail, setDetail] = useState<AgentDetailData | null>(null);
-  const [triggers, setTriggers] = useState<TriggerHistoryRow[]>([]);
-  const [triggersTotal, setTriggersTotal] = useState(0);
+  const [jobs, setJobs] = useState<JobRow[]>([]);
+  const [jobsTotal, setJobsTotal] = useState(0);
+  const [jobsPending, setJobsPending] = useState(0);
   const [triggersOffset, setTriggersOffset] = useState(0);
   const triggersLimit = 5;
   const [logs, setLogs] = useState<LogEntry[]>([]);
@@ -96,23 +97,24 @@ export function AgentDetailPage() {
     refetchDetail();
   }, [refetchDetail]);
 
-  // Load triggers
-  const refetchTriggers = useCallback(() => {
+  // Load jobs
+  const refetchJobs = useCallback(() => {
     if (!name) return;
-    getTriggerHistory(triggersLimit, triggersOffset, false, name)
+    getJobs(triggersLimit, triggersOffset, name)
       .then((d) => {
-        setTriggers(d.triggers);
-        setTriggersTotal(d.total);
+        setJobs(d.jobs);
+        setJobsTotal(d.total);
+        setJobsPending(d.totalPending);
       })
       .catch(() => {});
   }, [name, triggersOffset]);
 
   useEffect(() => {
-    refetchTriggers();
-  }, [refetchTriggers]);
+    refetchJobs();
+  }, [refetchJobs]);
 
   useInvalidation("stats", name, refetchDetail);
-  useInvalidation("triggers", name, refetchTriggers);
+  useInvalidation("runs", name, refetchJobs);
 
   // Poll logs
   useEffect(() => {
@@ -165,8 +167,36 @@ export function AgentDetailPage() {
   if (!name) return null;
 
   const summary = detail?.summary;
+
+  // Merge running instances into jobs list for the agent detail page
+  const mergedJobs: JobRow[] = triggersOffset === 0
+    ? (() => {
+        const running: JobRow[] = liveInstances.map((inst) => {
+          const sep = inst.trigger.indexOf(":");
+          return {
+            ts: new Date(inst.startedAt).getTime(),
+            triggerType: sep > -1 ? inst.trigger.slice(0, sep) : inst.trigger,
+            triggerSource: sep > -1 ? inst.trigger.slice(sep + 1).trim() : null,
+            agentName: inst.agentName,
+            instanceId: inst.id,
+            result: "running",
+            webhookReceiptId: null,
+            deadLetterReason: null,
+          };
+        });
+        const jobIds = new Set(jobs.map((j) => j.instanceId));
+        const unique = running.filter((r) => !jobIds.has(r.instanceId));
+        return [...unique, ...jobs].sort((a, b) => b.ts - a.ts);
+      })()
+    : jobs;
+
+  const runningOnPage = triggersOffset === 0 ? liveInstances.length : 0;
+  const adjustedJobsTotal = jobsTotal + runningOnPage;
   const triggersPage = Math.floor(triggersOffset / triggersLimit) + 1;
-  const triggersTotalPages = Math.max(1, Math.ceil(triggersTotal / triggersLimit));
+  const triggersTotalPages = Math.max(1, Math.ceil(adjustedJobsTotal / triggersLimit));
+
+  // Use live pending count from SSE stream if available
+  const livePending = agent?.queuedWebhooks ?? jobsPending;
 
   return (
     <div className="space-y-6">
@@ -338,14 +368,21 @@ export function AgentDetailPage() {
         </div>
       )}
 
-      {/* Recent Triggers */}
+      {/* Jobs */}
       <div className="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden">
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-slate-200 dark:border-slate-800">
-          <h2 className="text-sm font-medium text-slate-900 dark:text-white">
-            Recent Triggers
-          </h2>
+          <div className="flex items-center gap-2">
+            <h2 className="text-sm font-medium text-slate-900 dark:text-white">
+              Jobs
+            </h2>
+            {livePending > 0 && (
+              <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">
+                {livePending} pending
+              </span>
+            )}
+          </div>
           <Link
-            to={`/triggers?agent=${encodeURIComponent(name)}`}
+            to={`/jobs?agent=${encodeURIComponent(name)}`}
             className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
           >
             View all
@@ -359,10 +396,7 @@ export function AgentDetailPage() {
                   Time
                 </th>
                 <th className="text-left px-4 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide w-[1%] whitespace-nowrap">
-                  Type
-                </th>
-                <th className="text-left px-4 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide w-[1%] whitespace-nowrap">
-                  Source
+                  Trigger
                 </th>
                 <th className="text-left px-4 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">
                   Instance
@@ -373,58 +407,51 @@ export function AgentDetailPage() {
               </tr>
             </thead>
             <tbody>
-              {triggers.map((t, i) => (
+              {mergedJobs.map((j, i) => (
                 <tr
-                  key={`${t.ts}-${i}`}
+                  key={`${j.ts}-${i}`}
                   className="border-b border-slate-100 dark:border-slate-800/50 last:border-0"
                 >
                   <td className="px-4 py-2 text-slate-600 dark:text-slate-400 text-xs whitespace-nowrap">
-                    {fmtRelativeTime(t.ts)}
+                    {fmtRelativeTime(j.ts)}
                   </td>
                   <td className="px-4 py-2 whitespace-nowrap">
-                    <TriggerTypeBadge type={t.triggerType} />
-                  </td>
-                  <td className="px-4 py-2 text-xs text-slate-600 dark:text-slate-400 whitespace-nowrap">
-                    {t.triggerSource ? (
-                      t.triggerType === "agent" ? (
-                        <Link
-                          to={`/dashboard/agents/${encodeURIComponent(t.triggerSource)}`}
-                          className="text-blue-600 dark:text-blue-400 hover:underline"
-                        >
-                          {t.triggerSource}
-                        </Link>
-                      ) : (
-                        t.triggerSource
-                      )
+                    {j.instanceId ? (
+                      <Link
+                        to={`/dashboard/triggers/${encodeURIComponent(j.instanceId)}`}
+                        className="flex items-center gap-1.5 hover:opacity-80"
+                      >
+                        <TriggerTypeBadge type={j.triggerType} />
+                      </Link>
                     ) : (
-                      "\u2014"
+                      <TriggerTypeBadge type={j.triggerType} />
                     )}
                   </td>
                   <td className="px-4 py-2 min-w-0">
-                    {t.instanceId ? (
+                    {j.instanceId ? (
                       <Link
-                        to={`/dashboard/agents/${encodeURIComponent(name)}/instances/${encodeURIComponent(t.instanceId)}`}
+                        to={`/dashboard/agents/${encodeURIComponent(name)}/instances/${encodeURIComponent(j.instanceId)}`}
                         className="font-mono text-xs text-blue-600 dark:text-blue-400 hover:underline truncate block"
-                        title={t.instanceId}
+                        title={j.instanceId}
                       >
-                        {t.instanceId}
+                        {shortId(j.instanceId)}
                       </Link>
                     ) : (
                       <span className="text-xs text-slate-400">{"\u2014"}</span>
                     )}
                   </td>
                   <td className="px-4 py-2 whitespace-nowrap">
-                    <ResultBadge result={t.result} deadLetterReason={t.deadLetterReason} />
+                    <ResultBadge result={j.result} deadLetterReason={j.deadLetterReason} />
                   </td>
                 </tr>
               ))}
-              {triggers.length === 0 && (
+              {mergedJobs.length === 0 && (
                 <tr>
                   <td
-                    colSpan={5}
+                    colSpan={4}
                     className="px-4 py-6 text-center text-slate-500 dark:text-slate-400 text-xs"
                   >
-                    No recent triggers
+                    No jobs yet
                   </td>
                 </tr>
               )}
@@ -445,7 +472,7 @@ export function AgentDetailPage() {
             </span>
             <button
               onClick={() => setTriggersOffset((o) => o + triggersLimit)}
-              disabled={triggersOffset + triggersLimit >= triggersTotal}
+              disabled={triggersOffset + triggersLimit >= adjustedJobsTotal}
               className="px-3 py-1 text-xs rounded bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700 disabled:opacity-40 transition-colors"
             >
               Next

--- a/packages/frontend/src/pages/JobsPage.tsx
+++ b/packages/frontend/src/pages/JobsPage.tsx
@@ -1,0 +1,270 @@
+import { useEffect, useState, useCallback, useMemo } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { useInvalidation } from "../hooks/useInvalidation";
+import { useStatusStream } from "../hooks/StatusStreamContext";
+import { TriggerTypeBadge, ResultBadge } from "../components/Badge";
+import { getJobs } from "../lib/api";
+import type { JobRow } from "../lib/api";
+import { fmtDateTime, shortId } from "../lib/format";
+import { agentHueStyle } from "../lib/color";
+
+const PAGE_SIZE = 50;
+
+export function JobsPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const agentFilter = searchParams.get("agent") || undefined;
+
+  const [jobs, setJobs] = useState<JobRow[]>([]);
+  const [total, setTotal] = useState(0);
+  const [pending, setPending] = useState<Record<string, number>>({});
+  const [totalPending, setTotalPending] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const { agents, instances } = useStatusStream();
+  const agentNames = agents.map((a) => a.name);
+
+  const setFilter = useCallback(
+    (key: string, value: string | undefined) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        if (value) {
+          next.set(key, value);
+        } else {
+          next.delete(key);
+        }
+        next.delete("offset");
+        return next;
+      });
+    },
+    [setSearchParams],
+  );
+
+  const load = useCallback(
+    (newOffset: number) => {
+      setLoading(true);
+      getJobs(PAGE_SIZE, newOffset, agentFilter)
+        .then((data) => {
+          setJobs(data.jobs);
+          setTotal(data.total);
+          setPending(data.pending);
+          setTotalPending(data.totalPending);
+          setOffset(newOffset);
+        })
+        .catch(() => {})
+        .finally(() => setLoading(false));
+    },
+    [agentFilter],
+  );
+
+  useEffect(() => {
+    load(0);
+  }, [load]);
+
+  const refetchPage = useCallback(() => {
+    load(offset);
+  }, [load, offset]);
+
+  useInvalidation("runs", undefined, refetchPage);
+
+  const mergedJobs = useMemo(() => {
+    // Only include running instances on the first page
+    if (offset > 0) return jobs;
+    const running: JobRow[] = instances
+      .filter((inst) => {
+        if (inst.status !== "running") return false;
+        if (agentFilter && inst.agentName !== agentFilter) return false;
+        return true;
+      })
+      .map((inst) => {
+        const sep = inst.trigger.indexOf(":");
+        return {
+          ts: new Date(inst.startedAt).getTime(),
+          triggerType: sep > -1 ? inst.trigger.slice(0, sep) : inst.trigger,
+          triggerSource: sep > -1 ? inst.trigger.slice(sep + 1).trim() : null,
+          agentName: inst.agentName,
+          instanceId: inst.id,
+          result: "running",
+          webhookReceiptId: null,
+          deadLetterReason: null,
+        };
+      });
+    const apiIds = new Set(jobs.map((j) => j.instanceId));
+    const unique = running.filter((r) => !apiIds.has(r.instanceId));
+    return [...unique, ...jobs].sort((a, b) => b.ts - a.ts);
+  }, [instances, jobs, offset, agentFilter]);
+
+  const runningCount = instances.filter((i) => {
+    if (i.status !== "running") return false;
+    if (agentFilter && i.agentName !== agentFilter) return false;
+    return true;
+  }).length;
+  const adjustedTotal = total + runningCount;
+
+  const page = Math.floor(offset / PAGE_SIZE) + 1;
+  const totalPages = Math.max(1, Math.ceil(adjustedTotal / PAGE_SIZE));
+
+  // Show pending count from SSE stream for more real-time updates
+  const livePendingCount = useMemo(() => {
+    if (!agentFilter) {
+      return agents.reduce((sum, a) => sum + (a.queuedWebhooks || 0), 0);
+    }
+    const a = agents.find((a) => a.name === agentFilter);
+    return a?.queuedWebhooks || 0;
+  }, [agents, agentFilter]);
+
+  const displayPendingCount = livePendingCount > 0 ? livePendingCount : totalPending;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <div className="flex items-center gap-3">
+          <h1 className="text-xl font-bold text-slate-900 dark:text-white">Jobs</h1>
+          {displayPendingCount > 0 && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">
+              {displayPendingCount} pending
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-3 flex-wrap">
+          {/* Agent filter */}
+          <select
+            value={agentFilter || ""}
+            onChange={(e) => setFilter("agent", e.target.value || undefined)}
+            className="text-sm rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-white px-2 py-1"
+          >
+            <option value="">All Agents</option>
+            {agents.map((a) => (
+              <option key={a.name} value={a.name}>
+                {a.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 dark:border-slate-800">
+                <th className="text-left px-4 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">
+                  Time
+                </th>
+                <th className="text-left px-4 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">
+                  Trigger
+                </th>
+                <th className="text-left px-4 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">
+                  Agent
+                </th>
+                <th className="text-left px-4 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">
+                  Status
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {mergedJobs.map((j, i) => (
+                <tr
+                  key={`${j.ts}-${i}`}
+                  className="border-b border-slate-100 dark:border-slate-800/50 last:border-0 hover:bg-slate-100/50 dark:hover:bg-slate-800/30"
+                >
+                  <td className="px-4 py-2.5 text-slate-600 dark:text-slate-400 text-xs whitespace-nowrap">
+                    {fmtDateTime(j.ts)}
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <div className="flex flex-col gap-0.5">
+                      <div className="flex items-center gap-1.5">
+                        <TriggerTypeBadge type={j.triggerType} />
+                        {j.triggerSource && (
+                          <span className="text-xs text-slate-500 dark:text-slate-400 truncate max-w-[160px]">
+                            {j.triggerSource}
+                          </span>
+                        )}
+                      </div>
+                      {j.instanceId && (
+                        <Link
+                          to={`/dashboard/triggers/${encodeURIComponent(j.instanceId)}`}
+                          className="font-mono text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                          title={j.instanceId}
+                        >
+                          {shortId(j.instanceId)}
+                        </Link>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-4 py-2.5">
+                    {j.agentName ? (
+                      <Link
+                        to={j.instanceId
+                          ? `/dashboard/agents/${encodeURIComponent(j.agentName)}/instances/${encodeURIComponent(j.instanceId)}`
+                          : `/dashboard/agents/${encodeURIComponent(j.agentName)}`}
+                        className="hover:underline text-xs flex items-center gap-1.5"
+                      >
+                        <span
+                          className="w-2 h-2 rounded-full shrink-0 agent-color-dot"
+                          style={agentHueStyle(j.agentName, agentNames)}
+                        />
+                        <span className="agent-color-text" style={agentHueStyle(j.agentName, agentNames)}>
+                          {j.agentName}
+                        </span>
+                      </Link>
+                    ) : (
+                      <span className="text-slate-400 text-xs">{"\u2014"}</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <ResultBadge result={j.result} deadLetterReason={j.deadLetterReason} />
+                  </td>
+                </tr>
+              ))}
+              {mergedJobs.length === 0 && !loading && (
+                <tr>
+                  <td
+                    colSpan={4}
+                    className="px-4 py-8 text-center text-slate-500 dark:text-slate-400"
+                  >
+                    No jobs found
+                  </td>
+                </tr>
+              )}
+              {loading && (
+                <tr>
+                  <td
+                    colSpan={4}
+                    className="px-4 py-8 text-center text-slate-500 dark:text-slate-400"
+                  >
+                    Loading...
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-between px-4 py-2.5 border-t border-slate-200 dark:border-slate-800">
+            <button
+              onClick={() => load(Math.max(0, offset - PAGE_SIZE))}
+              disabled={offset === 0}
+              className="px-3 py-1 text-xs rounded bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700 disabled:opacity-40 transition-colors"
+            >
+              Previous
+            </button>
+            <span className="text-xs text-slate-500 dark:text-slate-400">
+              Page {page} of {totalPages} ({adjustedTotal} total)
+            </span>
+            <button
+              onClick={() => load(offset + PAGE_SIZE)}
+              disabled={offset + PAGE_SIZE >= adjustedTotal}
+              className="px-3 py-1 text-xs rounded bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700 disabled:opacity-40 transition-colors"
+            >
+              Next
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/TriggerDetailPage.tsx
+++ b/packages/frontend/src/pages/TriggerDetailPage.tsx
@@ -1,0 +1,345 @@
+import { useEffect, useState, useCallback } from "react";
+import { useParams, Link } from "react-router-dom";
+import { TriggerTypeBadge, ResultBadge } from "../components/Badge";
+import { getTriggerDetail, replayWebhook } from "../lib/api";
+import type { TriggerDetailData } from "../lib/api";
+import { fmtDateTime, shortId } from "../lib/format";
+import { agentHueStyle } from "../lib/color";
+import { useStatusStream } from "../hooks/StatusStreamContext";
+
+function prettyJson(raw: string | null | undefined): string {
+  if (!raw) return "\u2014";
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}
+
+export function TriggerDetailPage() {
+  const { instanceId } = useParams<{ instanceId: string }>();
+  const { agents } = useStatusStream();
+  const agentNames = agents.map((a) => a.name);
+
+  const [trigger, setTrigger] = useState<TriggerDetailData | null | undefined>(undefined);
+  const [replayResult, setReplayResult] = useState<string | null>(null);
+  const [replayError, setReplayError] = useState<string | null>(null);
+  const [replaying, setReplaying] = useState(false);
+
+  useEffect(() => {
+    if (!instanceId) return;
+    getTriggerDetail(instanceId)
+      .then((data) => setTrigger(data.trigger))
+      .catch(() => setTrigger(null));
+  }, [instanceId]);
+
+  const handleReplay = useCallback(async () => {
+    if (!trigger?.webhook?.receiptId) return;
+    setReplayResult(null);
+    setReplayError(null);
+    setReplaying(true);
+    try {
+      const result = await replayWebhook(trigger.webhook.receiptId);
+      setReplayResult(`Replayed: ${result.matched} matched, ${result.skipped} skipped`);
+    } catch (err) {
+      setReplayError(err instanceof Error ? err.message : "Replay failed");
+    } finally {
+      setReplaying(false);
+    }
+  }, [trigger]);
+
+  if (!instanceId) return null;
+
+  if (trigger === undefined) {
+    return (
+      <div className="text-center py-12 text-slate-500 dark:text-slate-400">
+        Loading...
+      </div>
+    );
+  }
+
+  if (trigger === null) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
+          <Link
+            to="/jobs"
+            className="text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+          </Link>
+          <h1 className="text-xl font-bold text-slate-900 dark:text-white">Trigger not found</h1>
+        </div>
+      </div>
+    );
+  }
+
+  const canReplay = !!(trigger.webhook?.receiptId && (trigger.webhook.headers || trigger.webhook.body));
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <div className="flex items-center gap-3">
+          <Link
+            to="/jobs"
+            className="text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+          </Link>
+          <div>
+            <h1 className="text-xl font-bold text-slate-900 dark:text-white font-mono">
+              {shortId(trigger.instanceId)}
+            </h1>
+            <div className="text-xs text-slate-500 dark:text-slate-400">Trigger Detail</div>
+          </div>
+          <TriggerTypeBadge type={trigger.triggerType} />
+        </div>
+        {trigger.triggerType === "webhook" && canReplay && (
+          <div className="flex items-center gap-2">
+            {replayResult && (
+              <span className="text-xs text-green-600 dark:text-green-400">{replayResult}</span>
+            )}
+            {replayError && (
+              <span className="text-xs text-red-600 dark:text-red-400">{replayError}</span>
+            )}
+            <button
+              onClick={handleReplay}
+              disabled={replaying}
+              className="px-3 py-1.5 text-xs font-medium rounded-md bg-blue-600 hover:bg-blue-700 disabled:opacity-40 text-white transition-colors"
+            >
+              {replaying ? "Replaying..." : "Replay"}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Info card */}
+      <div className="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden">
+        <div className="px-4 py-2.5 border-b border-slate-200 dark:border-slate-800">
+          <h2 className="text-sm font-medium text-slate-900 dark:text-white">Overview</h2>
+        </div>
+        <div className="divide-y divide-slate-100 dark:divide-slate-800/50">
+          <div className="px-4 py-3 flex items-center justify-between">
+            <span className="text-xs text-slate-500 dark:text-slate-400">Trigger Type</span>
+            <TriggerTypeBadge type={trigger.triggerType} />
+          </div>
+          <div className="px-4 py-3 flex items-center justify-between">
+            <span className="text-xs text-slate-500 dark:text-slate-400">Agent</span>
+            <Link
+              to={`/dashboard/agents/${encodeURIComponent(trigger.agentName)}`}
+              className="hover:underline text-xs flex items-center gap-1.5"
+            >
+              <span
+                className="w-2 h-2 rounded-full shrink-0 agent-color-dot"
+                style={agentHueStyle(trigger.agentName, agentNames)}
+              />
+              <span className="agent-color-text" style={agentHueStyle(trigger.agentName, agentNames)}>
+                {trigger.agentName}
+              </span>
+            </Link>
+          </div>
+          <div className="px-4 py-3 flex items-center justify-between">
+            <span className="text-xs text-slate-500 dark:text-slate-400">Instance</span>
+            <Link
+              to={`/dashboard/agents/${encodeURIComponent(trigger.agentName)}/instances/${encodeURIComponent(trigger.instanceId)}`}
+              className="font-mono text-xs text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              {shortId(trigger.instanceId)}
+            </Link>
+          </div>
+          <div className="px-4 py-3 flex items-center justify-between">
+            <span className="text-xs text-slate-500 dark:text-slate-400">Time</span>
+            <span className="text-xs text-slate-700 dark:text-slate-300">
+              {fmtDateTime(trigger.startedAt)}
+            </span>
+          </div>
+          {trigger.triggerSource && (
+            <div className="px-4 py-3 flex items-center justify-between">
+              <span className="text-xs text-slate-500 dark:text-slate-400">Source</span>
+              <span className="text-xs text-slate-700 dark:text-slate-300">{trigger.triggerSource}</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Webhook details */}
+      {trigger.triggerType === "webhook" && trigger.webhook && (
+        <div className="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden">
+          <div className="px-4 py-2.5 border-b border-slate-200 dark:border-slate-800">
+            <h2 className="text-sm font-medium text-slate-900 dark:text-white">Webhook Details</h2>
+          </div>
+          <div className="divide-y divide-slate-100 dark:divide-slate-800/50">
+            <div className="px-4 py-3 flex items-center justify-between">
+              <span className="text-xs text-slate-500 dark:text-slate-400">Receipt ID</span>
+              <Link
+                to={`/dashboard/webhooks/${encodeURIComponent(trigger.webhook.receiptId)}`}
+                className="font-mono text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                {shortId(trigger.webhook.receiptId)}
+              </Link>
+            </div>
+            <div className="px-4 py-3 flex items-center justify-between">
+              <span className="text-xs text-slate-500 dark:text-slate-400">Source</span>
+              <span className="text-xs text-slate-700 dark:text-slate-300">{trigger.webhook.source}</span>
+            </div>
+            {trigger.webhook.eventSummary && (
+              <div className="px-4 py-3 flex items-center justify-between">
+                <span className="text-xs text-slate-500 dark:text-slate-400">Event</span>
+                <span className="text-xs text-slate-700 dark:text-slate-300">{trigger.webhook.eventSummary}</span>
+              </div>
+            )}
+            {trigger.webhook.deliveryId && (
+              <div className="px-4 py-3 flex items-center justify-between">
+                <span className="text-xs text-slate-500 dark:text-slate-400">Delivery ID</span>
+                <span className="font-mono text-xs text-slate-700 dark:text-slate-300">{trigger.webhook.deliveryId}</span>
+              </div>
+            )}
+            <div className="px-4 py-3 flex items-center justify-between">
+              <span className="text-xs text-slate-500 dark:text-slate-400">Status</span>
+              <ResultBadge result={trigger.webhook.status === "processed" ? "completed" : "dead-letter"} />
+            </div>
+            <div className="px-4 py-3 flex items-center justify-between">
+              <span className="text-xs text-slate-500 dark:text-slate-400">Matched Agents</span>
+              <span className="text-xs text-slate-700 dark:text-slate-300">{trigger.webhook.matchedAgents}</span>
+            </div>
+          </div>
+          {trigger.webhook.headers && (
+            <div className="border-t border-slate-200 dark:border-slate-800">
+              <div className="px-4 py-2.5 border-b border-slate-100 dark:border-slate-800/50">
+                <h3 className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">Headers</h3>
+              </div>
+              <pre className="px-4 py-3 text-xs font-mono text-slate-700 dark:text-slate-300 overflow-x-auto whitespace-pre-wrap break-all">
+                {prettyJson(trigger.webhook.headers)}
+              </pre>
+            </div>
+          )}
+          {trigger.webhook.body && (
+            <div className="border-t border-slate-200 dark:border-slate-800">
+              <div className="px-4 py-2.5 border-b border-slate-100 dark:border-slate-800/50">
+                <h3 className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">Body</h3>
+              </div>
+              <pre className="px-4 py-3 text-xs font-mono text-slate-700 dark:text-slate-300 overflow-x-auto whitespace-pre-wrap break-all">
+                {prettyJson(trigger.webhook.body)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Agent trigger details */}
+      {trigger.triggerType === "agent" && (
+        <div className="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden">
+          <div className="px-4 py-2.5 border-b border-slate-200 dark:border-slate-800">
+            <h2 className="text-sm font-medium text-slate-900 dark:text-white">Agent Trigger Details</h2>
+          </div>
+          <div className="divide-y divide-slate-100 dark:divide-slate-800/50">
+            {trigger.callerAgent ? (
+              <>
+                <div className="px-4 py-3 flex items-center justify-between">
+                  <span className="text-xs text-slate-500 dark:text-slate-400">Called by</span>
+                  <Link
+                    to={`/dashboard/agents/${encodeURIComponent(trigger.callerAgent)}`}
+                    className="hover:underline text-xs flex items-center gap-1.5"
+                  >
+                    <span
+                      className="w-2 h-2 rounded-full shrink-0 agent-color-dot"
+                      style={agentHueStyle(trigger.callerAgent, agentNames)}
+                    />
+                    <span className="agent-color-text" style={agentHueStyle(trigger.callerAgent, agentNames)}>
+                      {trigger.callerAgent}
+                    </span>
+                  </Link>
+                </div>
+                {trigger.callerInstance && (
+                  <div className="px-4 py-3 flex items-center justify-between">
+                    <span className="text-xs text-slate-500 dark:text-slate-400">Caller Instance</span>
+                    <Link
+                      to={`/dashboard/agents/${encodeURIComponent(trigger.callerAgent)}/instances/${encodeURIComponent(trigger.callerInstance)}`}
+                      className="font-mono text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                    >
+                      {shortId(trigger.callerInstance)}
+                    </Link>
+                  </div>
+                )}
+                {trigger.callDepth !== undefined && (
+                  <div className="px-4 py-3 flex items-center justify-between">
+                    <span className="text-xs text-slate-500 dark:text-slate-400">Call Depth</span>
+                    <span className="text-xs text-slate-700 dark:text-slate-300">{trigger.callDepth}</span>
+                  </div>
+                )}
+              </>
+            ) : (
+              <div className="px-4 py-3">
+                <span className="text-xs text-slate-500 dark:text-slate-400">Caller information not available</span>
+              </div>
+            )}
+          </div>
+          {trigger.triggerContext && (
+            <div className="border-t border-slate-200 dark:border-slate-800">
+              <div className="px-4 py-2.5 border-b border-slate-100 dark:border-slate-800/50">
+                <h3 className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">Trigger Context</h3>
+              </div>
+              <pre className="px-4 py-3 text-xs font-mono text-slate-700 dark:text-slate-300 overflow-x-auto whitespace-pre-wrap break-all">
+                {trigger.triggerContext}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Manual trigger details */}
+      {trigger.triggerType === "manual" && (
+        <div className="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden">
+          <div className="px-4 py-2.5 border-b border-slate-200 dark:border-slate-800">
+            <h2 className="text-sm font-medium text-slate-900 dark:text-white">Manual Trigger Details</h2>
+          </div>
+          {trigger.triggerContext ? (
+            <div>
+              <div className="px-4 py-2.5 border-b border-slate-100 dark:border-slate-800/50">
+                <h3 className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">Prompt</h3>
+              </div>
+              <pre className="px-4 py-3 text-xs font-mono text-slate-700 dark:text-slate-300 overflow-x-auto whitespace-pre-wrap break-all">
+                {trigger.triggerContext}
+              </pre>
+            </div>
+          ) : (
+            <div className="px-4 py-3">
+              <span className="text-xs text-slate-500 dark:text-slate-400">
+                Prompt not available (run predates context tracking)
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Schedule trigger details */}
+      {trigger.triggerType === "schedule" && (
+        <div className="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden">
+          <div className="px-4 py-2.5 border-b border-slate-200 dark:border-slate-800">
+            <h2 className="text-sm font-medium text-slate-900 dark:text-white">Schedule Trigger Details</h2>
+          </div>
+          <div className="px-4 py-3">
+            <span className="text-xs text-slate-500 dark:text-slate-400">
+              Scheduled run at {fmtDateTime(trigger.startedAt)}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* Link to instance detail */}
+      <div className="flex justify-end">
+        <Link
+          to={`/dashboard/agents/${encodeURIComponent(trigger.agentName)}/instances/${encodeURIComponent(trigger.instanceId)}`}
+          className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          View run details →
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #408

## Summary

Replaces "Recent Triggers" on agent detail pages with a **Jobs** section and adds a new **/jobs** page to make the job queue explicit and visible.

## Changes

### Backend
- **Schema**: Added `trigger_context` column to `runs` table (nullable, backward compatible) with migration `0001_add_trigger_context.sql`
- **Stats store**: Updated `RunRecord` interface and `recordRun()` to persist trigger context
- **Execution**: Passes prompt as context for manual triggers, agent trigger context for agent-triggered runs
- **Jobs API**: New `GET /api/stats/jobs` endpoint — returns pending+running+completed jobs (no dead letters)
- **Trigger detail API**: New `GET /api/dashboard/triggers/:instanceId` endpoint with type-specific enrichment (webhook receipt data, agent caller chain, manual prompt)
- **Queue wiring**: `setQueuedWebhooks()` now called on every enqueue/dequeue so the pending count stays accurate in the UI
- **SPA fallback**: Added `/jobs` route to the frontend serving middleware

### Frontend
- **JobsPage** (`/jobs`): Full paginated job list with agent filter, pending count badge, Time/Trigger/Agent/Status columns. Agent name links to instance detail page.
- **TriggerDetailPage** (`/dashboard/triggers/:instanceId`): Unified trigger detail page — shows webhook headers/body with replay button, agent caller chain, manual prompt, or schedule info depending on trigger type
- **AgentDetailPage**: "Recent Triggers" section replaced with "Jobs" section — shows pending count badge, links triggers to detail page, "View all" goes to `/jobs?agent=<name>`
- **Layout**: Added "Jobs" nav link between Triggers and Settings
- **App.tsx**: Added `/jobs` and `/dashboard/triggers/:instanceId` routes
- **api.ts**: Added `JobRow`, `TriggerDetailData` types, `getJobs()` and `getTriggerDetail()` functions

## Notes
- Dead letters remain a `/triggers` concern only — they never appear on `/jobs`
- `queuedWebhooks` field on `AgentStatus` is reused for pending job count (was already intended for this but never wired up)
- Old runs before migration won't have `trigger_context` — handled gracefully with fallback message on trigger detail page
- All 3841 unit tests pass