### PR TITLE
Web UI nav bar update: mobile responsiveness and agents page heading

### DIFF
--- a/.changeset/nav-bar-mobile-update.md
+++ b/.changeset/nav-bar-mobile-update.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/frontend": patch
+---
+
+Update navbar for mobile: show "AL" instead of "Action Llama", icon-only nav links with larger icons on mobile. Add standalone "Agents" page heading and remove title from agents table header.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13799,7 +13799,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.20.0",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
@@ -13884,7 +13884,7 @@
     },
     "packages/frontend": {
       "name": "@action-llama/frontend",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
         "react": "^19.2.4",
         "react-dom": "^19.2.4",

--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -43,7 +43,8 @@ function Navbar() {
             to="/dashboard"
             className="text-lg font-bold text-slate-900 dark:text-white hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
           >
-            Action Llama
+            <span className="hidden sm:inline">Action Llama</span>
+            <span className="sm:hidden">AL</span>
           </Link>
           <Link
             to="/dashboard"
@@ -53,13 +54,13 @@ function Navbar() {
                 : "text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
             }`}
           >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="w-5 h-5 sm:w-4 sm:h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <rect x="3" y="4" width="18" height="12" rx="2" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" />
               <circle cx="9" cy="10" r="1.5" fill="currentColor" stroke="none" />
               <circle cx="15" cy="10" r="1.5" fill="currentColor" stroke="none" />
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 20h8M12 16v4" />
             </svg>
-            Agents
+            <span className="hidden sm:inline">Agents</span>
           </Link>
           <Link
             to="/activity"
@@ -69,10 +70,10 @@ function Navbar() {
                 : "text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
             }`}
           >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="w-5 h-5 sm:w-4 sm:h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
             </svg>
-            Activity
+            <span className="hidden sm:inline">Activity</span>
           </Link>
           <Link
             to="/dashboard/config"
@@ -83,7 +84,7 @@ function Navbar() {
             }`}
           >
             <svg
-              className="w-4 h-4"
+              className="w-5 h-5 sm:w-4 sm:h-4"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -101,7 +102,7 @@ function Navbar() {
                 d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
               />
             </svg>
-            Settings
+            <span className="hidden sm:inline">Settings</span>
           </Link>
         </div>
         <div className="flex items-center gap-3">

--- a/packages/frontend/src/pages/DashboardPage.tsx
+++ b/packages/frontend/src/pages/DashboardPage.tsx
@@ -183,6 +183,11 @@ export function DashboardPage() {
         </div>
       )}
 
+      {/* Header */}
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <h1 className="text-xl font-bold text-slate-900 dark:text-white">Agents</h1>
+      </div>
+
       {/* Token usage bar */}
       {totalTokens > 0 && (
         <div className="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 p-3">
@@ -231,10 +236,7 @@ export function DashboardPage() {
       {/* Agents table — full width */}
       <div className="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden">
         {/* Header with search */}
-        <div className="flex items-center justify-between px-4 py-2.5 border-b border-slate-200 dark:border-slate-800">
-          <h2 className="text-sm font-medium text-slate-900 dark:text-white">
-            Agents
-          </h2>
+        <div className="flex items-center justify-end px-4 py-2.5 border-b border-slate-200 dark:border-slate-800">
           <div className="relative">
             <input
               type="text"


### PR DESCRIPTION
Closes #440

## Changes

### Layout.tsx (Navbar)
- **Mobile title**: Shows "AL" on mobile (< 640px), "Action Llama" on desktop using responsive Tailwind classes
- **Icon-only nav on mobile**: Nav link icons are slightly larger (`w-5 h-5`) on mobile; text labels (Agents, Activity, Settings) are hidden on mobile with `hidden sm:inline`

### DashboardPage.tsx
- **Page heading**: Added standalone `<h1>Agents</h1>` at the top of the page, following the same pattern as ActivityPage
- **Table header**: Removed the "Agents" `<h2>` from the table header (title is now the page heading); search input remains in the table header with `justify-end` alignment

### Testing
- Build passes with no TypeScript errors
- Mobile (< 640px): "AL" title, larger icon-only nav links, "Agents" heading above table, search in table header
- Desktop (≥ 640px): "Action Llama" title, icon + text nav links, same page heading