### PR TITLE
fix: remove dead URI scheme validation branch in locks routes

### DIFF
--- a/.changeset/fix-dead-code-locks-uri-validation.md
+++ b/.changeset/fix-dead-code-locks-uri-validation.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Remove dead code in execution/routes/locks.ts — the invalid URI scheme branch was unreachable since `new URL()` already rejects URIs with invalid schemes (e.g. `123://...`) by throwing, which is caught by the existing catch block.

--- a/packages/action-llama/src/execution/routes/locks.ts
+++ b/packages/action-llama/src/execution/routes/locks.ts
@@ -33,12 +33,7 @@ export function registerLockRoutes(
 
     // Validate that resourceKey is a valid URI
     try {
-      const url = new URL(resourceKey);
-      const validSchemePattern = /^[a-z][a-z0-9+.-]*$/;
-      if (!validSchemePattern.test(url.protocol.slice(0, -1))) {
-        logger.warn({ route: "/locks/acquire", resourceKey }, "invalid URI scheme");
-        return c.json({ error: `Invalid URI scheme '${url.protocol}'. URI schemes must match pattern [a-z][a-z0-9+.-]*:` }, 400);
-      }
+      new URL(resourceKey);
     } catch (error) {
       logger.warn({ route: "/locks/acquire", resourceKey }, "invalid URI format");
       return c.json({ error: `Invalid URI format: ${error instanceof Error ? error.message : 'unknown error'}` }, 400);
@@ -103,12 +98,7 @@ export function registerLockRoutes(
 
     // Validate that resourceKey is a valid URI
     try {
-      const url = new URL(resourceKey);
-      const validSchemePattern = /^[a-z][a-z0-9+.-]*$/;
-      if (!validSchemePattern.test(url.protocol.slice(0, -1))) {
-        logger.warn({ route: "/locks/release", resourceKey }, "invalid URI scheme");
-        return c.json({ error: `Invalid URI scheme '${url.protocol}'. URI schemes must match pattern [a-z][a-z0-9+.-]*:` }, 400);
-      }
+      new URL(resourceKey);
     } catch (error) {
       logger.warn({ route: "/locks/release", resourceKey }, "invalid URI format");
       return c.json({ error: `Invalid URI format: ${error instanceof Error ? error.message : 'unknown error'}` }, 400);
@@ -154,12 +144,7 @@ export function registerLockRoutes(
 
     // Validate that resourceKey is a valid URI
     try {
-      const url = new URL(resourceKey);
-      const validSchemePattern = /^[a-z][a-z0-9+.-]*$/;
-      if (!validSchemePattern.test(url.protocol.slice(0, -1))) {
-        logger.warn({ route: "/locks/heartbeat", resourceKey }, "invalid URI scheme");
-        return c.json({ error: `Invalid URI scheme '${url.protocol}'. URI schemes must match pattern [a-z][a-z0-9+.-]*:` }, 400);
-      }
+      new URL(resourceKey);
     } catch (error) {
       logger.warn({ route: "/locks/heartbeat", resourceKey }, "invalid URI format");
       return c.json({ error: `Invalid URI format: ${error instanceof Error ? error.message : 'unknown error'}` }, 400);


### PR DESCRIPTION
Closes #447

## Summary

Removed dead code in `src/execution/routes/locks.ts` across all three route handlers (`/locks/acquire`, `/locks/release`, `/locks/heartbeat`).

## Problem

Each route contained a `validSchemePattern` check after calling `new URL(resourceKey)`:

```typescript
const url = new URL(resourceKey);
const validSchemePattern = /^[a-z][a-z0-9+.-]*$/;
if (!validSchemePattern.test(url.protocol.slice(0, -1))) {
  // ← this branch was unreachable
}
```

The `new URL()` constructor already rejects URIs with invalid schemes (e.g. `123://invalid`) by throwing a `TypeError`, which is caught by the surrounding `try/catch` block. Any URI that passes `new URL()` without throwing has a valid, lowercase-normalized scheme that already satisfies `[a-z][a-z0-9+.-]*`. The `if` block could never be entered.

## Fix

Removed the 6 dead statements (2 per handler × 3 handlers) — the `validSchemePattern` variable, the regex test, and the early return. The `try/catch` around `new URL()` is kept and continues to handle all invalid URI formats.

## Tests

All 43 existing tests in `test/execution/routes/locks.test.ts` pass, including the URI validation tests that cover the `123://invalid-scheme` case.