### PR TITLE
fix: update HostUserRuntime on hot-reload when runtime config changes

### DIFF
--- a/.changeset/fix-hot-reload-runtime-override.md
+++ b/.changeset/fix-hot-reload-runtime-override.md
@@ -1,0 +1,13 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fix hot-reload not updating HostUserRuntime when agent runtime config changes
+
+When an agent's `config.toml` is modified at runtime (e.g. adding `groups = ["docker"]` to the `[runtime]` section), the hot-reload watcher now correctly:
+
+1. Creates a new `HostUserRuntime` with the updated configuration (runAs user and groups)
+2. Updates `agentRuntimeOverrides` so future agent launches use the new runtime
+3. Calls `setRuntime` on all existing runners in the pool so even in-flight or next-queued runs pick up the change
+
+Previously, the watcher updated the `AgentConfig` but left the old `HostUserRuntime` instance (without the docker group) in place, causing Docker socket access failures for agents that gained `groups = ["docker"]` via a live config edit.

--- a/packages/action-llama/src/agents/container-runner.ts
+++ b/packages/action-llama/src/agents/container-runner.ts
@@ -67,6 +67,10 @@ export class ContainerAgentRunner {
     this.agentConfig = config;
   }
 
+  setRuntime(runtime: Runtime): void {
+    this.runtime = runtime;
+  }
+
   get containerName(): string | undefined {
     return this._containerName;
   }

--- a/packages/action-llama/src/execution/runtime-factory.ts
+++ b/packages/action-llama/src/execution/runtime-factory.ts
@@ -14,10 +14,26 @@ import { AgentError } from "../shared/errors.js";
 import { buildAllImages } from "./image-builder.js";
 import type { PromptSkills } from "../agents/prompt.js";
 import { globalRegistry } from "../extensions/registry.js";
