### PR TITLE
Web UI: show full instance ID and add copy button

### DIFF
--- a/.changeset/instance-page-ui-updates.md
+++ b/.changeset/instance-page-ui-updates.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/frontend": patch
+---
+
+Show full instance ID in h1 and add copy-to-clipboard button on instance detail page

--- a/package-lock.json
+++ b/package-lock.json
@@ -13799,7 +13799,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.18.11",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/packages/frontend/src/pages/InstanceDetailPage.tsx
+++ b/packages/frontend/src/pages/InstanceDetailPage.tsx
@@ -52,6 +52,7 @@ export function InstanceDetailPage() {
   >([]);
   const [following, setFollowing] = useState(true);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
   const [connected, setConnected] = useState(false);
   const cursorRef = useRef<string | null>(null);
   const logContainerRef = useRef<HTMLDivElement>(null);
@@ -211,9 +212,30 @@ export function InstanceDetailPage() {
             </svg>
           </Link>
           <div>
-            <h1 className="text-xl font-bold text-slate-900 dark:text-white font-mono">
-              {shortId(id)}
-            </h1>
+            <div className="flex items-center gap-1.5">
+              <h1 className="text-xl font-bold text-slate-900 dark:text-white font-mono break-all">
+                {id}
+              </h1>
+              <button
+                onClick={() => {
+                  navigator.clipboard.writeText(id);
+                  setCopied(true);
+                  setTimeout(() => setCopied(false), 2000);
+                }}
+                className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+                title="Copy instance ID"
+              >
+                {copied ? (
+                  <svg className="w-4 h-4 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                ) : (
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                  </svg>
+                )}
+              </button>
+            </div>
             <div className="text-xs text-slate-500 dark:text-slate-400">
               {name}
             </div>


### PR DESCRIPTION
Closes #414

## Changes

- **Show full instance ID**: Replaced `{shortId(id)}` with `{id}` in the `<h1>` tag on the instance detail page so the complete instance ID is always visible.
- **Copy button**: Added a small clipboard icon button next to the h1 that copies the full instance ID to the clipboard when clicked. The icon changes to a checkmark for 2 seconds to confirm the copy.
- Added `break-all` class to the h1 to gracefully handle long IDs (UUIDs etc.) on narrow screens.
- Added `copied` state variable for clipboard feedback.