### PR TITLE
fix: add groups=["docker"] to e2e-coverage-improver config.toml

### DIFF
--- a/.changeset/e2e-coverage-improver-docker-groups.md
+++ b/.changeset/e2e-coverage-improver-docker-groups.md
@@ -1,0 +1,10 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Add missing `groups = ["docker"]` to e2e-coverage-improver agent config
+
+The `e2e-coverage-improver` agent's `config.toml` was missing the `groups = ["docker"]`
+field that was introduced in PR #426. Without it, the agent runs without Docker group
+membership and cannot connect to `/var/run/docker.sock`, causing all e2e test runs to
+fail with `EACCES /var/run/docker.sock`. Closes #427.

--- a/agents/e2e-coverage-improver/config.toml
+++ b/agents/e2e-coverage-improver/config.toml
@@ -1,0 +1,3 @@
+[runtime]
+type = "host-user"
+groups = ["docker"]


### PR DESCRIPTION
Closes #427

## Summary

The `e2e-coverage-improver` agent was failing with Docker socket access errors because its `config.toml` was missing the `groups = ["docker"]` field that was introduced in PR #426.

## Changes

- Created `agents/e2e-coverage-improver/config.toml` with the `[runtime]` section including `groups = ["docker"]`
- Added changeset

## Root Cause

PR #426 added the `groups` field to the host-user runtime, but the agent config itself was never updated to use it. This meant the `al-agent` process (uid=998, gid=998) was still running without Docker group membership, causing `EACCES /var/run/docker.sock` errors on every e2e test run.

## Fix

```toml
[runtime]
type = "host-user"
groups = ["docker"]
```