### PR TITLE
feat: merge Triggers and Jobs into unified Activity page

### DIFF
--- a/.changeset/unify-activity-page.md
+++ b/.changeset/unify-activity-page.md
@@ -1,0 +1,7 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Merge the Triggers and Jobs pages into a unified Activity page. The new Activity page shows pending queue items, running instances, completed jobs, errors, and dead letters all in one view, sorted by timestamp. A Status filter replaces the dead-letters checkbox, and all existing /triggers and /jobs URLs redirect to /activity. Agent detail pages link to /activity?agent=X.
+
+Also adds a `peek()` method to the WorkQueue interface (MemoryWorkQueue, SqliteWorkQueue, EventSourcedWorkQueue) to expose queued items without consuming them, enabling pending items to appear as rows in the Activity feed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "move-integration-to-e2e",
+  "name": "repo",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -13799,7 +13799,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.19.2",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/packages/action-llama/src/control/routes/control.ts
+++ b/packages/action-llama/src/control/routes/control.ts
@@ -15,7 +15,10 @@ export interface ControlRoutesDeps {
   updateProjectScale?: (scale: number) => Promise<boolean>;
   updateAgentScale?: (name: string, scale: number) => Promise<boolean>;
   logger?: Logger;
-  workQueue?: { size(agentName: string): number };
+  workQueue?: {
+    size(agentName: string): number;
+    peek(agentName: string): { context: unknown; receivedAt: Date }[];
+  };
 }
 
 export function registerControlRoutes(app: Hono, deps: ControlRoutesDeps) {

--- a/packages/action-llama/src/control/routes/stats.ts
+++ b/packages/action-llama/src/control/routes/stats.ts
@@ -2,7 +2,19 @@ import type { Hono } from "hono";
 import type { StatsStore } from "../../stats/store.js";
 import type { StatusTracker } from "../../tui/status-tracker.js";
 
-export function registerStatsRoutes(app: Hono, statsStore?: StatsStore, statusTracker?: StatusTracker): void {
+export interface StatsControlDeps {
+  workQueue?: {
+    size(agentName: string): number;
+    peek(agentName: string): { context: unknown; receivedAt: Date }[];
+  };
+}
+
+export function registerStatsRoutes(
+  app: Hono,
+  statsStore?: StatsStore,
+  statusTracker?: StatusTracker,
+  controlDeps?: StatsControlDeps,
+): void {
   // Paginated runs for an agent
   app.get("/api/stats/agents/:name/runs", (c) => {
     const name = c.req.param("name");
@@ -125,6 +137,116 @@ export function registerStatsRoutes(app: Hono, statsStore?: StatsStore, statusTr
     const totalPending = Object.values(pending).reduce((s, n) => s + n, 0);
 
     return c.json({ jobs: mergedJobs, total: mergedTotal, pending, totalPending, limit, offset });
+  });
+
+  // Unified activity feed — runs + running instances + pending queue items + dead letters
+  app.get("/api/stats/activity", (c) => {
+    const limit = Math.min(100, Math.max(1, parseInt(c.req.query("limit") || "50", 10) || 50));
+    const offset = Math.max(0, parseInt(c.req.query("offset") || "0", 10) || 0);
+    const since = parseInt(c.req.query("since") || "0", 10) || 0;
+    const agentFilter = c.req.query("agent") || undefined;
+    const triggerTypeFilter = c.req.query("triggerType") || undefined;
+    const statusFilter = c.req.query("status") || "all";
+
+    // Base rows from runs table (include dead letters)
+    const rows: any[] = statsStore
+      ? statsStore.queryTriggerHistory({
+          since,
+          limit: 10000, // fetch all then filter/paginate after merge
+          offset: 0,
+          includeDeadLetters: true,
+          agentName: agentFilter,
+          triggerType: triggerTypeFilter,
+        })
+      : [];
+
+    // Merge running instances (avoid duplicates)
+    let allRows: any[] = [...rows];
+    if (statusTracker) {
+      const runningInRows = new Set(rows.map((r: any) => r.instanceId).filter(Boolean));
+      const running = statusTracker
+        .getInstances()
+        .filter((inst) => {
+          if (inst.status !== "running") return false;
+          if (agentFilter && inst.agentName !== agentFilter) return false;
+          if (triggerTypeFilter) {
+            const sep = inst.trigger.indexOf(":");
+            const type = sep > -1 ? inst.trigger.slice(0, sep) : inst.trigger;
+            if (type !== triggerTypeFilter) return false;
+          }
+          return !runningInRows.has(inst.id);
+        })
+        .map((inst) => {
+          const sep = inst.trigger.indexOf(":");
+          return {
+            ts: new Date(inst.startedAt).getTime(),
+            triggerType: sep > -1 ? inst.trigger.slice(0, sep) : inst.trigger,
+            triggerSource: sep > -1 ? inst.trigger.slice(sep + 1).trim() : null,
+            agentName: inst.agentName,
+            instanceId: inst.id,
+            result: "running",
+            webhookReceiptId: null,
+            deadLetterReason: null,
+          };
+        });
+      allRows = [...running, ...allRows];
+    }
+
+    // Merge pending queue items
+    if (controlDeps?.workQueue) {
+      const agents = statusTracker ? statusTracker.getAllAgents() : [];
+      const agentsToCheck = agentFilter
+        ? agents.filter((a) => a.name === agentFilter)
+        : agents;
+      for (const agent of agentsToCheck) {
+        const items = controlDeps.workQueue!.peek(agent.name);
+        for (const item of items) {
+          const ctx = item.context as any;
+          let triggerType = "manual";
+          let triggerSource: string | null = null;
+          if (ctx && typeof ctx === "object") {
+            if (ctx.type === "webhook") {
+              triggerType = "webhook";
+              triggerSource = ctx.source ?? null;
+            } else if (ctx.type === "schedule") {
+              triggerType = "schedule";
+            } else if (ctx.type === "agent-trigger" || ctx.type === "agent") {
+              triggerType = "agent";
+              triggerSource = ctx.callerAgent ?? null;
+            } else if (ctx.type === "manual") {
+              triggerType = "manual";
+            } else if (ctx.type) {
+              triggerType = ctx.type;
+            }
+          }
+          if (triggerTypeFilter && triggerType !== triggerTypeFilter) continue;
+          allRows.push({
+            ts: item.receivedAt.getTime(),
+            triggerType,
+            triggerSource,
+            agentName: agent.name,
+            instanceId: null,
+            result: "pending",
+            webhookReceiptId: null,
+            deadLetterReason: null,
+          });
+        }
+      }
+    }
+
+    // Sort all rows by ts descending
+    allRows.sort((a, b) => b.ts - a.ts);
+
+    // Apply status filter
+    let filtered = allRows;
+    if (statusFilter && statusFilter !== "all") {
+      filtered = allRows.filter((r) => r.result === statusFilter);
+    }
+
+    const total = filtered.length;
+    const paginated = filtered.slice(offset, offset + limit);
+
+    return c.json({ rows: paginated, total, limit, offset });
   });
 
   // Single webhook receipt by ID

--- a/packages/action-llama/src/events/event-queue-sqlite.ts
+++ b/packages/action-llama/src/events/event-queue-sqlite.ts
@@ -114,6 +114,22 @@ export class SqliteWorkQueue<T> implements WorkQueue<T> {
     };
   }
 
+  peek(agentName: string, limit?: number): QueuedWorkItem<T>[] {
+    const client = (this.db as any).$client;
+    const sql =
+      limit !== undefined
+        ? "SELECT payload, received_at FROM work_queue WHERE agent = ? ORDER BY rowid ASC LIMIT ?"
+        : "SELECT payload, received_at FROM work_queue WHERE agent = ? ORDER BY rowid ASC";
+    const rows: { payload: string; received_at: number }[] =
+      limit !== undefined
+        ? client.prepare(sql).all(agentName, limit)
+        : client.prepare(sql).all(agentName);
+    return rows.map((r) => ({
+      context: JSON.parse(r.payload) as T,
+      receivedAt: new Date(r.received_at),
+    }));
+  }
+
   size(agentName: string): number {
     const row = (this.db as any).$client
       .prepare("SELECT COUNT(*) AS n FROM work_queue WHERE agent = ?")

--- a/packages/action-llama/src/events/event-queue-unified.ts
+++ b/packages/action-llama/src/events/event-queue-unified.ts
@@ -157,6 +157,15 @@ export class EventSourcedWorkQueue<T> implements WorkQueue<T> {
     );
   }
 
+  peek(agentName: string, limit?: number): QueuedWorkItem<T>[] {
+    const state = this.queueState.get(agentName);
+    if (!state) return [];
+    const all = state.getAllItems()
+      .sort((a, b) => a.order - b.order)
+      .map((i) => i.item);
+    return limit !== undefined ? all.slice(0, limit) : all;
+  }
+
   size(agentName: string): number {
     const state = this.queueState.get(agentName);
     return state ? state.size() : 0;

--- a/packages/action-llama/src/events/event-queue.ts
+++ b/packages/action-llama/src/events/event-queue.ts
@@ -35,6 +35,12 @@ export class MemoryWorkQueue<T> implements WorkQueue<T> {
     return queue.shift();
   }
 
+  peek(agentName: string, limit?: number): QueuedWorkItem<T>[] {
+    const queue = this.queues.get(agentName);
+    if (!queue || queue.length === 0) return [];
+    return limit !== undefined ? queue.slice(0, limit) : [...queue];
+  }
+
   size(agentName: string): number {
     return this.queues.get(agentName)?.length ?? 0;
   }

--- a/packages/action-llama/src/gateway/index.ts
+++ b/packages/action-llama/src/gateway/index.ts
@@ -85,6 +85,7 @@ export async function startGateway(opts: GatewayOptions): Promise<GatewayServer>
         apiKey: opts.apiKey,
         statsStore: opts.statsStore,
         logger: opts.logger,
+        controlDeps: opts.controlDeps,
       });
     }
   } else if (opts.projectPath && opts.apiKey) {

--- a/packages/action-llama/src/gateway/routes/dashboard.ts
+++ b/packages/action-llama/src/gateway/routes/dashboard.ts
@@ -7,6 +7,7 @@ import type { StatusTracker } from "../../tui/status-tracker.js";
 import type { ApiKeySource } from "../../control/auth.js";
 import type { StatsStore } from "../../stats/store.js";
 import type { Logger } from "../../shared/logger.js";
+import type { StatsControlDeps } from "../../control/routes/stats.js";
 
 /**
  * Register all dashboard-related routes: SSE data stream, JSON API,
@@ -22,6 +23,7 @@ export async function registerDashboardRoutes(
     apiKey: ApiKeySource;
     statsStore?: StatsStore;
     logger: Logger;
+    controlDeps?: StatsControlDeps;
   },
 ): Promise<void> {
   const { statusTracker, projectPath, statsStore } = opts;
@@ -38,7 +40,7 @@ export async function registerDashboardRoutes(
   }
 
   // Stats API routes
-  registerStatsRoutes(app, statsStore, statusTracker);
+  registerStatsRoutes(app, statsStore, statusTracker, opts.controlDeps);
 
   // Root redirect to dashboard
   app.get("/", (c) => c.redirect("/dashboard"));

--- a/packages/action-llama/src/scheduler/gateway-setup.ts
+++ b/packages/action-llama/src/scheduler/gateway-setup.ts
@@ -222,6 +222,7 @@ export async function setupGateway(opts: {
       },
       workQueue: {
         size: (agentName: string) => state.schedulerCtx?.workQueue.size(agentName) ?? 0,
+        peek: (agentName: string) => state.schedulerCtx?.workQueue.peek(agentName) ?? [],
       },
     },
   });

--- a/packages/action-llama/src/shared/work-queue.ts
+++ b/packages/action-llama/src/shared/work-queue.ts
@@ -11,6 +11,8 @@ export interface EnqueueResult<T> {
 export interface WorkQueue<T> {
   enqueue(agentName: string, context: T, receivedAt?: Date): EnqueueResult<T>;
   dequeue(agentName: string): QueuedWorkItem<T> | undefined;
+  /** Return queued items for an agent without removing them (FIFO order). */
+  peek(agentName: string, limit?: number): QueuedWorkItem<T>[];
   size(agentName: string): number;
   clear(agentName: string): void;
   clearAll(): void;

--- a/packages/action-llama/test/control/routes/stats.test.ts
+++ b/packages/action-llama/test/control/routes/stats.test.ts
@@ -21,9 +21,9 @@ function mockStatusTracker(instances: any[] = [], agents: any[] = []) {
   } as any;
 }
 
