### PR TITLE
fix: add spinner feedback to Kill buttons

### DIFF
--- a/.changeset/kill-button-spinner.md
+++ b/.changeset/kill-button-spinner.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/frontend": patch
+---
+
+Add immediate spinner feedback to Kill buttons across Dashboard, Agent Detail, and Instance Detail pages. Buttons are now disabled with a spinning indicator the moment they are clicked, preventing double-clicks and providing visual feedback that the kill is in progress.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "move-integration-to-e2e",
+  "name": "repo",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -13799,7 +13799,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.19.2",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/packages/frontend/src/pages/AgentDetailPage.tsx
+++ b/packages/frontend/src/pages/AgentDetailPage.tsx
@@ -71,6 +71,8 @@ export function AgentDetailPage() {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [scaleInput, setScaleInput] = useState("");
   const [actionError, setActionError] = useState<string | null>(null);
+  const [killingAll, setKillingAll] = useState(false);
+  const [killingInstances, setKillingInstances] = useState<Set<string>>(new Set());
   const [showRunModal, setShowRunModal] = useState(false);
   const cursorRef = useRef<string | null>(null);
   const logContainerRef = useRef<HTMLDivElement>(null);
@@ -266,11 +268,25 @@ export function AgentDetailPage() {
             Chat
           </Link>
           <button
-            onClick={() => handleAction(() => killAgentInstances(name))}
-            disabled={!agent || agent.runningCount === 0}
+            onClick={async () => {
+              setKillingAll(true);
+              setActionError(null);
+              try { await killAgentInstances(name); }
+              catch (err) { setActionError(err instanceof Error ? err.message : "Action failed"); }
+              finally { setKillingAll(false); }
+            }}
+            disabled={!agent || agent.runningCount === 0 || killingAll}
             className="px-3 py-1.5 text-xs font-medium rounded-md bg-red-600 hover:bg-red-700 disabled:opacity-40 disabled:cursor-not-allowed text-white transition-colors"
           >
-            Kill
+            {killingAll ? (
+              <span className="flex items-center gap-1">
+                <svg className="w-3 h-3 animate-spin" viewBox="0 0 24 24" fill="none">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                Killing…
+              </span>
+            ) : "Kill"}
           </button>
           {agent && (
             <button
@@ -354,12 +370,31 @@ export function AgentDetailPage() {
                     {inst.status}
                   </span>
                   <button
-                    onClick={() =>
-                      handleAction(() => killInstance(inst.id))
-                    }
-                    className="px-2 py-1 text-xs rounded bg-red-600 hover:bg-red-700 text-white transition-colors"
+                    onClick={async () => {
+                      setKillingInstances((prev) => new Set(prev).add(inst.id));
+                      setActionError(null);
+                      try { await killInstance(inst.id); }
+                      catch (err) { setActionError(err instanceof Error ? err.message : "Action failed"); }
+                      finally {
+                        setKillingInstances((prev) => {
+                          const next = new Set(prev);
+                          next.delete(inst.id);
+                          return next;
+                        });
+                      }
+                    }}
+                    disabled={killingInstances.has(inst.id)}
+                    className="px-2 py-1 text-xs rounded bg-red-600 hover:bg-red-700 disabled:opacity-40 disabled:cursor-not-allowed text-white transition-colors"
                   >
-                    Kill
+                    {killingInstances.has(inst.id) ? (
+                      <span className="flex items-center gap-1">
+                        <svg className="w-3 h-3 animate-spin" viewBox="0 0 24 24" fill="none">
+                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                        </svg>
+                        Killing…
+                      </span>
+                    ) : "Kill"}
                   </button>
                 </div>
               </div>

--- a/packages/frontend/src/pages/DashboardPage.tsx
+++ b/packages/frontend/src/pages/DashboardPage.tsx
@@ -23,16 +23,29 @@ function formatScale(agent: AgentStatus): string {
   return "";
 }
 
+function SpinnerIcon() {
+  return (
+    <svg className="w-3 h-3 animate-spin" viewBox="0 0 24 24" fill="none">
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+    </svg>
+  );
+}
+
 function ActionMenu({
   agent,
   isPaused,
   onAction,
   onRunClick,
+  killingAgents,
+  onKillAgent,
 }: {
   agent: AgentStatus;
   isPaused: boolean;
   onAction: (fn: () => Promise<unknown>) => void;
   onRunClick: () => void;
+  killingAgents: Set<string>;
+  onKillAgent: (agentName: string) => void;
 }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -67,11 +80,16 @@ function ActionMenu({
             Run
           </button>
           <button
-            onClick={() => { onAction(() => killAgentInstances(agent.name)); setOpen(false); }}
-            disabled={agent.runningCount === 0}
+            onClick={() => { onKillAgent(agent.name); setOpen(false); }}
+            disabled={agent.runningCount === 0 || killingAgents.has(agent.name)}
             className="w-full text-left px-3 py-1.5 text-xs text-red-700 dark:text-red-400 hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-40 disabled:cursor-not-allowed"
           >
-            Kill
+            {killingAgents.has(agent.name) ? (
+              <span className="flex items-center gap-1">
+                <SpinnerIcon />
+                Killing…
+              </span>
+            ) : "Kill"}
           </button>
           <button
             onClick={() => { onAction(() => agent.enabled ? disableAgent(agent.name) : enableAgent(agent.name)); setOpen(false); }}
@@ -90,6 +108,7 @@ export function DashboardPage() {
   const { agents, schedulerInfo } = useStatusStream();
   const agentNames = agents.map((a) => a.name);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [killingAgents, setKillingAgents] = useState<Set<string>>(new Set());
   const [runModalAgent, setRunModalAgent] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
@@ -120,6 +139,22 @@ export function DashboardPage() {
     },
     [],
   );
+
+  const handleKillAgent = useCallback(async (agentName: string) => {
+    setKillingAgents((prev) => new Set(prev).add(agentName));
+    setActionError(null);
+    try {
+      await killAgentInstances(agentName);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Action failed");
+    } finally {
+      setKillingAgents((prev) => {
+        const next = new Set(prev);
+        next.delete(agentName);
+        return next;
+      });
+    }
+  }, []);
 
   const isPaused = schedulerInfo?.paused ?? false;
 
@@ -294,14 +329,17 @@ export function DashboardPage() {
                         Run
                       </button>
                       <button
-                        onClick={() =>
-                          handleAction(() => killAgentInstances(agent.name))
-                        }
-                        disabled={agent.runningCount === 0}
+                        onClick={() => handleKillAgent(agent.name)}
+                        disabled={agent.runningCount === 0 || killingAgents.has(agent.name)}
                         className="px-2 py-1 text-xs rounded bg-red-600 hover:bg-red-700 disabled:opacity-40 disabled:cursor-not-allowed text-white transition-colors"
                         title="Kill all instances"
                       >
-                        Kill
+                        {killingAgents.has(agent.name) ? (
+                          <span className="flex items-center gap-1">
+                            <SpinnerIcon />
+                            Killing…
+                          </span>
+                        ) : "Kill"}
                       </button>
                       <button
                         onClick={() =>
@@ -322,7 +360,7 @@ export function DashboardPage() {
                     </div>
                     {/* Mobile: dropdown */}
                     <div className="sm:hidden">
-                      <ActionMenu agent={agent} isPaused={isPaused} onAction={handleAction} onRunClick={() => setRunModalAgent(agent.name)} />
+                      <ActionMenu agent={agent} isPaused={isPaused} onAction={handleAction} onRunClick={() => setRunModalAgent(agent.name)} killingAgents={killingAgents} onKillAgent={handleKillAgent} />
                     </div>
                   </td>
                 </tr>

--- a/packages/frontend/src/pages/InstanceDetailPage.tsx
+++ b/packages/frontend/src/pages/InstanceDetailPage.tsx
@@ -52,6 +52,7 @@ export function InstanceDetailPage() {
   >([]);
   const [following, setFollowing] = useState(true);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [killing, setKilling] = useState(false);
   const [copied, setCopied] = useState(false);
   const [connected, setConnected] = useState(false);
   const cursorRef = useRef<string | null>(null);
@@ -249,10 +250,25 @@ export function InstanceDetailPage() {
         </div>
         {isRunning && (
           <button
-            onClick={() => handleAction(() => killInstance(id))}
-            className="px-3 py-1.5 text-xs font-medium rounded-md bg-red-600 hover:bg-red-700 text-white transition-colors"
+            onClick={async () => {
+              setKilling(true);
+              setActionError(null);
+              try { await killInstance(id); }
+              catch (err) { setActionError(err instanceof Error ? err.message : "Action failed"); }
+              finally { setKilling(false); }
+            }}
+            disabled={killing}
+            className="px-3 py-1.5 text-xs font-medium rounded-md bg-red-600 hover:bg-red-700 disabled:opacity-40 disabled:cursor-not-allowed text-white transition-colors"
           >
-            Kill
+            {killing ? (
+              <span className="flex items-center gap-1">
+                <svg className="w-3 h-3 animate-spin" viewBox="0 0 24 24" fill="none">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                Killing…
+              </span>
+            ) : "Kill"}
           </button>
         )}
       </div>


### PR DESCRIPTION
Closes #422

## Summary

When Kill buttons are clicked, they now immediately show a disabled state with a spinning indicator and "Killing…" text, preventing double-clicks and giving users immediate visual feedback that the kill operation is in progress.

## Changes

- **DashboardPage.tsx**: Added `killingAgents` state (Set<string>) and `handleKillAgent` helper. Desktop inline Kill buttons and mobile ActionMenu Kill entries now show a spinner while killing is in flight.
- **AgentDetailPage.tsx**: Added `killingAll` and `killingInstances` states. Header "Kill" button shows spinner while killing all instances; per-instance Kill buttons in the Running Instances section show individual spinners.
- **InstanceDetailPage.tsx**: Added `killing` state. Header Kill button shows spinner while the kill is in progress.

## Behavior

- Button becomes disabled immediately on click (prevents double-clicks)
- Spinner animation + "Killing…" text shown while request is in flight
- Button returns to normal if an error occurs (error message displayed)
- Button disappears/updates naturally once the instance is killed (SSE stream updates the UI)