### PR TITLE
fix: replace jq with shell string concatenation in al-subagent scripts

### DIFF
--- a/.changeset/fix-subagent-jq-dependency.md
+++ b/.changeset/fix-subagent-jq-dependency.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Replace jq dependency in al-subagent and al-subagent-wait scripts with shell string concatenation, fixing test failures in environments without jq installed

--- a/packages/action-llama/docker/bin/al-subagent
+++ b/packages/action-llama/docker/bin/al-subagent
@@ -7,8 +7,7 @@ if [ -z "$1" ]; then echo '{"ok":false,"reason":"usage: echo ctx | al-subagent <
 CONTEXT=$(cat)
 _raw=$(curl -s -w '\n%{http_code}' -X POST "$GATEWAY_URL/calls" \
   -H 'Content-Type: application/json' \
-  -d "$(jq -n --arg s "$SHUTDOWN_SECRET" --arg t "$1" --arg c "$CONTEXT" \
-    '{secret:$s,targetAgent:$t,context:$c}')")
+  -d '{"secret":"'"$SHUTDOWN_SECRET"'","targetAgent":"'"$1"'","context":"'"$CONTEXT"'"}')
 AL_HTTP_CODE=$(printf '%s' "$_raw" | tail -n1)
 printf '%s' "$_raw" | sed '$d'
 http_exit "$AL_HTTP_CODE"

--- a/packages/action-llama/docker/bin/al-subagent-wait
+++ b/packages/action-llama/docker/bin/al-subagent-wait
@@ -20,7 +20,7 @@ while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
     _code=$(printf '%s' "$_raw" | tail -n1)
     # On connection failure during polling, keep trying
     case "$_code" in 000) ALL_DONE=false; continue;; esac
-    STATUS=$(printf '%s' "$_raw" | sed '$d' | jq -r .status 2>/dev/null)
+    STATUS=$(printf '%s' "$_raw" | sed '$d' | sed -n 's/.*"status":"\([^"]*\)".*/\1/p')
     case "$STATUS" in running|pending) ALL_DONE=false;; esac
   done
   if $ALL_DONE; then break; fi


### PR DESCRIPTION
Closes #431

## Summary

Replaced `jq` usage in `al-subagent` and `al-subagent-wait` shell scripts with plain shell string concatenation, matching the pattern already used in `rlock`, `runlock`, and other gateway scripts.

### Changes

- **`al-subagent`**: Replaced `jq -n --arg ...` JSON construction with shell string interpolation (`'{"secret":"'"aa1de992-fe33-4403-9500-ae424481f0d1"'",...}'`).
- **`al-subagent-wait`**: Replaced `jq -r .status` status parsing with `sed -n 's/.*"status":"\([^"]*\)".*/\1/p'`.
- **`al-subagent-check`**: No `jq` usage to replace — tests for this script were failing because they depend on `al-subagent` working correctly first.

### Tests

All 33 tests in `command-exit-codes.test.ts` now pass, including the previously failing:
- `al-subagent > exit 0 — dispatches call`
- `al-subagent > exit 1 — dispatch rejected`
- `al-subagent > exit 3 — invalid secret`
- `al-subagent-check > exit 0 — checks running call`
- `al-subagent-wait > exit 0 — all calls complete`
- `al-subagent-wait > exit 8 — timeout`