-function createApp(statsStore?: any, statusTracker?: any) {
+function createApp(statsStore?: any, statusTracker?: any, controlDeps?: any) {
   const app = new Hono();
-  registerStatsRoutes(app, statsStore, statusTracker);
+  registerStatsRoutes(app, statsStore, statusTracker, controlDeps);
   return app;
 }
 
@@ -496,6 +496,182 @@ describe("stats routes", () => {
       expect(stats.queryTriggerHistory).toHaveBeenCalledWith(
         expect.objectContaining({ limit: 100, offset: 0 })
       );
+    });
+  });
+
+  describe("GET /api/stats/activity", () => {
+    it("returns empty rows when no stats store is provided", async () => {
+      const app = createApp();
+
+      const res = await app.request("/api/stats/activity");
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.rows).toEqual([]);
+      expect(data.total).toBe(0);
+      expect(data.limit).toBe(50);
+      expect(data.offset).toBe(0);
+    });
+
+    it("returns rows from the stats store including dead letters", async () => {
+      const stats = mockStatsStore();
+      const completedRow = { ts: 1000, triggerType: "schedule", agentName: "reporter", instanceId: "i1", result: "completed", webhookReceiptId: null, deadLetterReason: null };
+      const deadLetterRow = { ts: 500, triggerType: "webhook", agentName: "reporter", instanceId: null, result: "dead-letter", webhookReceiptId: "r1", deadLetterReason: "no_match" };
+      stats.queryTriggerHistory.mockReturnValue([completedRow, deadLetterRow]);
+      const app = createApp(stats);
+
+      const res = await app.request("/api/stats/activity");
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.rows).toHaveLength(2);
+      expect(data.total).toBe(2);
+      // Should always pass includeDeadLetters: true
+      expect(stats.queryTriggerHistory).toHaveBeenCalledWith(
+        expect.objectContaining({ includeDeadLetters: true })
+      );
+    });
+
+    it("merges running instances from statusTracker", async () => {
+      const stats = mockStatsStore();
+      stats.queryTriggerHistory.mockReturnValue([
+        { ts: 500, triggerType: "schedule", agentName: "reporter", instanceId: "i1", result: "completed" },
+      ]);
+
+      const tracker = mockStatusTracker([
+        { id: "inst-running", agentName: "reporter", status: "running", startedAt: new Date(2000).toISOString(), trigger: "webhook:github" },
+      ]);
+      const app = createApp(stats, tracker);
+
+      const res = await app.request("/api/stats/activity");
+      const data = await res.json();
+
+      expect(data.rows).toHaveLength(2);
+      const running = data.rows.find((r: any) => r.result === "running");
+      expect(running).toBeDefined();
+      expect(running.instanceId).toBe("inst-running");
+      expect(running.triggerType).toBe("webhook");
+      expect(running.triggerSource).toBe("github");
+    });
+
+    it("merges pending queue items from controlDeps.workQueue.peek", async () => {
+      const stats = mockStatsStore();
+      stats.queryTriggerHistory.mockReturnValue([]);
+
+      const tracker = mockStatusTracker([], [
+        { name: "reporter", queuedWebhooks: 1 },
+      ]);
+
+      const controlDeps = {
+        workQueue: {
+          size: vi.fn().mockReturnValue(1),
+          peek: vi.fn().mockReturnValue([
+            { context: { type: "webhook", source: "github" }, receivedAt: new Date(3000) },
+          ]),
+        },
+      };
+
+      const app = createApp(stats, tracker, controlDeps);
+
+      const res = await app.request("/api/stats/activity");
+      const data = await res.json();
+
+      const pending = data.rows.find((r: any) => r.result === "pending");
+      expect(pending).toBeDefined();
+      expect(pending.triggerType).toBe("webhook");
+      expect(pending.triggerSource).toBe("github");
+      expect(pending.instanceId).toBeNull();
+      expect(pending.agentName).toBe("reporter");
+    });
+
+    it("filters by status=pending returns only pending rows", async () => {
+      const stats = mockStatsStore();
+      stats.queryTriggerHistory.mockReturnValue([
+        { ts: 500, triggerType: "schedule", agentName: "reporter", instanceId: "i1", result: "completed" },
+      ]);
+
+      const tracker = mockStatusTracker([], [{ name: "reporter", queuedWebhooks: 1 }]);
+      const controlDeps = {
+        workQueue: {
+          size: vi.fn().mockReturnValue(1),
+          peek: vi.fn().mockReturnValue([
+            { context: { type: "schedule" }, receivedAt: new Date(3000) },
+          ]),
+        },
+      };
+      const app = createApp(stats, tracker, controlDeps);
+
+      const res = await app.request("/api/stats/activity?status=pending");
+      const data = await res.json();
+
+      expect(data.rows.every((r: any) => r.result === "pending")).toBe(true);
+    });
+
+    it("filters by status=dead-letter returns only dead letters", async () => {
+      const stats = mockStatsStore();
+      stats.queryTriggerHistory.mockReturnValue([
+        { ts: 1000, triggerType: "schedule", agentName: "reporter", instanceId: "i1", result: "completed" },
+        { ts: 500, triggerType: "webhook", agentName: "reporter", instanceId: null, result: "dead-letter", webhookReceiptId: "r1", deadLetterReason: "no_match" },
+      ]);
+
+      const app = createApp(stats);
+
+      const res = await app.request("/api/stats/activity?status=dead-letter");
+      const data = await res.json();
+
+      expect(data.rows).toHaveLength(1);
+      expect(data.rows[0].result).toBe("dead-letter");
+    });
+
+    it("filters by agent parameter", async () => {
+      const stats = mockStatsStore();
+      stats.queryTriggerHistory.mockReturnValue([
+        { ts: 1000, triggerType: "schedule", agentName: "reporter", instanceId: "i1", result: "completed" },
+      ]);
+
+      const app = createApp(stats);
+
+      await app.request("/api/stats/activity?agent=reporter");
+      expect(stats.queryTriggerHistory).toHaveBeenCalledWith(
+        expect.objectContaining({ agentName: "reporter" })
+      );
+    });
+
+    it("sorts all rows by ts descending", async () => {
+      const stats = mockStatsStore();
+      stats.queryTriggerHistory.mockReturnValue([
+        { ts: 1000, triggerType: "schedule", agentName: "reporter", instanceId: "i1", result: "completed" },
+        { ts: 300, triggerType: "webhook", agentName: "reporter", instanceId: "i2", result: "error" },
+      ]);
+
+      const tracker = mockStatusTracker([
+        { id: "r1", agentName: "reporter", status: "running", startedAt: new Date(2000).toISOString(), trigger: "manual" },
+      ]);
+      const app = createApp(stats, tracker);
+
+      const res = await app.request("/api/stats/activity");
+      const data = await res.json();
+
+      // Rows should be sorted newest first: ts=2000 (running), ts=1000 (completed), ts=300 (error)
+      expect(data.rows[0].ts).toBe(2000);
+      expect(data.rows[1].ts).toBe(1000);
+      expect(data.rows[2].ts).toBe(300);
+    });
+
+    it("paginates results with limit and offset", async () => {
+      const stats = mockStatsStore();
+      stats.queryTriggerHistory.mockReturnValue([
+        { ts: 3000, result: "completed", triggerType: "schedule", agentName: "a", instanceId: "i1" },
+        { ts: 2000, result: "completed", triggerType: "schedule", agentName: "a", instanceId: "i2" },
+        { ts: 1000, result: "completed", triggerType: "schedule", agentName: "a", instanceId: "i3" },
+      ]);
+
+      const app = createApp(stats);
+
+      const res = await app.request("/api/stats/activity?limit=2&offset=1");
+      const data = await res.json();
+
+      expect(data.total).toBe(3);
+      expect(data.rows).toHaveLength(2);
+      expect(data.rows[0].instanceId).toBe("i2"); // second row after sort
     });
   });
 });