+import { HostUserRuntime } from "../docker/host-user-runtime.js";
 
 export interface RuntimeResult {
   runtime: Runtime;
   agentRuntimeOverrides: Record<string, Runtime>;
+}
+
+/**
+ * Create a per-agent Runtime override for agents with a [runtime] config section.
+ * Returns undefined if no override is needed (e.g. default container runtime).
+ * Extracted as a named function so it can be called during both startup and
+ * hot-reload without requiring a dynamic import.
+ */
+export function createAgentRuntimeOverride(agentConfig: AgentConfig): Runtime | undefined {
+  if (agentConfig.runtime?.type === "host-user") {
+    const runAs = agentConfig.runtime.run_as ?? "al-agent";
+    const groups = agentConfig.runtime.groups ?? [];
+    return new HostUserRuntime(runAs, groups);
+  }
+  return undefined;
 }
 
 export async function createContainerRuntime(
@@ -58,12 +74,13 @@ export async function createContainerRuntime(
   // Build per-agent runtime overrides for agents with [runtime] config
   const agentRuntimeOverrides: Record<string, Runtime> = {};
   for (const agentConfig of activeAgentConfigs) {
-    if (agentConfig.runtime?.type === "host-user") {
-      const runAs = agentConfig.runtime.run_as ?? "al-agent";
-      const groups = agentConfig.runtime.groups ?? [];
-      const { HostUserRuntime } = await import("../docker/host-user-runtime.js");
-      agentRuntimeOverrides[agentConfig.name] = new HostUserRuntime(runAs, groups);
-      logger.info({ agent: agentConfig.name, runAs, groups }, "using host-user runtime");
+    const override = createAgentRuntimeOverride(agentConfig);
+    if (override) {
+      agentRuntimeOverrides[agentConfig.name] = override;
+      logger.info(
+        { agent: agentConfig.name, runAs: agentConfig.runtime?.run_as ?? "al-agent", groups: agentConfig.runtime?.groups ?? [] },
+        "using host-user runtime",
+      );
     }
   }
 

--- a/packages/action-llama/src/scheduler/watcher.ts
+++ b/packages/action-llama/src/scheduler/watcher.ts
@@ -19,6 +19,7 @@ import type { WebhookRegistry } from "../webhooks/registry.js";
 import type { WebhookSourceConfig } from "../shared/config.js";
 import { RunnerPool, type PoolRunner } from "../execution/runner-pool.js";
 import { buildSingleAgentImage } from "../execution/image-builder.js";
+import { createAgentRuntimeOverride } from "../execution/runtime-factory.js";
 import { registerWebhookBindings } from "../events/webhook-setup.js";
 import type { SchedulerContext } from "../execution/execution.js";
 import { runWithReruns, makeWebhookPrompt, executeRun, drainQueues } from "../execution/execution.js";
@@ -316,6 +317,26 @@ export function watchAgents(ctx: HotReloadContext): WatcherHandle {
     // Update description in status tracker (may have changed in SKILL.md frontmatter)
     ctx.statusTracker?.setAgentDescription(agentName, newConfig.description);
 
+    // Detect runtime config changes and update the agentRuntimeOverrides if needed.
+    // This ensures that when [runtime] settings change (e.g. groups = ["docker"] is added),
+    // subsequent agent launches use the updated HostUserRuntime with the new configuration.
+    const oldRuntimeConfig = JSON.stringify(oldConfig?.runtime ?? null);
+    const newRuntimeConfig = JSON.stringify(newConfig.runtime ?? null);
+    if (oldRuntimeConfig !== newRuntimeConfig) {
+      const newOverride = createAgentRuntimeOverride(newConfig);
+      if (newOverride) {
+        ctx.agentRuntimeOverrides[agentName] = newOverride;
+        ctx.logger.info(
+          { agent: agentName, runAs: newConfig.runtime?.run_as ?? "al-agent", groups: newConfig.runtime?.groups ?? [] },
+          "hot reload: updated host-user runtime config",
+        );
+      } else {
+        // Reverted to container runtime — remove the host-user override
+        delete ctx.agentRuntimeOverrides[agentName];
+        ctx.logger.info({ agent: agentName }, "hot reload: reverted to container runtime");
+      }
+    }
+
     // Rebuild image (only for container-based runtimes)
     const agentRuntime = ctx.agentRuntimeOverrides[agentName] || ctx.runtime;
     let image = ctx.agentImages[agentName] || ctx.baseImage;
@@ -336,7 +357,7 @@ export function watchAgents(ctx: HotReloadContext): WatcherHandle {
     }
     ctx.agentImages[agentName] = image;
 
-    // Update existing runners with new image and config
+    // Update existing runners with new image, config, and runtime (if changed)
     const pool = ctx.runnerPools[agentName];
     if (pool) {
       for (const runner of pool.allRunners) {
@@ -345,6 +366,14 @@ export function watchAgents(ctx: HotReloadContext): WatcherHandle {
         }
         if ('setAgentConfig' in runner && typeof (runner as any).setAgentConfig === 'function') {
           (runner as any).setAgentConfig(newConfig);
+        }
+        // Propagate runtime changes to existing runners so in-flight and future
+        // launches within the same runner instance use the updated runtime config.
+        if (oldRuntimeConfig !== newRuntimeConfig) {
+          const updatedRuntime = ctx.agentRuntimeOverrides[agentName] || ctx.runtime;
+          if ('setRuntime' in runner && typeof (runner as any).setRuntime === 'function') {
+            (runner as any).setRuntime(updatedRuntime);
+          }
         }
       }
 

--- a/packages/action-llama/test/scheduler/watcher.test.ts
+++ b/packages/action-llama/test/scheduler/watcher.test.ts
@@ -48,6 +48,16 @@ vi.mock("../../src/execution/execution.js", () => ({
   drainQueues: vi.fn(async () => {}),
 }));
 
+const { mockHostUserRuntime, mockCreateAgentRuntimeOverride } = vi.hoisted(() => {
+  const inst = { type: "mock-host-user-runtime" } as any;
+  const fn = vi.fn((_config: any) => inst);
+  return { mockHostUserRuntime: inst, mockCreateAgentRuntimeOverride: fn };
+});
+
+vi.mock("../../src/execution/runtime-factory.js", () => ({
+  createAgentRuntimeOverride: mockCreateAgentRuntimeOverride,
+}));
+
 import { watch } from "fs";
 import { discoverAgents, loadAgentConfig, validateAgentConfig } from "../../src/shared/config.js";
 import { buildSingleAgentImage } from "../../src/execution/image-builder.js";
@@ -289,6 +299,43 @@ describe("watchAgents handler (via _handleAgentChange)", () => {
     expect(ctx.statusTracker!.setAgentState).toHaveBeenCalledWith("agent-a", "building");
     expect(ctx.statusTracker!.setAgentState).toHaveBeenCalledWith("agent-a", "idle");
     expect(ctx.statusTracker!.addLogLine).toHaveBeenCalledWith("agent-a", "hot-reloaded");
+  });
+
+  it("handles changed agent: updates agentRuntimeOverrides and runner runtime when runtime config changes", async () => {
+    const runner = {
+      ...makeMockRunner("agent-a"),
+      setRuntime: vi.fn(),
+    };
+    const pool = new RunnerPool([runner]);
+    // Start with a host-user agent that has no docker group
+    const oldConfig = makeAgentConfig("agent-a", {
+      runtime: { type: "host-user", run_as: "al-agent", groups: [] },
+    });
+    const ctx = makeContext({
+      agentConfigs: [oldConfig],
+      runnerPools: { "agent-a": pool },
+      agentRuntimeOverrides: { "agent-a": { type: "old-host-user-runtime" } as any },
+    });
+
+    // New config adds docker group
+    const updatedConfig = makeAgentConfig("agent-a", {
+      runtime: { type: "host-user", run_as: "al-agent", groups: ["docker"] },
+    });
+    mockedDiscoverAgents.mockReturnValue(["agent-a"]);
+    mockedLoadAgentConfig.mockReturnValue(updatedConfig);
+
+    // Make createAgentRuntimeOverride return the mock runtime for the new config
+    mockCreateAgentRuntimeOverride.mockReturnValue(mockHostUserRuntime);
+
+    const handle = watchAgents(ctx);
+    await handle._handleAgentChange("agent-a");
+
+    // createAgentRuntimeOverride should have been called with the new config
+    expect(mockCreateAgentRuntimeOverride).toHaveBeenCalledWith(updatedConfig);
+    // agentRuntimeOverrides should be updated with the new runtime
+    expect(ctx.agentRuntimeOverrides["agent-a"]).toBe(mockHostUserRuntime);
+    // Existing runner should have its runtime updated via setRuntime
+    expect(runner.setRuntime).toHaveBeenCalledWith(mockHostUserRuntime);
   });
 
   it("handles new agent: creates runners and pool", async () => {


### PR DESCRIPTION
Closes #429

## Problem

When an agent's `config.toml` is modified at runtime (e.g. adding `groups = ["docker"]` to the `[runtime]` section), the hot-reload watcher updated the `AgentConfig` but left the old `HostUserRuntime` instance (without the docker group) in `agentRuntimeOverrides`. This meant:

- Future agent launches via the same runner pool used the old runtime (no docker group)
- Existing runners also retained the old runtime

This explains why PR #428 added the config but some agent instances (started after a hot-reload rather than a full scheduler restart) still lacked the docker group.

## Fix

Extracted `createAgentRuntimeOverride()` as a named, statically-importable helper in `runtime-factory.ts`. The hot-reload `handleChangedAgent` function now:

1. Detects when the `[runtime]` config has changed by comparing old vs new runtime config JSON
2. Calls `createAgentRuntimeOverride(newConfig)` to create a new `HostUserRuntime` with the updated settings
3. Updates `ctx.agentRuntimeOverrides[agentName]` so future agent launches use the new runtime
4. Calls `setRuntime()` on all existing runners in the pool (new method added to `ContainerAgentRunner`)

A new unit test verifies the full flow: that changing `groups` in config.toml during a hot-reload results in both `agentRuntimeOverrides` and existing runners being updated.