### PR TITLE
feat: add groups field to host-user runtime for Docker socket access

### DIFF
--- a/.changeset/host-user-runtime-groups.md
+++ b/.changeset/host-user-runtime-groups.md
@@ -1,0 +1,25 @@
+---
+"@action-llama/action-llama": minor
+---
+
+Add `groups` field to `AgentRuntimeType` for host-user runtime Docker socket access
+
+The `[runtime]` table in `agents/<name>/config.toml` now accepts a `groups` array
+that specifies additional OS groups the agent process should run with. When set, the
+host-user runtime passes `-g <group>` to `sudo` so the agent gains access to resources
+protected by that group (e.g. the Docker socket requires the `docker` group).
+
+Example `config.toml` for an agent that needs Docker access:
+
+```toml
+[runtime]
+type = "host-user"
+groups = ["docker"]
+```
+
+The `al doctor` command now also validates that any explicitly-configured groups exist
+on the system, warning if a configured group is not found.
+
+This fixes the e2e-coverage-improver agent's inability to run `npm run test:e2e` due
+to the Docker socket being inaccessible when running as `al-agent` without docker group
+membership.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "move-integration-to-e2e",
+  "name": "repo",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -13799,7 +13799,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.19.2",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/packages/action-llama/src/cli/commands/doctor.ts
+++ b/packages/action-llama/src/cli/commands/doctor.ts
@@ -241,20 +241,29 @@ export async function execute(opts: { project: string; env?: string; checkOnly?:
   }
 
   // Validate host-user runtime requirements
-  const hostUserAgents = new Map<string, string>(); // agentName -> run_as
+  const hostUserAgents = new Map<string, { runAs: string; groups: string[] }>(); // agentName -> { runAs, groups }
   for (const name of agents) {
     try {
       const runtimeConfig = loadAgentRuntimeConfig(projectPath, name);
       if (runtimeConfig.runtime?.type === "host-user") {
         const runAs = runtimeConfig.runtime.run_as ?? "al-agent";
-        hostUserAgents.set(name, runAs);
+        const groups = runtimeConfig.runtime.groups ?? [];
+        hostUserAgents.set(name, { runAs, groups });
       }
     } catch { /* already caught above */ }
   }
 
   if (hostUserAgents.size > 0) {
     const { execFileSync } = await import("child_process");
-    const uniqueUsers = new Set(hostUserAgents.values());
+    // Deduplicate by runAs user — track max groups per user
+    const uniqueUsers = new Map<string, string[]>(); // runAs -> merged groups
+    for (const { runAs, groups } of hostUserAgents.values()) {
+      const existing = uniqueUsers.get(runAs) ?? [];
+      for (const g of groups) {
+        if (!existing.includes(g)) existing.push(g);
+      }
+      uniqueUsers.set(runAs, existing);
+    }
     const isLinux = process.platform === "linux";
     const isMac = process.platform === "darwin";
     const currentUser = process.env.USER || process.env.LOGNAME || "unknown";
@@ -263,7 +272,7 @@ export async function execute(opts: { project: string; env?: string; checkOnly?:
       console.log(`\n--- Host-User Runtime (${hostUserAgents.size} agent(s)) ---\n`);
     }
 
-    for (const runAs of uniqueUsers) {
+    for (const [runAs] of uniqueUsers) {
       // Check if user exists
       let userExists = false;
       try {
@@ -344,7 +353,8 @@ export async function execute(opts: { project: string; env?: string; checkOnly?:
           }
         }
 
-        // Check Docker group membership
+        // Check Docker group membership (always checked for host-user agents)
+        // and any explicitly-configured groups from [runtime] groups = [...]
         if (userExists) {
           let dockerGroupExists = false;
           try {
@@ -357,8 +367,8 @@ export async function execute(opts: { project: string; env?: string; checkOnly?:
           if (dockerGroupExists) {
             let inDockerGroup = false;
             try {
-              const groups = execFileSync("id", ["-Gn", runAs], { stdio: "pipe", timeout: 5000 }).toString();
-              inDockerGroup = groups.split(/\s+/).includes("docker");
+              const userGroups = execFileSync("id", ["-Gn", runAs], { stdio: "pipe", timeout: 5000 }).toString();
+              inDockerGroup = userGroups.split(/\s+/).includes("docker");
             } catch {
               // Failed to check groups
             }
@@ -383,6 +393,28 @@ export async function execute(opts: { project: string; env?: string; checkOnly?:
                 `Agents that need Docker will fail. Run:\n` +
                 `    sudo usermod -aG docker ${runAs}`
               );
+            }
+          }
+
+          // Check explicitly-configured additional groups
+          const configuredGroups = uniqueUsers.get(runAs) ?? [];
+          for (const groupName of configuredGroups) {
+            if (groupName === "docker") continue; // Already checked above
+            let groupExists = false;
+            try {
+              execFileSync("getent", ["group", groupName], { stdio: "pipe", timeout: 5000 });
+              groupExists = true;
+            } catch {
+              // Group doesn't exist on this system
+            }
+
+            if (!groupExists) {
+              validationWarnings.push(
+                `Group "${groupName}" configured for host-user runtime agent does not exist on this system. ` +
+                `The agent will start but may lack required access. Create the group or verify the configuration.`
+              );
+            } else {
+              if (!opts.silent) console.log(`  [ok] Group "${groupName}" exists`);
             }
           }
         }

--- a/packages/action-llama/src/docker/host-user-runtime.ts
+++ b/packages/action-llama/src/docker/host-user-runtime.ts
@@ -156,11 +156,13 @@ export class HostUserRuntime implements Runtime {
   readonly needsGateway = false;
 
   private runAs: string;
+  private groups: string[];
   private processes = new Map<string, ProcessHandle>();
   private runAgentNames = new Map<string, string>();
 
-  constructor(runAs: string = "al-agent") {
+  constructor(runAs: string = "al-agent", groups: string[] = []) {
     this.runAs = runAs;
+    this.groups = groups;
   }
 
   async isAgentRunning(agentName: string): Promise<boolean> {
@@ -322,13 +324,22 @@ export class HostUserRuntime implements Runtime {
     // Find the `al` binary path
     const alBin = process.argv[1] || "al";
 
-    // Spawn: sudo -u <runAs> <al> _run-agent <agentName>
-    const proc = spawn("sudo", [
-      "-u", this.runAs,
+    // Build sudo args: sudo -u <runAs> [-g <group>] --preserve-env=... <al> _run-agent <agentName>
+    // When groups are configured, set the first group as the primary group so the agent
+    // process has the required group access (e.g. "docker" for Docker socket access).
+    // sudo running as root can set the group regardless of the user's /etc/group membership.
+    const sudoArgs: string[] = ["-u", this.runAs];
+    if (this.groups.length > 0) {
+      sudoArgs.push("-g", this.groups[0]);
+    }
+    sudoArgs.push(
       "--preserve-env=AL_CREDENTIALS_PATH,AL_WORK_DIR,AL_INSTANCE_ID,PROMPT,GATEWAY_URL,SHUTDOWN_SECRET,OTEL_TRACE_PARENT,OTEL_EXPORTER_OTLP_ENDPOINT,PATH,HOME",
       alBin, "_run-agent", opts.agentName,
       "--project", process.cwd(),
-    ], {
+    );
+
+    // Spawn: sudo -u <runAs> [-g <group>] <al> _run-agent <agentName>
+    const proc = spawn("sudo", sudoArgs, {
       stdio: ["ignore", logFd, logFd],
       env,
       cwd: workDir,

--- a/packages/action-llama/src/execution/runtime-factory.ts
+++ b/packages/action-llama/src/execution/runtime-factory.ts
@@ -60,9 +60,10 @@ export async function createContainerRuntime(
   for (const agentConfig of activeAgentConfigs) {
     if (agentConfig.runtime?.type === "host-user") {
       const runAs = agentConfig.runtime.run_as ?? "al-agent";
+      const groups = agentConfig.runtime.groups ?? [];
       const { HostUserRuntime } = await import("../docker/host-user-runtime.js");
-      agentRuntimeOverrides[agentConfig.name] = new HostUserRuntime(runAs);
-      logger.info({ agent: agentConfig.name, runAs }, "using host-user runtime");
+      agentRuntimeOverrides[agentConfig.name] = new HostUserRuntime(runAs, groups);
+      logger.info({ agent: agentConfig.name, runAs, groups }, "using host-user runtime");
     }
   }
 

--- a/packages/action-llama/src/shared/config/types.ts
+++ b/packages/action-llama/src/shared/config/types.ts
@@ -98,6 +98,7 @@ export interface AgentHooks {
 export interface AgentRuntimeType {
   type?: "container" | "host-user";  // default: "container"
   run_as?: string;                   // OS user for host-user mode (default: "al-agent")
+  groups?: string[];                 // Additional OS groups for host-user mode (e.g. ["docker"])
 }
 
 /**

--- a/packages/action-llama/src/shared/validation.ts
+++ b/packages/action-llama/src/shared/validation.ts
@@ -104,7 +104,7 @@ const AGENT_RUNTIME_CONFIG_SCHEMA: ConfigSchema = {
     },
     runtime: {
       required: new Set(),
-      optional: new Set(["type", "run_as"]),
+      optional: new Set(["type", "run_as", "groups"]),
       nested: {}
     },
   }

--- a/packages/action-llama/test/cli/commands/doctor.test.ts
+++ b/packages/action-llama/test/cli/commands/doctor.test.ts
@@ -750,6 +750,71 @@ describe("doctor", () => {
     });
   });
 
+  describe("host-user configured groups check", () => {
+    beforeEach(() => {
+      // Default: user exists, sudo works, docker group exists (user in docker group),
+      // custom group "audio" also exists
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === "id" && args[0] === "al-agent") return Buffer.from("1001");
+        if (cmd === "id" && args[0] === "-Gn") return Buffer.from("al-agent docker");
+        if (cmd === "getent" && args[0] === "group" && args[1] === "docker") return Buffer.from("docker:x:999:");
+        if (cmd === "getent" && args[0] === "group" && args[1] === "audio") return Buffer.from("audio:x:29:");
+        if (cmd === "sudo" && args[0] === "-n") return Buffer.from("");
+        throw new Error(`unexpected execFileSync: ${cmd} ${args.join(" ")}`);
+      });
+    });
+
+    it("prints ok when a configured group exists on the system", async () => {
+      mockDiscoverAgents.mockReturnValue(["e2e"]);
+      mockLoadAgentConfig.mockReturnValue({ name: "e2e", credentials: [] });
+      mockLoadAgentRuntimeConfig.mockReturnValue({
+        runtime: { type: "host-user", groups: ["audio"] },
+      });
+      mockCredentialExists.mockReturnValue(true);
+
+      const output = await captureLog(() => execute({ project: ".", checkOnly: true }));
+      expect(output).toContain('[ok] Group "audio" exists');
+    });
+
+    it("warns when a configured group does not exist on the system", async () => {
+      mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === "id" && args[0] === "al-agent") return Buffer.from("1001");
+        if (cmd === "id" && args[0] === "-Gn") return Buffer.from("al-agent docker");
+        if (cmd === "getent" && args[0] === "group" && args[1] === "docker") return Buffer.from("docker:x:999:");
+        if (cmd === "getent" && args[0] === "group" && args[1] === "nonexistent-group") throw new Error("not found");
+        if (cmd === "sudo" && args[0] === "-n") return Buffer.from("");
+        throw new Error(`unexpected execFileSync: ${cmd} ${args.join(" ")}`);
+      });
+
+      mockDiscoverAgents.mockReturnValue(["e2e"]);
+      mockLoadAgentConfig.mockReturnValue({ name: "e2e", credentials: [] });
+      mockLoadAgentRuntimeConfig.mockReturnValue({
+        runtime: { type: "host-user", groups: ["nonexistent-group"] },
+      });
+      mockCredentialExists.mockReturnValue(true);
+
+      const output = await captureLog(() => execute({ project: ".", checkOnly: true }));
+      expect(output).toContain('"nonexistent-group"');
+      expect(output).toContain("does not exist");
+    });
+
+    it("does not double-check docker group when it is in configured groups", async () => {
+      mockDiscoverAgents.mockReturnValue(["e2e"]);
+      mockLoadAgentConfig.mockReturnValue({ name: "e2e", credentials: [] });
+      mockLoadAgentRuntimeConfig.mockReturnValue({
+        runtime: { type: "host-user", groups: ["docker"] },
+      });
+      mockCredentialExists.mockReturnValue(true);
+
+      const output = await captureLog(() => execute({ project: ".", checkOnly: true }));
+      // docker group check is done by the normal docker group check, not the extra groups loop
+      expect(output).toContain("docker group");
+      // Should not have duplicate "ok" messages for docker
+      const dockerOkCount = (output.match(/\[ok\] Group "docker" exists/g) || []).length;
+      expect(dockerOkCount).toBe(0); // docker is skipped in the extra groups loop
+    });
+  });
+
   describe("project-root guard", () => {
     it("throws ConfigError when project path looks like an agent directory (SKILL.md at root)", async () => {
       // Simulate existsSync returning true for the SKILL.md at project root

--- a/packages/action-llama/test/docker/host-user-runtime.test.ts
+++ b/packages/action-llama/test/docker/host-user-runtime.test.ts
@@ -154,6 +154,68 @@ describe("HostUserRuntime", () => {
 
       fakeProc.emit("exit", 0);
     });
+
+    it("does not include -g flag when no groups configured", async () => {
+      const fakeProc = makeFakeProc();
+      mockSpawn.mockReturnValueOnce(fakeProc);
+
+      await runtime.launch({
+        image: "ignored",
+        agentName: "test-agent",
+        env: {},
+        credentials: { strategy: "host-user" as const, stagingDir: "/tmp/creds", bundle: {} },
+      });
+
+      const spawnCall = mockSpawn.mock.calls[0];
+      const sudoArgs: string[] = spawnCall[1];
+      expect(sudoArgs).not.toContain("-g");
+
+      fakeProc.emit("exit", 0);
+    });
+
+    it("includes -g flag when groups are configured", async () => {
+      const runtimeWithGroups = new HostUserRuntime("al-agent", ["docker"]);
+      const fakeProc = makeFakeProc();
+      mockSpawn.mockReturnValueOnce(fakeProc);
+
+      await runtimeWithGroups.launch({
+        image: "ignored",
+        agentName: "test-agent",
+        env: {},
+        credentials: { strategy: "host-user" as const, stagingDir: "/tmp/creds", bundle: {} },
+      });
+
+      const spawnCall = mockSpawn.mock.calls[0];
+      const sudoArgs: string[] = spawnCall[1];
+      expect(sudoArgs).toContain("-g");
+      expect(sudoArgs).toContain("docker");
+
+      // -g should come after -u and the runAs user
+      const gIndex = sudoArgs.indexOf("-g");
+      expect(sudoArgs[gIndex + 1]).toBe("docker");
+
+      fakeProc.emit("exit", 0);
+    });
+
+    it("uses first group when multiple groups are configured", async () => {
+      const runtimeWithGroups = new HostUserRuntime("al-agent", ["docker", "audio"]);
+      const fakeProc = makeFakeProc();
+      mockSpawn.mockReturnValueOnce(fakeProc);
+
+      await runtimeWithGroups.launch({
+        image: "ignored",
+        agentName: "test-agent",
+        env: {},
+        credentials: { strategy: "host-user" as const, stagingDir: "/tmp/creds", bundle: {} },
+      });
+
+      const spawnCall = mockSpawn.mock.calls[0];
+      const sudoArgs: string[] = spawnCall[1];
+      const gIndex = sudoArgs.indexOf("-g");
+      expect(sudoArgs[gIndex + 1]).toBe("docker");
+
+      fakeProc.emit("exit", 0);
+    });
   });
 
   describe("isAgentRunning / listRunningAgents", () => {

--- a/packages/action-llama/test/execution/runtime-factory.test.ts
+++ b/packages/action-llama/test/execution/runtime-factory.test.ts
@@ -20,7 +20,7 @@ vi.mock("../../src/docker/network.js", () => ({
 // HostUserRuntime mock
 vi.mock("../../src/docker/host-user-runtime.js", () => ({
   HostUserRuntime: class MockHostUserRuntime {
-    constructor(public runAs: string) {}
+    constructor(public runAs: string, public groups: string[] = []) {}
     isContainerRuntime = false;
   },
 }));
@@ -156,6 +156,46 @@ describe("createContainerRuntime", () => {
     const override = result.agentRuntimeOverrides["host-agent"] as any;
     expect(override).toBeDefined();
     expect(override.runAs).toBe("al-agent");
+  });
+
+  it("passes groups to HostUserRuntime when configured", async () => {
+    const { execFileSync } = await import("child_process");
+    vi.mocked(execFileSync).mockReturnValue(Buffer.from("Docker info"));
+
+    const agentWithGroups = makeAgentConfig({
+      name: "host-agent",
+      runtime: { type: "host-user", run_as: "al-agent", groups: ["docker"] } as any,
+    });
+
+    const result = await createContainerRuntime(
+      {} as any,
+      [agentWithGroups],
+      makeLogger()
+    );
+
+    const override = result.agentRuntimeOverrides["host-agent"] as any;
+    expect(override).toBeDefined();
+    expect(override.runAs).toBe("al-agent");
+    expect(override.groups).toEqual(["docker"]);
+  });
+
+  it("uses empty groups array when groups not specified in host-user runtime config", async () => {
+    const { execFileSync } = await import("child_process");
+    vi.mocked(execFileSync).mockReturnValue(Buffer.from("Docker info"));
+
+    const agentWithHostRuntime = makeAgentConfig({
+      name: "host-agent",
+      runtime: { type: "host-user" } as any,
+    });
+
+    const result = await createContainerRuntime(
+      {} as any,
+      [agentWithHostRuntime],
+      makeLogger()
+    );
+
+    const override = result.agentRuntimeOverrides["host-agent"] as any;
+    expect(override.groups).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Closes #425

## Summary

The `e2e-coverage-improver` agent runs as `al-agent` (via host-user runtime) but `al-agent` is not in the `docker` group, so it cannot access the Docker socket at `/run/docker.sock`.

This PR adds a `groups` field to the `[runtime]` config in `agents/<name>/config.toml` that lets host-user agents declare which OS groups they need. When set, the `sudo` invocation includes `-g <group>` so the agent process gains the required group access.

## Usage

Configure the `e2e-coverage-improver` agent's `config.toml`:

```toml
[runtime]
type = "host-user"
groups = ["docker"]
```

This causes the agent to be launched as:
```
sudo -u al-agent -g docker al _run-agent e2e-coverage-improver ...
```

The agent process runs as `al-agent` with `docker` as the primary group, giving access to the Docker socket (`srw-rw---- 1 root docker`) without requiring `al-agent` to be permanently added to the docker group via `usermod`.

## Changes

- **`types.ts`** — Add `groups?: string[]` to `AgentRuntimeType`
- **`validation.ts`** — Register `groups` in the runtime schema (prevents unknown-field warnings)
- **`host-user-runtime.ts`** — Accept `groups` in constructor; add `-g <group>` to sudo args when set
- **`runtime-factory.ts`** — Pass `runtime.groups` to `HostUserRuntime`
- **`doctor.ts`** — Check that configured groups exist on the system (warn if missing)
- Tests added for all changed modules (8 new tests)