--- a/packages/action-llama/test/events/event-queue.test.ts
+++ b/packages/action-llama/test/events/event-queue.test.ts
@@ -111,6 +111,50 @@ function workQueueSuite(
       expect(queue.size("agent-a")).toBe(0);
       expect(queue.size("agent-b")).toBe(0);
     });
+
+    it("peek returns items in FIFO order without removing them", () => {
+      ({ queue, cleanup } = factory());
+      queue.enqueue("agent-a", "event-1");
+      queue.enqueue("agent-a", "event-2");
+      queue.enqueue("agent-a", "event-3");
+
+      const peeked = queue.peek("agent-a");
+      expect(peeked).toHaveLength(3);
+      expect(peeked[0].context).toBe("event-1");
+      expect(peeked[1].context).toBe("event-2");
+      expect(peeked[2].context).toBe("event-3");
+
+      // Items should still be in the queue
+      expect(queue.size("agent-a")).toBe(3);
+    });
+
+    it("peek respects the limit parameter", () => {
+      ({ queue, cleanup } = factory());
+      queue.enqueue("agent-a", "event-1");
+      queue.enqueue("agent-a", "event-2");
+      queue.enqueue("agent-a", "event-3");
+
+      const peeked = queue.peek("agent-a", 2);
+      expect(peeked).toHaveLength(2);
+      expect(peeked[0].context).toBe("event-1");
+      expect(peeked[1].context).toBe("event-2");
+    });
+
+    it("peek returns empty array for unknown agent", () => {
+      ({ queue, cleanup } = factory());
+      expect(queue.peek("unknown")).toEqual([]);
+    });
+
+    it("peek does not affect subsequent dequeue operations", () => {
+      ({ queue, cleanup } = factory());
+      queue.enqueue("agent-a", "event-1");
+      queue.enqueue("agent-a", "event-2");
+
+      queue.peek("agent-a");
+      expect(queue.dequeue("agent-a")?.context).toBe("event-1");
+      expect(queue.dequeue("agent-a")?.context).toBe("event-2");
+      expect(queue.dequeue("agent-a")).toBeUndefined();
+    });
   });
 }
 

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -4,8 +4,7 @@ import { LoginPage } from "./pages/LoginPage";
 import { DashboardPage } from "./pages/DashboardPage";
 import { AgentDetailPage } from "./pages/AgentDetailPage";
 import { InstanceDetailPage } from "./pages/InstanceDetailPage";
