### PR TITLE
fix: remove dot indicator from agent name displays

### DIFF
--- a/.changeset/remove-agent-color-dot.md
+++ b/.changeset/remove-agent-color-dot.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/frontend": patch
+---
+
+Remove colored dot indicator from agent name displays throughout the Web UI

--- a/package-lock.json
+++ b/package-lock.json
@@ -13288,7 +13288,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
@@ -13373,7 +13373,7 @@
     },
     "packages/frontend": {
       "name": "@action-llama/frontend",
-      "version": "0.17.2",
+      "version": "0.18.0",
       "dependencies": {
         "react": "^19.2.4",
         "react-dom": "^19.2.4",

--- a/packages/frontend/package-lock.json
+++ b/packages/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@action-llama/frontend",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@action-llama/frontend",
-      "version": "0.17.2",
+      "version": "0.18.0",
       "dependencies": {
         "react": "^19.2.4",
         "react-dom": "^19.2.4",

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -9,13 +9,6 @@
   background: hsl(var(--agent-hue) 50% 35%);
 }
 
-.agent-color-dot {
-  background: hsl(var(--agent-hue) 60% 45%);
-}
-.agent-color-dot:where(.dark, .dark *) {
-  background: hsl(var(--agent-hue) 60% 65%);
-}
-
 .agent-color-text {
   color: hsl(var(--agent-hue) 60% 40%);
 }

--- a/packages/frontend/src/lib/color.ts
+++ b/packages/frontend/src/lib/color.ts
@@ -2,7 +2,7 @@
  * Deterministic agent color generation.
  *
  * Hashes the agent name to a hue (0-360) and returns it.
- * Use with the `.agent-color-bg` and `.agent-color-dot` CSS classes
+ * Use with the `.agent-color-bg` and `.agent-color-text` CSS classes
  * by setting `--agent-hue` as an inline style.
  */
 

--- a/packages/frontend/src/pages/ActivityPage.tsx
+++ b/packages/frontend/src/pages/ActivityPage.tsx
@@ -262,10 +262,6 @@ export function ActivityPage() {
                           style={{ fontSize: "16px" }}
                         >
                           <span
-                            className="w-2 h-2 rounded-full shrink-0 agent-color-dot"
-                            style={agentHueStyle(row.agentName, agentNames)}
-                          />
-                          <span
                             className="agent-color-text font-mono"
                             style={agentHueStyle(row.agentName, agentNames)}
                           >
@@ -278,10 +274,6 @@ export function ActivityPage() {
                           className="hover:underline flex items-center gap-1.5"
                           style={{ fontSize: "16px" }}
                         >
-                          <span
-                            className="w-2 h-2 rounded-full shrink-0 agent-color-dot"
-                            style={agentHueStyle(row.agentName, agentNames)}
-                          />
                           <span
                             className="agent-color-text"
                             style={agentHueStyle(row.agentName, agentNames)}

--- a/packages/frontend/src/pages/AgentDetailPage.tsx
+++ b/packages/frontend/src/pages/AgentDetailPage.tsx
@@ -18,7 +18,6 @@ import type {
 import { RunModal } from "../components/RunModal";
 import { RunDropdown } from "../components/RunDropdown";
 import { fmtSmartTime } from "../lib/format";
-import { agentHueStyle } from "../lib/color";
 
 const ROW_STATUS_STYLES: Record<string, string> = {
   pending: "border-l-2 border-l-amber-400 dark:border-l-amber-500 bg-amber-50/40 dark:bg-amber-950/20",
@@ -65,7 +64,6 @@ export function AgentDetailPage() {
   const { name } = useParams<{ name: string }>();
   const navigate = useNavigate();
   const { agents } = useStatusStream();
-  const agentNames = agents.map((a) => a.name);
   const [detail, setDetail] = useState<AgentDetailData | null>(null);
   const [activity, setActivity] = useState<ActivityRow[]>([]);
   const [logs, setLogs] = useState<LogEntry[]>([]);
@@ -163,10 +161,6 @@ export function AgentDetailPage() {
               />
             </svg>
           </Link>
-          <span
-            className="w-3 h-3 rounded-full shrink-0 agent-color-dot"
-            style={agentHueStyle(name ?? "", agentNames)}
-          />
           <h1 className="text-xl font-bold text-slate-900 dark:text-white">
             {name}
           </h1>

--- a/packages/frontend/src/pages/AgentStatsPage.tsx
+++ b/packages/frontend/src/pages/AgentStatsPage.tsx
@@ -10,14 +10,12 @@ import {
 } from "../lib/api";
 import type { AgentDetailData, RunRecord } from "../lib/api";
 import { fmtDur, fmtCost, fmtTokens, fmtSmartTime, shortId } from "../lib/format";
-import { agentHueStyle } from "../lib/color";
 
 const PAGE_SIZE = 20;
 
 export function AgentStatsPage() {
   const { name } = useParams<{ name: string }>();
   const { agents } = useStatusStream();
-  const agentNames = agents.map((a) => a.name);
   const [detail, setDetail] = useState<AgentDetailData | null>(null);
   const [runs, setRuns] = useState<RunRecord[]>([]);
   const [totalRuns, setTotalRuns] = useState(0);
@@ -78,10 +76,6 @@ export function AgentStatsPage() {
               />
             </svg>
           </Link>
-          <span
-            className="w-3 h-3 rounded-full shrink-0 agent-color-dot"
-            style={agentHueStyle(name ?? "", agentNames)}
-          />
           <div>
             <h1 className="text-xl font-bold text-slate-900 dark:text-white">
               {name}

--- a/packages/frontend/src/pages/DashboardPage.tsx
+++ b/packages/frontend/src/pages/DashboardPage.tsx
@@ -218,10 +218,6 @@ export function DashboardPage() {
                     key={a.name}
                     className="flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400"
                   >
-                    <span
-                      className="w-2 h-2 rounded-full agent-color-dot"
-                      style={agentHueStyle(a.name, agentNames)}
-                    />
                     <span className="agent-color-text" style={agentHueStyle(a.name, agentNames)}>
                       {a.name}
                     </span>
@@ -288,10 +284,6 @@ export function DashboardPage() {
                       className="font-medium hover:underline truncate flex items-center gap-1.5"
                       title={agent.name}
                     >
-                      <span
-                        className="w-2 h-2 rounded-full shrink-0 agent-color-dot"
-                        style={agentHueStyle(agent.name, agentNames)}
-                      />
                       <span className="agent-color-text truncate" style={{ fontSize: "16px", ...agentHueStyle(agent.name, agentNames) }}>
                         {agent.name}
                       </span>

--- a/packages/frontend/src/pages/JobsPage.tsx
+++ b/packages/frontend/src/pages/JobsPage.tsx
@@ -201,10 +201,6 @@ export function JobsPage() {
                           : `/dashboard/agents/${encodeURIComponent(j.agentName)}`}
                         className="hover:underline text-xs flex items-center gap-1.5"
                       >
-                        <span
-                          className="w-2 h-2 rounded-full shrink-0 agent-color-dot"
-                          style={agentHueStyle(j.agentName, agentNames)}
-                        />
                         <span className="agent-color-text" style={agentHueStyle(j.agentName, agentNames)}>
                           {j.agentName}
                         </span>

--- a/packages/frontend/src/pages/TriggerDetailPage.tsx
+++ b/packages/frontend/src/pages/TriggerDetailPage.tsx
@@ -134,10 +134,6 @@ export function TriggerDetailPage() {
               to={`/dashboard/agents/${encodeURIComponent(trigger.agentName)}`}
               className="hover:underline text-xs flex items-center gap-1.5"
             >
-              <span
-                className="w-2 h-2 rounded-full shrink-0 agent-color-dot"
-                style={agentHueStyle(trigger.agentName, agentNames)}
-              />
               <span className="agent-color-text" style={agentHueStyle(trigger.agentName, agentNames)}>
                 {trigger.agentName}
               </span>
@@ -246,10 +242,6 @@ export function TriggerDetailPage() {
                     to={`/dashboard/agents/${encodeURIComponent(trigger.callerAgent)}`}
                     className="hover:underline text-xs flex items-center gap-1.5"
                   >
-                    <span
-                      className="w-2 h-2 rounded-full shrink-0 agent-color-dot"
-                      style={agentHueStyle(trigger.callerAgent, agentNames)}
-                    />
                     <span className="agent-color-text" style={agentHueStyle(trigger.callerAgent, agentNames)}>
                       {trigger.callerAgent}
                     </span>

--- a/packages/frontend/src/pages/TriggerHistoryPage.tsx
+++ b/packages/frontend/src/pages/TriggerHistoryPage.tsx
@@ -209,10 +209,6 @@ export function TriggerHistoryPage() {
                         to={`/dashboard/agents/${encodeURIComponent(t.agentName)}`}
                         className="hover:underline text-xs flex items-center gap-1.5"
                       >
-                        <span
-                          className="w-2 h-2 rounded-full shrink-0 agent-color-dot"
-                          style={agentHueStyle(t.agentName, agentNames)}
-                        />
                         <span className="agent-color-text" style={agentHueStyle(t.agentName, agentNames)}>
                           {t.agentName}
                         </span>


### PR DESCRIPTION
Closes #455

## Summary

Removed the small colored circle (dot) rendered before agent names throughout the Web UI. The colored text styling () is preserved — agent names continue to be color-coded via text color.

## Changes

- **DashboardPage.tsx** — removed dot span from token usage legend and agent table rows
- **AgentDetailPage.tsx** — removed dot span from page header; cleaned up unused  import and  variable
- **AgentStatsPage.tsx** — removed dot span from page header; cleaned up unused  import and  variable
- **ActivityPage.tsx** — removed dot spans from instance ID and agent name displays in the Instance column
- **TriggerHistoryPage.tsx** — removed dot span from agent column
- **TriggerDetailPage.tsx** — removed dot spans from agent and caller agent fields
- **JobsPage.tsx** — removed dot span from agent column
- **index.css** — removed dead  CSS rules
- **color.ts** — updated JSDoc comment to reference  instead of 