### PR TITLE
fix: support AL_RUNS_DIR env var to avoid EACCES on root-owned /tmp/al-runs

### DIFF
--- a/.changeset/fix-host-user-runtime-runs-dir.md
+++ b/.changeset/fix-host-user-runtime-runs-dir.md
@@ -1,0 +1,7 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fix EACCES errors in host-user-runtime tests when /tmp/al-runs is root-owned.
+
+The source code now reads `AL_RUNS_DIR` from the environment (falling back to the existing `/tmp/al-runs` default), and the test suite creates an isolated temp directory per test run and points `AL_RUNS_DIR` at it via `process.env`. This prevents permission errors when `/tmp/al-runs` already exists and is owned by root.

--- a/packages/action-llama/src/docker/host-user-runtime.ts
+++ b/packages/action-llama/src/docker/host-user-runtime.ts
@@ -32,7 +32,10 @@ import type {
 import { parseCredentialRef, getDefaultBackend } from "../shared/credentials.js";
 import { CONSTANTS } from "../shared/constants.js";
 
-const RUNS_DIR = join(tmpdir(), "al-runs");
+/** Returns the runs directory, honouring the AL_RUNS_DIR env var override. */
+function getRunsDir(): string {
+  return process.env.AL_RUNS_DIR ?? join(tmpdir(), "al-runs");
+}
 const ORPHAN_POLL_MS = 500;
 
 /** Metadata persisted alongside a running process for orphan recovery. */
@@ -44,7 +47,7 @@ interface PidFileData {
 }
 
 function pidFilePath(runId: string): string {
-  return join(RUNS_DIR, `${runId}.pid`);
+  return join(getRunsDir(), `${runId}.pid`);
 }
 
 function writePidFile(runId: string, data: PidFileData): void {
@@ -172,9 +175,9 @@ export class HostUserRuntime implements Runtime {
 
     // Check PID files for orphaned processes from a previous scheduler session
     try {
-      if (!existsSync(RUNS_DIR)) return false;
+      if (!existsSync(getRunsDir())) return false;
       const prefix = `al-${agentName}-`;
-      for (const f of readdirSync(RUNS_DIR)) {
+      for (const f of readdirSync(getRunsDir())) {
         if (!f.startsWith(prefix) || !f.endsWith(".pid")) continue;
         const runId = f.slice(0, -4);
         const data = readPidFile(runId);
@@ -204,8 +207,8 @@ export class HostUserRuntime implements Runtime {
 
     // Scan PID files for orphaned processes from a previous scheduler session
     try {
-      if (!existsSync(RUNS_DIR)) return agents;
-      for (const file of readdirSync(RUNS_DIR)) {
+      if (!existsSync(getRunsDir())) return agents;
+      for (const file of readdirSync(getRunsDir())) {
         if (!file.endsWith(".pid")) continue;
         const runId = file.slice(0, -4);
         if (knownRunIds.has(runId)) continue;
@@ -295,10 +298,10 @@ export class HostUserRuntime implements Runtime {
     const runId = `al-${opts.agentName}-${randomUUID().slice(0, 8)}`;
 
     // Ensure runs directory exists
-    mkdirSync(RUNS_DIR, { recursive: true });
+    mkdirSync(getRunsDir(), { recursive: true });
 
     // Create working directory
-    const workDir = join(RUNS_DIR, runId);
+    const workDir = join(getRunsDir(), runId);
     mkdirSync(workDir, { recursive: true, mode: 0o755 });
 
     const uid = resolveUid(this.runAs);
@@ -309,7 +312,7 @@ export class HostUserRuntime implements Runtime {
 
     // Create log file — child writes directly to this fd so output survives
     // scheduler restarts. streamLogs() tails this file using fs.watch().
-    const logPath = join(RUNS_DIR, `${runId}.log`);
+    const logPath = join(getRunsDir(), `${runId}.log`);
     const logFd = openSync(logPath, "a");
 
     // Build env vars for the child process
@@ -405,7 +408,7 @@ export class HostUserRuntime implements Runtime {
     onLine: (line: string) => void,
     _onStderr?: (text: string) => void,
   ): { stop: () => void } {
-    const logPath = join(RUNS_DIR, `${runId}.log`);
+    const logPath = join(getRunsDir(), `${runId}.log`);
     if (!existsSync(logPath)) return { stop: () => {} };
 
     let offset = 0;
@@ -520,7 +523,7 @@ export class HostUserRuntime implements Runtime {
 
   async remove(runId: string): Promise<void> {
     // Clean up working directory and PID file
-    const workDir = join(RUNS_DIR, runId);
+    const workDir = join(getRunsDir(), runId);
     try {
       rmSync(workDir, { recursive: true, force: true });
     } catch { /* best effort */ }
@@ -530,8 +533,8 @@ export class HostUserRuntime implements Runtime {
   async fetchLogs(agentName: string, limit: number): Promise<string[]> {
     // Read from log files in RUNS_DIR matching this agent
     try {
-      if (!existsSync(RUNS_DIR)) return [];
-      const files = readdirSync(RUNS_DIR)
+      if (!existsSync(getRunsDir())) return [];
+      const files = readdirSync(getRunsDir())
         .filter(f => f.startsWith(`al-${agentName}-`) && f.endsWith(".log"))
         .sort()
         .reverse();
@@ -540,7 +543,7 @@ export class HostUserRuntime implements Runtime {
       for (const file of files) {
         if (allLines.length >= limit) break;
         try {
-          const content = readFileSync(join(RUNS_DIR, file), "utf-8");
+          const content = readFileSync(join(getRunsDir(), file), "utf-8");
           allLines.push(...content.split("\n").filter(Boolean));
         } catch { /* file may be gone */ }
       }

--- a/packages/action-llama/test/docker/host-user-runtime.test.ts
+++ b/packages/action-llama/test/docker/host-user-runtime.test.ts
@@ -27,10 +27,9 @@ vi.mock("../../src/shared/credentials.js", () => ({
 import { HostUserRuntime } from "../../src/docker/host-user-runtime.js";
 import type { RuntimeCredentials } from "../../src/docker/runtime.js";
 
-const RUNS_DIR = join(tmpdir(), "al-runs");
-
 describe("HostUserRuntime", () => {
   let runtime: HostUserRuntime;
+  let testRunsDir: string;
 
   function makeFakeProc(pid?: number) {
     const { EventEmitter } = require("events");
@@ -41,17 +40,21 @@ describe("HostUserRuntime", () => {
   }
 
   function writePidFileManually(runId: string, data: any) {
-    mkdirSync(RUNS_DIR, { recursive: true });
-    writeFileSync(join(RUNS_DIR, `${runId}.pid`), JSON.stringify(data) + "\n");
+    mkdirSync(testRunsDir, { recursive: true });
+    writeFileSync(join(testRunsDir, `${runId}.pid`), JSON.stringify(data) + "\n");
   }
 
   function writeLogFile(runId: string, content: string) {
-    mkdirSync(RUNS_DIR, { recursive: true });
-    writeFileSync(join(RUNS_DIR, `${runId}.log`), content);
+    mkdirSync(testRunsDir, { recursive: true });
+    writeFileSync(join(testRunsDir, `${runId}.log`), content);
   }
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Create a fresh temp directory for each test so we never conflict with a
+    // pre-existing /tmp/al-runs that may be owned by a different user (e.g. root).
+    testRunsDir = mkdtempSync(join(tmpdir(), "al-runs-test-"));
+    process.env.AL_RUNS_DIR = testRunsDir;
     // Default: user exists with uid/gid 1001
     mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
       if (cmd === "id" && args[0] === "-u") return "1001\n";
@@ -62,16 +65,11 @@ describe("HostUserRuntime", () => {
   });
 
   afterEach(() => {
-    // Clean up test artifacts in RUNS_DIR
+    // Remove the per-test temp directory and restore the env var.
+    delete process.env.AL_RUNS_DIR;
     try {
-      for (const f of readdirSync(RUNS_DIR)) {
-        if (f.includes("-test-") || f.includes("buffer-") || f.includes("stream-") ||
-            f.includes("wait-") || f.includes("kill-") || f.includes("active-") ||
-            f.includes("listed-") || f.includes("sigkill-") || f.includes("shutdown-")) {
-          rmSync(join(RUNS_DIR, f), { recursive: true, force: true });
-        }
-      }
-    } catch { /* dir may not exist */ }
+      rmSync(testRunsDir, { recursive: true, force: true });
+    } catch { /* best effort */ }
   });
 
   describe("needsGateway", () => {
@@ -317,7 +315,7 @@ describe("HostUserRuntime", () => {
       });
 
       // launch() creates the log file via openSync. Write some content to it.
-      const logPath = join(RUNS_DIR, `${runId}.log`);
+      const logPath = join(testRunsDir, `${runId}.log`);
       writeFileSync(logPath, "hello from agent\n");
 
       const lines: string[] = [];
@@ -528,7 +526,7 @@ describe("HostUserRuntime", () => {
         expect(lines.length).toBeGreaterThan(0);
         expect(lines.some((l) => l.includes("hello"))).toBe(true);
       } finally {
-        rmSync(join(RUNS_DIR, "al-test-fetch-abc123.log"), { force: true });
+        rmSync(join(testRunsDir, "al-test-fetch-abc123.log"), { force: true });
       }
     });
   });
@@ -547,7 +545,7 @@ describe("HostUserRuntime", () => {
         credentials: { strategy: "host-user" as const, stagingDir: "/tmp/creds", bundle: {} },
       });
 
-      const pidFile = join(RUNS_DIR, `${runId}.pid`);
+      const pidFile = join(testRunsDir, `${runId}.pid`);
       expect(existsSync(pidFile)).toBe(true);
 
       const data = JSON.parse(readFileSync(pidFile, "utf-8").trim());
@@ -572,7 +570,7 @@ describe("HostUserRuntime", () => {
         credentials: { strategy: "host-user" as const, stagingDir: "/tmp/creds", bundle: {} },
       });
 
-      const pidFile = join(RUNS_DIR, `${runId}.pid`);
+      const pidFile = join(testRunsDir, `${runId}.pid`);
       expect(existsSync(pidFile)).toBe(true);
 
       fakeProc.emit("exit", 0);
@@ -590,7 +588,7 @@ describe("HostUserRuntime", () => {
         credentials: { strategy: "host-user" as const, stagingDir: "/tmp/creds", bundle: {} },
       });
 
-      const data = JSON.parse(readFileSync(join(RUNS_DIR, `${runId}.pid`), "utf-8").trim());
+      const data = JSON.parse(readFileSync(join(testRunsDir, `${runId}.pid`), "utf-8").trim());
       expect(data.env.SHUTDOWN_SECRET).toBeUndefined();
 
       fakeProc.emit("exit", 0);
@@ -618,7 +616,7 @@ describe("HostUserRuntime", () => {
 
       it("cleans up stale PID files for dead processes", async () => {
         const runId = "al-test-stale-deadbeef";
-        const pidFile = join(RUNS_DIR, `${runId}.pid`);
+        const pidFile = join(testRunsDir, `${runId}.pid`);
         writePidFileManually(runId, {
           pid: 2147483647,
           agentName: "test-stale",
@@ -633,12 +631,12 @@ describe("HostUserRuntime", () => {
 
       it("removes corrupt PID files", async () => {
         const runId = "al-test-corrupt-abc123";
-        mkdirSync(RUNS_DIR, { recursive: true });
-        writeFileSync(join(RUNS_DIR, `${runId}.pid`), "not valid json\n");
+        mkdirSync(testRunsDir, { recursive: true });
+        writeFileSync(join(testRunsDir, `${runId}.pid`), "not valid json\n");
 
         const agents = await runtime.listRunningAgents();
         expect(agents.find(a => a.taskId === runId)).toBeUndefined();
-        expect(existsSync(join(RUNS_DIR, `${runId}.pid`))).toBe(false);
+        expect(existsSync(join(testRunsDir, `${runId}.pid`))).toBe(false);
       });
     });
 
@@ -674,7 +672,7 @@ describe("HostUserRuntime", () => {
 
       it("returns null and cleans up PID file for dead process", async () => {
         const runId = "al-test-dead-abc12345";
-        const pidFile = join(RUNS_DIR, `${runId}.pid`);
+        const pidFile = join(testRunsDir, `${runId}.pid`);
         writePidFileManually(runId, {
           pid: 2147483647,
           agentName: "test-dead",
@@ -716,7 +714,7 @@ describe("HostUserRuntime", () => {
 
       it("cleans up PID file when orphan is already dead", async () => {
         const runId = "al-test-deadorphan-abc123";
-        const pidFile = join(RUNS_DIR, `${runId}.pid`);
+        const pidFile = join(testRunsDir, `${runId}.pid`);
         writePidFileManually(runId, {
           pid: 2147483647,
           agentName: "test-deadorphan",
@@ -732,7 +730,7 @@ describe("HostUserRuntime", () => {
     describe("remove cleans up PID file", () => {
       it("removes PID file along with working directory", async () => {
         const runId = "al-test-removepid-abc123";
-        const pidFile = join(RUNS_DIR, `${runId}.pid`);
+        const pidFile = join(testRunsDir, `${runId}.pid`);
         writePidFileManually(runId, {
           pid: 12345,
           agentName: "test-removepid",


### PR DESCRIPTION
Closes #432

## Summary

When `/tmp/al-runs` already exists and is owned by root (as happens in the Action-Llama scheduler's host-user runtime environment), the `al-agent` user (uid=998) cannot create subdirectories or files inside it, causing 37 of 52 `HostUserRuntime` unit tests to fail with `EACCES: permission denied`.

## Changes

### `src/docker/host-user-runtime.ts`
- Replaced the hardcoded `const RUNS_DIR = join(tmpdir(), 'al-runs')` constant with a `getRunsDir()` function that reads `process.env.AL_RUNS_DIR` and falls back to `/tmp/al-runs` when the env var is not set.
- All internal usages of `RUNS_DIR` updated to call `getRunsDir()`.
- This is backwards-compatible: production behaviour is unchanged unless `AL_RUNS_DIR` is explicitly set.

### `test/docker/host-user-runtime.test.ts`
- Removed the module-level `const RUNS_DIR` constant.
- Added a `testRunsDir` variable that is populated with a fresh `mkdtempSync` directory in `beforeEach` and `process.env.AL_RUNS_DIR` is set to it, so the runtime under test writes to the isolated temp dir.
- `afterEach` deletes the temp dir and unsets `AL_RUNS_DIR`, ensuring no cross-test pollution.
- All test-body references to the old `RUNS_DIR` constant replaced with `testRunsDir`.

## Verification

All 52 `HostUserRuntime` unit tests now pass, and the full suite of 4176 tests passes with no regressions.