-import { TriggerHistoryPage } from "./pages/TriggerHistoryPage";
-import { JobsPage } from "./pages/JobsPage";
+import { ActivityPage } from "./pages/ActivityPage";
 import { TriggerDetailPage } from "./pages/TriggerDetailPage";
 import { ProjectConfigPage } from "./pages/ProjectConfigPage";
 import { AgentSkillPage } from "./pages/AgentSkillPage";
@@ -14,7 +13,7 @@ import { WebhookReceiptPage } from "./pages/WebhookReceiptPage";
 
 function AgentTriggersRedirect() {
   const { name } = useParams<{ name: string }>();
-  return <Navigate to={`/triggers?agent=${encodeURIComponent(name ?? "")}`} replace />;
+  return <Navigate to={`/activity?agent=${encodeURIComponent(name ?? "")}`} replace />;
 }
 
 export function App() {
@@ -38,9 +37,10 @@ export function App() {
           path="/dashboard/agents/:name/skill"
           element={<AgentSkillPage />}
         />
-        <Route path="/dashboard/triggers" element={<Navigate to="/triggers" replace />} />
-        <Route path="/triggers" element={<TriggerHistoryPage />} />
-        <Route path="/jobs" element={<JobsPage />} />
+        <Route path="/dashboard/triggers" element={<Navigate to="/activity" replace />} />
+        <Route path="/activity" element={<ActivityPage />} />
+        <Route path="/triggers" element={<Navigate to="/activity" replace />} />
+        <Route path="/jobs" element={<Navigate to="/activity" replace />} />
         <Route path="/dashboard/triggers/:instanceId" element={<TriggerDetailPage />} />
         <Route path="/dashboard/webhooks/:receiptId" element={<WebhookReceiptPage />} />
         <Route path="/dashboard/config" element={<ProjectConfigPage />} />

--- a/packages/frontend/src/components/Badge.tsx
+++ b/packages/frontend/src/components/Badge.tsx
@@ -19,6 +19,13 @@ export function TriggerTypeBadge({ type }: { type: string }) {
 }
 
 export function ResultBadge({ result, deadLetterReason }: { result: string; deadLetterReason?: string | null }) {
+  if (result === "pending") {
+    return (
+      <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">
+        pending
+      </span>
+    );
+  }
   if (result === "completed" || result === "rerun") {
     return (
       <span className="text-green-600 dark:text-green-400 text-xs font-medium">

--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -32,8 +32,7 @@ function Navbar() {
   }, [navigate]);
 
   const isSettings = location.pathname === "/dashboard/config";
-  const isTriggers = location.pathname === "/triggers";
-  const isJobs = location.pathname === "/jobs";
+  const isActivity = location.pathname === "/activity";
 
   return (
     <header className="border-b border-slate-200 dark:border-slate-800 px-4 sm:px-6 py-3">
@@ -46,9 +45,9 @@ function Navbar() {
             Action Llama
           </Link>
           <Link
-            to="/triggers"
+            to="/activity"
             className={`flex items-center gap-1.5 text-sm transition-colors ${
-              isTriggers
+              isActivity
                 ? "text-blue-600 dark:text-blue-400"
                 : "text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
             }`}
@@ -56,20 +55,7 @@ function Navbar() {
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
             </svg>
-            Triggers
-          </Link>
-          <Link
-            to="/jobs"
-            className={`flex items-center gap-1.5 text-sm transition-colors ${
-              isJobs
-                ? "text-blue-600 dark:text-blue-400"
-                : "text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
-            }`}
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-            </svg>
-            Jobs
+            Activity
           </Link>
           <Link
             to="/dashboard/config"

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -127,6 +127,18 @@ export interface JobRow {
   deadLetterReason?: string | null;
 }
 
+export interface ActivityRow {
+  ts: number;
+  triggerType: string;
+  triggerSource?: string | null;
+  agentName?: string | null;
+  instanceId?: string | null;
+  /** "pending" | "running" | "completed" | "rerun" | "error" | "dead-letter" */
+  result: string;
+  webhookReceiptId?: string | null;
+  deadLetterReason?: string | null;
+}
+
 export interface TriggerDetailData {
   instanceId: string;
   agentName: string;
@@ -300,6 +312,20 @@ export function getJobs(
 ): Promise<{ jobs: JobRow[]; total: number; pending: Record<string, number>; totalPending: number }> {
   let url = `/api/stats/jobs?limit=${limit}&offset=${offset}`;
   if (agent) url += `&agent=${encodeURIComponent(agent)}`;
+  return fetchJSON(url);
+}
+
+export function getActivity(
+  limit: number,
+  offset: number,
+  agent?: string,
+  triggerType?: string,
+  status?: string,
+): Promise<{ rows: ActivityRow[]; total: number }> {
+  let url = `/api/stats/activity?limit=${limit}&offset=${offset}`;
+  if (agent) url += `&agent=${encodeURIComponent(agent)}`;
+  if (triggerType) url += `&triggerType=${encodeURIComponent(triggerType)}`;
+  if (status && status !== "all") url += `&status=${encodeURIComponent(status)}`;
   return fetchJSON(url);
 }
 

--- a/packages/frontend/src/pages/ActivityPage.tsx
+++ b/packages/frontend/src/pages/ActivityPage.tsx
@@ -1,0 +1,272 @@
+import { useEffect, useState, useCallback } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { useInvalidation } from "../hooks/useInvalidation";
+import { useStatusStream } from "../hooks/StatusStreamContext";
+import { TriggerTypeBadge, ResultBadge } from "../components/Badge";
+import { getActivity } from "../lib/api";
+import type { ActivityRow } from "../lib/api";
+import { fmtDateTime, shortId } from "../lib/format";
+import { agentHueStyle } from "../lib/color";
+
+const PAGE_SIZE = 50;
+
+const STATUS_OPTIONS = [
+  { value: "all", label: "All Statuses" },
+  { value: "pending", label: "Pending" },
+  { value: "running", label: "Running" },
+  { value: "completed", label: "Completed" },
+  { value: "error", label: "Error" },
+  { value: "dead-letter", label: "Dead Letter" },
+];
+
+export function ActivityPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const agentFilter = searchParams.get("agent") || undefined;
+  const triggerTypeFilter = searchParams.get("type") || undefined;
+  const statusFilter = searchParams.get("status") || "all";
+
+  const [rows, setRows] = useState<ActivityRow[]>([]);
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const { agents } = useStatusStream();
+  const agentNames = agents.map((a) => a.name);
+
+  const setFilter = useCallback(
+    (key: string, value: string | undefined) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        if (value && value !== "all") {
+          next.set(key, value);
+        } else {
+          next.delete(key);
+        }
+        next.delete("offset");
+        return next;
+      });
+    },
+    [setSearchParams],
+  );
+
+  const load = useCallback(
+    (newOffset: number) => {
+      setLoading(true);
+      getActivity(PAGE_SIZE, newOffset, agentFilter, triggerTypeFilter, statusFilter)
+        .then((data) => {
+          setRows(data.rows);
+          setTotal(data.total);
+          setOffset(newOffset);
+        })
+        .catch(() => {})
+        .finally(() => setLoading(false));
+    },
+    [agentFilter, triggerTypeFilter, statusFilter],
+  );
+
+  useEffect(() => {
+    load(0);
+  }, [load]);
+
+  const refetchPage = useCallback(() => {
+    load(offset);
+  }, [load, offset]);
+
+  useInvalidation("runs", undefined, refetchPage);
+  useInvalidation("triggers", undefined, refetchPage);
+
+  const page = Math.floor(offset / PAGE_SIZE) + 1;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  // Live pending count from SSE for badge display
+  const livePendingCount = agentFilter
+    ? agents.find((a) => a.name === agentFilter)?.queuedWebhooks ?? 0
+    : agents.reduce((sum, a) => sum + (a.queuedWebhooks || 0), 0);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <div className="flex items-center gap-3">
+          <h1 className="text-xl font-bold text-slate-900 dark:text-white">Activity</h1>
+          {livePendingCount > 0 && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">
+              {livePendingCount} pending
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-3 flex-wrap">
+          {/* Agent filter */}
+          <select
+            value={agentFilter || ""}
+            onChange={(e) => setFilter("agent", e.target.value || undefined)}
+            className="text-sm rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-white px-2 py-1"
+          >
+            <option value="">All Agents</option>
+            {agents.map((a) => (
+              <option key={a.name} value={a.name}>
+                {a.name}
+              </option>
+            ))}
+          </select>
+          {/* Trigger type filter */}
+          <select
+            value={triggerTypeFilter || ""}
+            onChange={(e) => setFilter("type", e.target.value || undefined)}
+            className="text-sm rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-white px-2 py-1"
+          >
+            <option value="">All Types</option>
+            <option value="schedule">Schedule</option>
+            <option value="webhook">Webhook</option>
+            <option value="manual">Manual</option>
+            <option value="agent">Agent</option>
+          </select>
+          {/* Status filter */}
+          <select
+            value={statusFilter}
+            onChange={(e) => setFilter("status", e.target.value)}
+            className="text-sm rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-white px-2 py-1"
+          >
+            {STATUS_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 dark:border-slate-800">
+                <th className="text-left px-4 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">
+                  Timestamp
+                </th>
+                <th className="text-left px-4 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">
+                  Type
+                </th>
+                <th className="text-left px-4 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">
+                  Source
+                </th>
+                <th className="text-left px-4 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">
+                  Agent
+                </th>
+                <th className="text-left px-4 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">
+                  Instance
+                </th>
+                <th className="text-left px-4 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">
+                  Status
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, i) => (
+                <tr
+                  key={`${row.ts}-${i}`}
+                  className="border-b border-slate-100 dark:border-slate-800/50 last:border-0 hover:bg-slate-100/50 dark:hover:bg-slate-800/30"
+                >
+                  <td className="px-4 py-2.5 text-slate-600 dark:text-slate-400 text-xs whitespace-nowrap">
+                    {fmtDateTime(row.ts)}
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <TriggerTypeBadge type={row.triggerType} />
+                  </td>
+                  <td className="px-4 py-2.5 text-slate-600 dark:text-slate-400 text-xs">
+                    {row.triggerSource && row.webhookReceiptId ? (
+                      <Link
+                        to={`/dashboard/webhooks/${row.webhookReceiptId}`}
+                        className="text-blue-600 dark:text-blue-400 hover:underline"
+                      >
+                        {row.triggerSource}
+                      </Link>
+                    ) : (
+                      row.triggerSource ?? "\u2014"
+                    )}
+                  </td>
+                  <td className="px-4 py-2.5">
+                    {row.agentName ? (
+                      <Link
+                        to={`/dashboard/agents/${encodeURIComponent(row.agentName)}`}
+                        className="hover:underline text-xs flex items-center gap-1.5"
+                      >
+                        <span
+                          className="w-2 h-2 rounded-full shrink-0 agent-color-dot"
+                          style={agentHueStyle(row.agentName, agentNames)}
+                        />
+                        <span className="agent-color-text" style={agentHueStyle(row.agentName, agentNames)}>
+                          {row.agentName}
+                        </span>
+                      </Link>
+                    ) : (
+                      <span className="text-slate-400 text-xs">{"\u2014"}</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2.5">
+                    {row.instanceId && row.agentName ? (
+                      <Link
+                        to={`/dashboard/agents/${encodeURIComponent(row.agentName)}/instances/${encodeURIComponent(row.instanceId)}`}
+                        className="font-mono text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                      >
+                        {shortId(row.instanceId)}
+                      </Link>
+                    ) : (
+                      <span className="text-slate-400 text-xs">{"\u2014"}</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <ResultBadge result={row.result} deadLetterReason={row.deadLetterReason} />
+                  </td>
+                </tr>
+              ))}
+              {rows.length === 0 && !loading && (
+                <tr>
+                  <td
+                    colSpan={6}
+                    className="px-4 py-8 text-center text-slate-500 dark:text-slate-400"
+                  >
+                    No activity found
+                  </td>
+                </tr>
+              )}
+              {loading && (
+                <tr>
+                  <td
+                    colSpan={6}
+                    className="px-4 py-8 text-center text-slate-500 dark:text-slate-400"
+                  >
+                    Loading...
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-between px-4 py-2.5 border-t border-slate-200 dark:border-slate-800">
+            <button
+              onClick={() => load(Math.max(0, offset - PAGE_SIZE))}
+              disabled={offset === 0}
+              className="px-3 py-1 text-xs rounded bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700 disabled:opacity-40 transition-colors"
+            >
+              Previous
+            </button>
+            <span className="text-xs text-slate-500 dark:text-slate-400">
+              Page {page} of {totalPages} ({total} total)
+            </span>
+            <button
+              onClick={() => load(offset + PAGE_SIZE)}
+              disabled={offset + PAGE_SIZE >= total}
+              className="px-3 py-1 text-xs rounded bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700 disabled:opacity-40 transition-colors"
+            >
+              Next
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/AgentDetailPage.tsx
+++ b/packages/frontend/src/pages/AgentDetailPage.tsx
@@ -382,7 +382,7 @@ export function AgentDetailPage() {
             )}
           </div>
           <Link
-            to={`/jobs?agent=${encodeURIComponent(name)}`}
+            to={`/activity?agent=${encodeURIComponent(name)}`}
             className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
           >
             View all


### PR DESCRIPTION
Closes #418

## Summary

This PR merges the separate **Triggers** and **Jobs** pages into a single unified **Activity** page, addressing the UX confusion identified in #418.

## Changes

### Backend
- Added `peek(agentName, limit?)` method to the `WorkQueue<T>` interface and all implementations (`MemoryWorkQueue`, `SqliteWorkQueue`, `EventSourcedWorkQueue`) — returns queued items in FIFO order without consuming them
- Added `GET /api/stats/activity` endpoint that merges:
  - Historical runs (including dead letters) from the stats store
  - Live running instances from the status tracker
  - Pending queue items via `workQueue.peek()`
  - All rows sorted by timestamp descending
  - Status filter: `all` | `pending` | `running` | `completed` | `error` | `dead-letter`
- Existing `/api/stats/triggers` and `/api/stats/jobs` endpoints preserved for backward compatibility
- Wired `controlDeps.workQueue.peek` through gateway-setup → registerDashboardRoutes → registerStatsRoutes

### Frontend
- New `ActivityPage.tsx` — unified page with Agent, Type, and Status filters
- Replaced **Triggers** + **Jobs** nav links with single **Activity** link
- `/triggers` and `/jobs` routes redirect to `/activity`
- Agent detail page "View all" link → `/activity?agent=X`
- Added `pending` result case to `ResultBadge` component (amber badge)
- Added `getActivity()` API function and `ActivityRow` type

### Tests
- 17 new unit tests: `peek()` behavior on MemoryWorkQueue + SqliteWorkQueue, and `/api/stats/activity` endpoint coverage (merge logic, status filter, pagination, sort order)