### PR TITLE
feat: agent admin page with gear icon link

### DIFF
--- a/.changeset/agent-admin-page.md
+++ b/.changeset/agent-admin-page.md
@@ -1,0 +1,6 @@
+---
+"@action-llama/frontend": minor
+"@action-llama/action-llama": minor
+---
+
+Add agent admin page with gear icon link from agent detail. Moves Scale, Enable/Disable, and Skill content to a combined admin page. Replaces Run/Chat buttons with a RunDropdown split-button component.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6042,7 +6042,7 @@
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -6148,7 +6148,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7368,7 +7368,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {

--- a/packages/action-llama/test/playwright/dashboard.spec.ts
+++ b/packages/action-llama/test/playwright/dashboard.spec.ts
@@ -237,34 +237,10 @@ test.describe("Agent detail", () => {
     await expect(page.locator("#agent-state")).toContainText("running", { timeout: 5000 });
   });
 
-  test("Enable/Disable toggle updates via SSE", async ({ page }) => {
-    const btn = page.locator("#toggle-btn");
-    await expect(btn).toContainText("Disable");
-    await btn.click();
-    await expect(btn).toContainText("Enable", { timeout: 5000 });
-    await btn.click();
-    await expect(btn).toContainText("Disable", { timeout: 5000 });
-  });
-
-  test("View Skill link is visible", async ({ page }) => {
-    const link = page.locator('a[href="/dashboard/agents/single-agent/skill"]');
+  test("Admin link is visible", async ({ page }) => {
+    const link = page.locator('a[href="/dashboard/agents/single-agent/admin"]');
     await expect(link).toBeVisible();
-    await expect(link).toContainText("View Skill");
-  });
-
-  test("scale input shows current value and Update button exists", async ({ page }) => {
-    await expect(page.locator("#agent-scale-input")).toBeVisible();
-    await expect(page.locator("#agent-scale-input")).toHaveValue("1");
-    await expect(page.locator("#update-agent-scale-btn")).toBeVisible();
-  });
-
-  test("scale update shows success alert", async ({ page }) => {
-    const dialogPromise = page.waitForEvent("dialog");
-    await page.fill("#agent-scale-input", "3");
-    await page.click("#update-agent-scale-btn");
-    const dialog = await dialogPromise;
-    expect(dialog.message()).toContain("Agent scale updated");
-    await dialog.accept();
+    await expect(link).toContainText("Admin");
   });
 
   test("Kill All button is disabled when no instances running", async ({ page }) => {
@@ -305,13 +281,58 @@ test.describe("Agent detail", () => {
   });
 });
 
+// ──── Agent admin ─────────────────────────────────────────────────────
+
+test.describe("Agent admin", () => {
+  test.beforeEach(async ({ page, request }) => {
+    await resetState(request);
+    await login(page);
+    await page.goto("/dashboard/agents/single-agent/admin");
+  });
+
+  test("shows agent name and Admin subtitle", async ({ page }) => {
+    await expect(page.locator("h1")).toContainText("single-agent");
+    await expect(page.locator("text=Admin")).toBeVisible();
+  });
+
+  test("scale input shows current value and Update button exists", async ({ page }) => {
+    await expect(page.locator("#agent-scale-input")).toBeVisible();
+    await expect(page.locator("#agent-scale-input")).toHaveValue("1");
+    await expect(page.locator("#update-agent-scale-btn")).toBeVisible();
+  });
+
+  test("scale update shows success alert", async ({ page }) => {
+    const dialogPromise = page.waitForEvent("dialog");
+    await page.fill("#agent-scale-input", "3");
+    await page.click("#update-agent-scale-btn");
+    const dialog = await dialogPromise;
+    expect(dialog.message()).toContain("Agent scale updated");
+    await dialog.accept();
+  });
+
+  test("Enable/Disable toggle updates via SSE", async ({ page }) => {
+    const btn = page.locator("#toggle-btn");
+    await expect(btn).toContainText("Disable");
+    await btn.click();
+    await expect(btn).toContainText("Enable", { timeout: 5000 });
+    await btn.click();
+    await expect(btn).toContainText("Disable", { timeout: 5000 });
+  });
+
+  test("skill route redirects to admin", async ({ page }) => {
+    await page.goto("/dashboard/agents/single-agent/skill");
+    await page.waitForURL("**/dashboard/agents/single-agent/admin");
+    await expect(page.locator("h1")).toContainText("single-agent");
+  });
+});
+
 // ──── Agent detail (scaled) ───────────────────────────────────────────
 
 test.describe("Agent detail — scaled agent", () => {
   test.beforeEach(async ({ page, request }) => {
     await resetState(request);
     await login(page);
-    await page.goto("/dashboard/agents/scaled-agent");
+    await page.goto("/dashboard/agents/scaled-agent/admin");
   });
 
   test("shows scale=2 in the scale input", async ({ page }) => {

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -3,11 +3,11 @@ import { Layout } from "./components/Layout";
 import { LoginPage } from "./pages/LoginPage";
 import { DashboardPage } from "./pages/DashboardPage";
 import { AgentDetailPage } from "./pages/AgentDetailPage";
+import { AgentAdminPage } from "./pages/AgentAdminPage";
 import { InstanceDetailPage } from "./pages/InstanceDetailPage";
 import { ActivityPage } from "./pages/ActivityPage";
 import { TriggerDetailPage } from "./pages/TriggerDetailPage";
 import { ProjectConfigPage } from "./pages/ProjectConfigPage";
-import { AgentSkillPage } from "./pages/AgentSkillPage";
 import { AgentStatsPage } from "./pages/AgentStatsPage";
 import { ChatPage } from "./pages/ChatPage";
 import { WebhookReceiptPage } from "./pages/WebhookReceiptPage";
@@ -15,6 +15,11 @@ import { WebhookReceiptPage } from "./pages/WebhookReceiptPage";
 function AgentTriggersRedirect() {
   const { name } = useParams<{ name: string }>();
   return <Navigate to={`/activity?agent=${encodeURIComponent(name ?? "")}`} replace />;
+}
+
+function AgentSkillRedirect() {
+  const { name } = useParams<{ name: string }>();
+  return <Navigate to={`/dashboard/agents/${encodeURIComponent(name ?? "")}/admin`} replace />;
 }
 
 export function App() {
@@ -35,8 +40,12 @@ export function App() {
           element={<AgentTriggersRedirect />}
         />
         <Route
+          path="/dashboard/agents/:name/admin"
+          element={<AgentAdminPage />}
+        />
+        <Route
           path="/dashboard/agents/:name/skill"
-          element={<AgentSkillPage />}
+          element={<AgentSkillRedirect />}
         />
         <Route
           path="/dashboard/agents/:name/stats"

--- a/packages/frontend/src/components/RunDropdown.tsx
+++ b/packages/frontend/src/components/RunDropdown.tsx
@@ -1,0 +1,65 @@
+import { useRef, useState, useEffect } from "react";
+
+interface RunDropdownProps {
+  disabled?: boolean;
+  onQuickRun: () => void;
+  onRunWithPrompt: () => void;
+  onChat: () => void;
+}
+
+export function RunDropdown({ disabled, onQuickRun, onRunWithPrompt, onChat }: RunDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleMouseDown(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [open]);
+
+  return (
+    <div className="relative inline-flex" ref={menuRef}>
+      {/* Primary Run button */}
+      <button
+        onClick={onQuickRun}
+        disabled={disabled}
+        className="px-3 py-1.5 text-xs font-medium rounded-l-md bg-green-600 hover:bg-green-700 disabled:opacity-40 disabled:cursor-not-allowed text-white transition-colors"
+      >
+        Run
+      </button>
+      {/* Caret / dropdown toggle */}
+      <button
+        onClick={() => setOpen((v) => !v)}
+        disabled={disabled}
+        className="px-1.5 py-1.5 text-xs font-medium rounded-r-md bg-green-600 hover:bg-green-700 disabled:opacity-40 disabled:cursor-not-allowed text-white transition-colors border-l border-green-700"
+        aria-label="More run options"
+      >
+        <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {/* Dropdown menu */}
+      {open && (
+        <div className="absolute right-0 mt-8 w-40 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-md shadow-lg z-10 py-1">
+          <button
+            onClick={() => { setOpen(false); onRunWithPrompt(); }}
+            className="w-full text-left px-3 py-1.5 text-xs text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
+          >
+            Run with Prompt
+          </button>
+          <button
+            onClick={() => { setOpen(false); onChat(); }}
+            className="w-full text-left px-3 py-1.5 text-xs text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
+          >
+            Chat
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/AgentAdminPage.tsx
+++ b/packages/frontend/src/pages/AgentAdminPage.tsx
@@ -1,0 +1,475 @@
+import { useEffect, useState, useCallback } from "react";
+import { useParams, Link } from "react-router-dom";
+import { useStatusStream } from "../hooks/StatusStreamContext";
+import {
+  getAgentSkill,
+  getAgentDetail,
+  updateAgentScale,
+  enableAgent,
+  disableAgent,
+} from "../lib/api";
+import type { AgentConfig, AgentDetailData } from "../lib/api";
+
+// ── Markdown helpers (copied from AgentSkillPage) ─────────────────────
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function renderInline(text: string): string {
+  let result = escapeHtml(text);
+
+  result = result.replace(
+    /`([^`]+)`/g,
+    '<code class="bg-slate-200 dark:bg-slate-800 px-1 py-0.5 rounded text-sm font-mono">$1</code>',
+  );
+
+  result = result.replace(
+    /\[([^\]]+)\]\(([^)]+)\)/g,
+    '<a href="$2" class="text-blue-600 dark:text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">$1</a>',
+  );
+
+  result = result.replace(
+    /\*\*([^*]+)\*\*/g,
+    '<strong class="font-semibold">$1</strong>',
+  );
+
+  result = result.replace(
+    /\*([^*]+)\*/g,
+    '<em class="italic">$1</em>',
+  );
+
+  return result;
+}
+
+function renderMarkdown(content: string): string {
+  if (!content) return "";
+
+  const lines = content.split("\n");
+  const result: string[] = [];
+  let inCodeBlock = false;
+  let codeBlockLanguage = "";
+  let currentList: { type: "ul" | "ol"; items: string[] } | null = null;
+
+  function closeCurrentList() {
+    if (currentList) {
+      const listClass =
+        currentList.type === "ul"
+          ? "list-disc list-inside mb-4 space-y-1"
+          : "list-decimal list-inside mb-4 space-y-1";
+      result.push(`<${currentList.type} class="${listClass}">`);
+      for (const item of currentList.items) {
+        result.push(`<li class="ml-2">${renderInline(item)}</li>`);
+      }
+      result.push(`</${currentList.type}>`);
+      currentList = null;
+    }
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    if (trimmed.startsWith("```")) {
+      if (inCodeBlock) {
+        result.push("</code></pre>");
+        inCodeBlock = false;
+        codeBlockLanguage = "";
+      } else {
+        closeCurrentList();
+        codeBlockLanguage = trimmed.slice(3).trim();
+        const langClass = codeBlockLanguage
+          ? ` language-${escapeHtml(codeBlockLanguage)}`
+          : "";
+        result.push(
+          `<pre class="bg-slate-100 dark:bg-slate-900 rounded-lg p-4 overflow-x-auto text-sm"><code${langClass ? ` class="${langClass}"` : ""}>`,
+        );
+        inCodeBlock = true;
+      }
+      continue;
+    }
+
+    if (inCodeBlock) {
+      result.push(escapeHtml(line));
+      continue;
+    }
+
+    if (!trimmed) {
+      closeCurrentList();
+      result.push("<br>");
+      continue;
+    }
+
+    if (trimmed.startsWith("#")) {
+      closeCurrentList();
+      const headerMatch = trimmed.match(/^(#+)\s+(.+)$/);
+      if (headerMatch) {
+        const level = Math.min(headerMatch[1].length, 6);
+        const text = headerMatch[2];
+        const sizeClass =
+          level === 1
+            ? "text-2xl"
+            : level === 2
+              ? "text-xl"
+              : level === 3
+                ? "text-lg"
+                : "text-base";
+        result.push(
+          `<h${level} class="${sizeClass} font-bold text-slate-900 dark:text-white mt-6 mb-3">${renderInline(text)}</h${level}>`,
+        );
+      }
+      continue;
+    }
+
+    const ulMatch = trimmed.match(/^[-*+]\s+(.+)$/);
+    const olMatch = trimmed.match(/^\d+\.\s+(.+)$/);
+
+    if (ulMatch) {
+      if (!currentList || currentList.type !== "ul") {
+        closeCurrentList();
+        currentList = { type: "ul", items: [] };
+      }
+      currentList.items.push(ulMatch[1]);
+      continue;
+    }
+
+    if (olMatch) {
+      if (!currentList || currentList.type !== "ol") {
+        closeCurrentList();
+        currentList = { type: "ol", items: [] };
+      }
+      currentList.items.push(olMatch[1]);
+      continue;
+    }
+
+    closeCurrentList();
+    if (trimmed) {
+      result.push(
+        `<p class="mb-4 leading-relaxed">${renderInline(trimmed)}</p>`,
+      );
+    }
+  }
+
+  if (inCodeBlock) {
+    result.push("</code></pre>");
+  }
+  closeCurrentList();
+
+  return result.join("\n");
+}
+
+// ── Component ─────────────────────────────────────────────────────────
+
+export function AgentAdminPage() {
+  const { name } = useParams<{ name: string }>();
+  const { agents } = useStatusStream();
+
+  const [detail, setDetail] = useState<AgentDetailData | null>(null);
+  const [scaleInput, setScaleInput] = useState("");
+  const [body, setBody] = useState<string | null>(null);
+  const [agentConfig, setAgentConfig] = useState<AgentConfig | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const agent = agents.find((a) => a.name === name) ?? detail?.agent ?? null;
+
+  // Load detail (for scale)
+  const refetchDetail = useCallback(() => {
+    if (!name) return;
+    getAgentDetail(name)
+      .then((d) => {
+        setDetail(d);
+        if (d.agent) setScaleInput(String(d.agent.scale));
+      })
+      .catch(() => {});
+  }, [name]);
+
+  useEffect(() => {
+    refetchDetail();
+  }, [refetchDetail]);
+
+  // Sync scale input when agent updates via SSE
+  useEffect(() => {
+    if (agent) setScaleInput(String(agent.scale));
+  }, [agent?.scale]);
+
+  // Load skill
+  useEffect(() => {
+    if (!name) return;
+    getAgentSkill(name)
+      .then((d) => {
+        setBody(d.body);
+        setAgentConfig(d.agentConfig);
+      })
+      .catch((err) =>
+        setError(err instanceof Error ? err.message : "Failed to load skill"),
+      );
+  }, [name]);
+
+  const handleAction = useCallback(async (fn: () => Promise<unknown>) => {
+    setActionError(null);
+    try {
+      await fn();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Action failed");
+    }
+  }, []);
+
+  const handleScaleUpdate = useCallback(() => {
+    if (!name) return;
+    const val = parseInt(scaleInput, 10);
+    if (isNaN(val) || val < 1) return;
+    handleAction(() => updateAgentScale(name, val));
+  }, [name, scaleInput, handleAction]);
+
+  if (!name) return null;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <div className="flex items-center gap-3">
+          <Link
+            to={`/dashboard/agents/${encodeURIComponent(name)}`}
+            className="text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </Link>
+          <div>
+            <h1 className="text-xl font-bold text-slate-900 dark:text-white">
+              {name}
+            </h1>
+            <div className="text-xs text-slate-500 dark:text-slate-400">
+              Admin
+            </div>
+          </div>
+        </div>
+        <Link
+          to={`/dashboard/agents/${encodeURIComponent(name)}`}
+          className="px-3 py-1.5 text-xs font-medium rounded-md bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700 transition-colors"
+        >
+          Back to Agent
+        </Link>
+      </div>
+
+      {actionError && (
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3 text-sm text-red-700 dark:text-red-400">
+          {actionError}
+        </div>
+      )}
+
+      {/* Controls */}
+      <div className="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden">
+        <div className="px-4 py-2.5 border-b border-slate-200 dark:border-slate-800">
+          <h2 className="text-sm font-medium text-slate-900 dark:text-white">Controls</h2>
+        </div>
+        <div className="p-4 flex items-center gap-4 flex-wrap">
+          {/* Scale */}
+          <div className="flex items-center gap-1">
+            <span className="text-xs text-slate-500 dark:text-slate-400">Scale:</span>
+            <input
+              id="agent-scale-input"
+              type="number"
+              min={1}
+              value={scaleInput}
+              onChange={(e) => setScaleInput(e.target.value)}
+              className="w-16 px-2 py-1 bg-white dark:bg-slate-950 border border-slate-300 dark:border-slate-700 rounded text-base text-slate-900 dark:text-slate-200"
+            />
+            <button
+              id="update-agent-scale-btn"
+              onClick={handleScaleUpdate}
+              className="px-2 py-1.5 text-xs font-medium rounded-md bg-blue-600 hover:bg-blue-700 text-white transition-colors"
+            >
+              Set
+            </button>
+          </div>
+          {/* Enable / Disable */}
+          {agent && (
+            <button
+              id="toggle-btn"
+              onClick={() =>
+                handleAction(() =>
+                  agent.enabled ? disableAgent(name) : enableAgent(name),
+                )
+              }
+              className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+                agent.enabled
+                  ? "bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-600"
+                  : "bg-blue-600 hover:bg-blue-700 text-white"
+              }`}
+            >
+              {agent.enabled ? "Disable" : "Enable"}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Configuration (from skill) */}
+      {agentConfig && (
+        <div className="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden">
+          <div className="px-4 py-2.5 border-b border-slate-200 dark:border-slate-800">
+            <h2 className="text-sm font-medium text-slate-900 dark:text-white">
+              Configuration
+            </h2>
+          </div>
+          <div className="p-4 space-y-4 text-sm">
+            {agentConfig.description && (
+              <p className="text-slate-700 dark:text-slate-300">{agentConfig.description}</p>
+            )}
+            <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3">
+              {agentConfig.schedule && (
+                <div>
+                  <dt className="text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wide">Schedule</dt>
+                  <dd className="mt-0.5">
+                    <code className="text-xs bg-slate-200 dark:bg-slate-800 px-1.5 py-0.5 rounded font-mono">{agentConfig.schedule}</code>
+                  </dd>
+                </div>
+              )}
+              {agentConfig.models && agentConfig.models.length > 0 && (
+                <div>
+                  <dt className="text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wide">Models</dt>
+                  <dd className="mt-0.5 space-y-0.5">
+                    {agentConfig.models.map((m, i) => (
+                      <div key={i} className="text-xs text-slate-700 dark:text-slate-300">
+                        {m.provider}/{m.model}{m.thinkingLevel ? ` (${m.thinkingLevel})` : ""}
+                        <span className="text-slate-400 dark:text-slate-500 ml-1">[{m.authType}]</span>
+                      </div>
+                    ))}
+                  </dd>
+                </div>
+              )}
+              {agentConfig.credentials && agentConfig.credentials.length > 0 && (
+                <div>
+                  <dt className="text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wide">Credentials</dt>
+                  <dd className="mt-0.5 flex flex-wrap gap-1">
+                    {agentConfig.credentials.map((c) => (
+                      <span key={c} className="px-1.5 py-0.5 text-xs bg-slate-200 dark:bg-slate-800 rounded font-mono">{c}</span>
+                    ))}
+                  </dd>
+                </div>
+              )}
+              {agentConfig.hooks && (agentConfig.hooks.pre?.length || agentConfig.hooks.post?.length) && (
+                <div>
+                  <dt className="text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wide">Hooks</dt>
+                  <dd className="mt-0.5 text-xs text-slate-700 dark:text-slate-300">
+                    {agentConfig.hooks.pre && agentConfig.hooks.pre.length > 0 && <div>Pre: {agentConfig.hooks.pre.join(", ")}</div>}
+                    {agentConfig.hooks.post && agentConfig.hooks.post.length > 0 && <div>Post: {agentConfig.hooks.post.join(", ")}</div>}
+                  </dd>
+                </div>
+              )}
+              {agentConfig.params && Object.keys(agentConfig.params).length > 0 && (
+                <div className="sm:col-span-2">
+                  <dt className="text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wide">Params</dt>
+                  <dd className="mt-0.5">
+                    <pre className="text-xs bg-slate-200 dark:bg-slate-800 p-2 rounded overflow-x-auto">
+                      {JSON.stringify(agentConfig.params, null, 2)}
+                    </pre>
+                  </dd>
+                </div>
+              )}
+            </dl>
+            {agentConfig.webhooks && agentConfig.webhooks.length > 0 && (
+              <div>
+                <h3 className="text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-2">Webhook Filters</h3>
+                <div className="space-y-3">
+                  {agentConfig.webhooks.map((w, i) => (
+                    <div key={i} className="bg-slate-100 dark:bg-slate-800 rounded p-3 text-xs space-y-1">
+                      <div className="font-medium text-slate-700 dark:text-slate-300">
+                        {w.source ?? "unknown"}
+                      </div>
+                      {w.events && w.events.length > 0 && (
+                        <div className="text-slate-600 dark:text-slate-400">
+                          <span className="text-slate-500">events:</span>{" "}
+                          {w.events.map((e) => (
+                            <span key={e} className="inline-block mr-1 px-1.5 py-0.5 bg-slate-200 dark:bg-slate-700 rounded font-mono">{e}</span>
+                          ))}
+                        </div>
+                      )}
+                      {w.actions && w.actions.length > 0 && (
+                        <div className="text-slate-600 dark:text-slate-400">
+                          <span className="text-slate-500">actions:</span> {w.actions.join(", ")}
+                        </div>
+                      )}
+                      {w.repos && w.repos.length > 0 && (
+                        <div className="text-slate-600 dark:text-slate-400">
+                          <span className="text-slate-500">repos:</span> {w.repos.join(", ")}
+                        </div>
+                      )}
+                      {(w.org || (w.orgs && w.orgs.length > 0)) && (
+                        <div className="text-slate-600 dark:text-slate-400">
+                          <span className="text-slate-500">orgs:</span> {w.org ?? w.orgs?.join(", ")}
+                        </div>
+                      )}
+                      {w.branches && w.branches.length > 0 && (
+                        <div className="text-slate-600 dark:text-slate-400">
+                          <span className="text-slate-500">branches:</span> {w.branches.join(", ")}
+                        </div>
+                      )}
+                      {w.labels && w.labels.length > 0 && (
+                        <div className="text-slate-600 dark:text-slate-400">
+                          <span className="text-slate-500">labels:</span> {w.labels.join(", ")}
+                        </div>
+                      )}
+                      {w.assignee && (
+                        <div className="text-slate-600 dark:text-slate-400">
+                          <span className="text-slate-500">assignee:</span> {w.assignee}
+                        </div>
+                      )}
+                      {w.author && (
+                        <div className="text-slate-600 dark:text-slate-400">
+                          <span className="text-slate-500">author:</span> {w.author}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Skill body */}
+      {error ? (
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-sm text-red-700 dark:text-red-400">
+          {error}
+        </div>
+      ) : body === null ? (
+        <div className="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 p-8 text-center text-slate-500 dark:text-slate-400">
+          Loading...
+        </div>
+      ) : (
+        <div className="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden">
+          <div className="px-4 py-2.5 border-b border-slate-200 dark:border-slate-800">
+            <h2 className="text-sm font-medium text-slate-900 dark:text-white">
+              Skill
+            </h2>
+          </div>
+          <div className="p-6">
+            <div
+              className="prose prose-slate dark:prose-invert max-w-none text-sm text-slate-700 dark:text-slate-300"
+              dangerouslySetInnerHTML={{ __html: renderMarkdown(body) }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/AgentDetailPage.tsx
+++ b/packages/frontend/src/pages/AgentDetailPage.tsx
@@ -9,9 +9,6 @@ import {
   getActivity,
   triggerAgent,
   killAgentInstances,
-  enableAgent,
-  disableAgent,
-  updateAgentScale,
 } from "../lib/api";
 import type {
   AgentDetailData,
@@ -19,6 +16,7 @@ import type {
   LogEntry,
 } from "../lib/api";
 import { RunModal } from "../components/RunModal";
+import { RunDropdown } from "../components/RunDropdown";
 import { fmtSmartTime } from "../lib/format";
 import { agentHueStyle } from "../lib/color";
 
@@ -71,7 +69,6 @@ export function AgentDetailPage() {
   const [detail, setDetail] = useState<AgentDetailData | null>(null);
   const [activity, setActivity] = useState<ActivityRow[]>([]);
   const [logs, setLogs] = useState<LogEntry[]>([]);
-  const [scaleInput, setScaleInput] = useState("");
   const [actionError, setActionError] = useState<string | null>(null);
   const [killingAll, setKillingAll] = useState(false);
   const [showRunModal, setShowRunModal] = useState(false);
@@ -86,7 +83,6 @@ export function AgentDetailPage() {
     getAgentDetail(name)
       .then((d) => {
         setDetail(d);
-        if (d.agent) setScaleInput(String(d.agent.scale));
       })
       .catch(() => {});
   }, [name]);
@@ -133,11 +129,6 @@ export function AgentDetailPage() {
     }
   }, [logs]);
 
-  // Sync scale input when agent updates
-  useEffect(() => {
-    if (agent) setScaleInput(String(agent.scale));
-  }, [agent?.scale]);
-
   const handleAction = useCallback(async (fn: () => Promise<unknown>) => {
     setActionError(null);
     try {
@@ -146,13 +137,6 @@ export function AgentDetailPage() {
       setActionError(err instanceof Error ? err.message : "Action failed");
     }
   }, []);
-
-  const handleScaleUpdate = useCallback(() => {
-    if (!name) return;
-    const val = parseInt(scaleInput, 10);
-    if (isNaN(val) || val < 1) return;
-    handleAction(() => updateAgentScale(name, val));
-  }, [name, scaleInput, handleAction]);
 
   if (!name) return null;
 
@@ -192,38 +176,23 @@ export function AgentDetailPage() {
           )}
         </div>
         <div className="flex items-center gap-2 flex-wrap">
-          {agent && (
-            <div className="flex items-center gap-1 mr-1">
-              <span className="text-xs text-slate-500 dark:text-slate-400">Scale:</span>
-              <input
-                type="number"
-                min={1}
-                value={scaleInput}
-                onChange={(e) => setScaleInput(e.target.value)}
-                className="w-16 px-2 py-1 bg-white dark:bg-slate-950 border border-slate-300 dark:border-slate-700 rounded text-base text-slate-900 dark:text-slate-200"
-              />
-              <button
-                onClick={handleScaleUpdate}
-                className="px-2 py-1.5 text-xs font-medium rounded-md bg-blue-600 hover:bg-blue-700 text-white transition-colors"
-              >
-                Set
-              </button>
-            </div>
-          )}
-          <button
-            onClick={() => setShowRunModal(true)}
+          <RunDropdown
             disabled={agent ? !agent.enabled : false}
-            className="px-3 py-1.5 text-xs font-medium rounded-md bg-green-600 hover:bg-green-700 disabled:opacity-40 disabled:cursor-not-allowed text-white transition-colors"
-          >
-            Run
-          </button>
-          <Link
-            to={`/chat/${encodeURIComponent(name)}`}
-            className="px-3 py-1.5 text-xs font-medium rounded-md bg-purple-600 hover:bg-purple-700 text-white transition-colors"
-          >
-            Chat
-          </Link>
+            onQuickRun={async () => {
+              try {
+                const result = await triggerAgent(name!, undefined);
+                if (result?.instanceId) {
+                  navigate(`/dashboard/agents/${encodeURIComponent(name!)}/instances/${encodeURIComponent(result.instanceId)}`);
+                }
+              } catch (err) {
+                setActionError(err instanceof Error ? err.message : "Action failed");
+              }
+            }}
+            onRunWithPrompt={() => setShowRunModal(true)}
+            onChat={() => navigate(`/chat/${encodeURIComponent(name!)}`)}
+          />
           <button
+            id="agent-kill-btn"
             onClick={async () => {
               setKillingAll(true);
               setActionError(null);
@@ -244,24 +213,6 @@ export function AgentDetailPage() {
               </span>
             ) : "Kill"}
           </button>
-          {agent && (
-            <button
-              onClick={() =>
-                handleAction(() =>
-                  agent.enabled
-                    ? disableAgent(name)
-                    : enableAgent(name),
-                )
-              }
-              className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
-                agent.enabled
-                  ? "bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-600"
-                  : "bg-blue-600 hover:bg-blue-700 text-white"
-              }`}
-            >
-              {agent.enabled ? "Disable" : "Enable"}
-            </button>
-          )}
           <Link
             to={`/dashboard/agents/${encodeURIComponent(name)}/stats`}
             className="px-3 py-1.5 text-xs font-medium rounded-md bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700 transition-colors flex items-center gap-1.5"
@@ -272,10 +223,14 @@ export function AgentDetailPage() {
             Stats
           </Link>
           <Link
-            to={`/dashboard/agents/${encodeURIComponent(name)}/skill`}
-            className="px-3 py-1.5 text-xs font-medium rounded-md bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700 transition-colors"
+            to={`/dashboard/agents/${encodeURIComponent(name)}/admin`}
+            className="px-3 py-1.5 text-xs font-medium rounded-md bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700 transition-colors flex items-center gap-1"
           >
-            View Skill
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+            Admin
           </Link>
         </div>
       </div>


### PR DESCRIPTION
Closes #445

## Changes

### New files
- **** — Split-button component with primary "Run" action and dropdown for "Run with Prompt" and "Chat"
- **** — Combined admin page with Scale control, Enable/Disable toggle, Configuration section (from Skill page), and rendered SKILL.md content

### Modified files
- **** — Removed Scale/Enable-Disable/View Skill controls and Chat button; replaced Run button with `RunDropdown`; added gear icon ⚙️ + "Admin" link; removed unused imports
- **** — Added `/dashboard/agents/:name/admin` route; changed `/dashboard/agents/:name/skill` to redirect to admin page; removed `AgentSkillPage` import
- **** — Updated agent detail tests (Admin link check instead of View Skill); moved scale/toggle tests to new "Agent admin" test suite; added skill redirect test

### Summary
- Agent detail page header now shows: **RunDropdown → Kill → Stats → Admin (gear icon)**
- Clicking Run immediately triggers the agent (no prompt)
- Dropdown provides "Run with Prompt" (opens modal) and "Chat" options
- Admin page consolidates Scale, Enable/Disable, Configuration, and Skill content in one place
- `/dashboard/agents/:name/skill` now redirects to `/dashboard/agents/:name/admin`