### PR TITLE
fix: complete e2e-coverage-improver config.toml with all required fields

### DIFF
--- a/.changeset/fix-e2e-coverage-improver-config.md
+++ b/.changeset/fix-e2e-coverage-improver-config.md
@@ -1,0 +1,10 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fix e2e-coverage-improver config.toml to include complete configuration
+
+PR #428 created the config.toml with only the `[runtime]` section, missing the
+`models`, `credentials`, `schedule`, `timeout`, and `[params]` fields required
+for the agent to run correctly. This restores the full configuration including
+`groups = ["docker"]` so the agent has Docker socket access.

--- a/agents/e2e-coverage-improver/config.toml
+++ b/agents/e2e-coverage-improver/config.toml
@@ -1,3 +1,11 @@
+models = ["sonnet"]
+credentials = ["github_token", "git_ssh"]
+schedule = "0 * * * *"
+timeout = 3600
+
 [runtime]
 type = "host-user"
 groups = ["docker"]
+
+[params]
+repo = "Action-Llama/action-llama"


### PR DESCRIPTION
Closes #433

## Problem

PR #428 created `agents/e2e-coverage-improver/config.toml` with only the `[runtime]` section (3 lines), missing the `models`, `credentials`, `schedule`, `timeout`, and `[params]` fields required for the agent to operate correctly.

## Fix

Restored the complete configuration, matching the expected file described in issue #433:

```toml
models = ["sonnet"]
credentials = ["github_token", "git_ssh"]
schedule = "0 * * * *"
timeout = 3600

[runtime]
type = "host-user"
groups = ["docker"]

[params]
repo = "Action-Llama/action-llama"
```

This ensures:
- The agent runs on schedule (`0 * * * *`)
- It uses the correct model and credentials
- It has Docker group access via `groups = ["docker"]` so it can connect to `/var/run/docker.sock`
- It targets the correct repository via `[params]`