### PR TITLE
Unify webhook display with TriggerBadge everywhere

### DIFF
--- a/.changeset/unify-webhook-display.md
+++ b/.changeset/unify-webhook-display.md
@@ -1,0 +1,12 @@
+---
+"@action-llama/action-llama": patch
+"@action-llama/frontend": patch
+---
+
+Unify webhook display: use provider-colored TriggerBadge everywhere
+
+- Fix webhook trigger source to store provider name (e.g. "github") instead of event type (e.g. "issues") in scheduler, watcher, and execution
+- Fix pending queue item source access in stats route (ctx.context?.source)
+- Add getWebhookSourcesBatch() to StatsStore for enriching historical webhook rows
+- Add "manual" and "agent" color variants to TriggerBadge
+- Refactor ActivityTable to use TriggerBadge (source-colored) instead of TriggerTypeBadge, shared across Activity page and agent detail page

--- a/packages/action-llama/src/control/routes/stats.ts
+++ b/packages/action-llama/src/control/routes/stats.ts
@@ -207,7 +207,7 @@ export function registerStatsRoutes(
           if (ctx && typeof ctx === "object") {
             if (ctx.type === "webhook") {
               triggerType = "webhook";
-              triggerSource = ctx.source ?? null;
+              triggerSource = ctx.context?.source ?? null;
             } else if (ctx.type === "schedule") {
               triggerType = "schedule";
             } else if (ctx.type === "agent-trigger" || ctx.type === "agent") {
@@ -236,6 +236,21 @@ export function registerStatsRoutes(
 
     // Sort all rows by ts descending
     allRows.sort((a, b) => b.ts - a.ts);
+
+    // Enrich webhook rows with provider name from receipts (handles pre-fix historical data)
+    if (statsStore) {
+      const receiptIds = allRows
+        .filter((r: any) => r.triggerType === "webhook" && r.webhookReceiptId)
+        .map((r: any) => r.webhookReceiptId as string);
+      if (receiptIds.length > 0) {
+        const sources = statsStore.getWebhookSourcesBatch(receiptIds);
+        for (const row of allRows) {
+          if (row.webhookReceiptId && sources[row.webhookReceiptId]) {
+            row.triggerSource = sources[row.webhookReceiptId];
+          }
+        }
+      }
+    }
 
     // Apply status filter (supports comma-separated values, e.g. "pending,running,completed")
     let filtered = allRows;

--- a/packages/action-llama/src/execution/execution.ts
+++ b/packages/action-llama/src/execution/execution.ts
@@ -291,11 +291,11 @@ function fireQueuedItem(
     
     // Create instance lifecycle for webhook run (if supported)
     const instanceLifecycle = ctx.statusTracker?.createInstance ? 
-      ctx.statusTracker.createInstance(runner.instanceId, agentConfig.name, `webhook:${work.context.event}`) || undefined :
+      ctx.statusTracker.createInstance(runner.instanceId, agentConfig.name, `webhook:${work.context.source}`) || undefined :
       undefined;
     
     const prompt = makeWebhookPrompt(agentConfig, work.context, ctx);
-    executeRun(runner, prompt, { type: 'webhook', source: work.context.event, receiptId: work.context.receiptId }, agentConfig.name, 0, ctx, instanceLifecycle)
+    executeRun(runner, prompt, { type: 'webhook', source: work.context.source, receiptId: work.context.receiptId }, agentConfig.name, 0, ctx, instanceLifecycle)
       .then(() => drainQueues(ctx))
       .catch((err) => ctx.logger.error({ err, agent: agentConfig.name }, "queued webhook failed"));
 

--- a/packages/action-llama/src/scheduler/index.ts
+++ b/packages/action-llama/src/scheduler/index.ts
@@ -106,7 +106,7 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
           if (result.action === "dispatched") {
             logger.info({ agent: config.name, event: context.event, action: context.action }, "webhook triggering agent");
             const prompt = makeWebhookPrompt(config, context, state.schedulerCtx);
-            executeRun(result.runner, prompt, { type: 'webhook', source: context.event, receiptId: context.receiptId }, config.name, 0, state.schedulerCtx)
+            executeRun(result.runner, prompt, { type: 'webhook', source: context.source, receiptId: context.receiptId }, config.name, 0, state.schedulerCtx)
               .then(() => drainQueues(state.schedulerCtx!))
               .catch((err) => logger.error({ err, agent: config.name }, "webhook run failed"));
             return true;

--- a/packages/action-llama/src/scheduler/watcher.ts
+++ b/packages/action-llama/src/scheduler/watcher.ts
@@ -41,7 +41,7 @@ function buildWebhookTrigger(pool: RunnerPool, ctx: HotReloadContext) {
     }
     ctx.logger.info({ agent: config.name, event: context.event, action: context.action }, "webhook triggering agent");
     const prompt = makeWebhookPrompt(config, context, ctx.schedulerCtx);
-    executeRun(runner, prompt, { type: 'webhook', source: context.event, receiptId: context.receiptId }, config.name, 0, ctx.schedulerCtx)
+    executeRun(runner, prompt, { type: 'webhook', source: context.source, receiptId: context.receiptId }, config.name, 0, ctx.schedulerCtx)
       .then(() => drainQueues(ctx.schedulerCtx))
       .catch((err) => ctx.logger.error({ err, agent: config.name }, "webhook run failed"));
     return true;

--- a/packages/action-llama/src/stats/store.ts
+++ b/packages/action-llama/src/stats/store.ts
@@ -303,6 +303,16 @@ export class StatsStore {
     return row ? this.mapReceipt(row) : undefined;
   }
 
+  getWebhookSourcesBatch(ids: string[]): Record<string, string> {
+    if (ids.length === 0) return {};
+    const client = (this.db as any).$client;
+    const placeholders = ids.map(() => "?").join(",");
+    const rows = client.prepare(
+      `SELECT id, source FROM webhook_receipts WHERE id IN (${placeholders})`
+    ).all(...ids) as { id: string; source: string }[];
+    return Object.fromEntries(rows.map((r) => [r.id, r.source]));
+  }
+
   getWebhookReceipt(id: string): WebhookReceipt | undefined {
     const row = (this.db as any).$client
       .prepare("SELECT * FROM webhook_receipts WHERE id = ? LIMIT 1")

--- a/packages/action-llama/test/control/routes/stats.test.ts
+++ b/packages/action-llama/test/control/routes/stats.test.ts
@@ -8,6 +8,7 @@ function mockStatsStore() {
     countRunsByAgent: vi.fn().mockReturnValue(0),
     queryRunByInstanceId: vi.fn().mockReturnValue(undefined),
     getWebhookReceipt: vi.fn().mockReturnValue(undefined),
+    getWebhookSourcesBatch: vi.fn().mockReturnValue({}),
     queryTriggerHistory: vi.fn().mockReturnValue([]),
     countTriggerHistory: vi.fn().mockReturnValue(0),
   } as any;
@@ -564,7 +565,7 @@ describe("stats routes", () => {
         workQueue: {
           size: vi.fn().mockReturnValue(1),
           peek: vi.fn().mockReturnValue([
-            { context: { type: "webhook", source: "github" }, receivedAt: new Date(3000) },
+            { context: { type: "webhook", context: { source: "github", event: "issues" } }, receivedAt: new Date(3000) },
           ]),
         },
       };
@@ -937,7 +938,7 @@ describe("stats routes", () => {
         workQueue: {
           size: vi.fn().mockReturnValue(2),
           peek: vi.fn().mockReturnValue([
-            { context: { type: "webhook", source: "github" }, receivedAt: new Date(1000) },
+            { context: { type: "webhook", context: { source: "github", event: "issues" } }, receivedAt: new Date(1000) },
             { context: { type: "schedule" }, receivedAt: new Date(2000) },
           ]),
         },

--- a/packages/frontend/src/components/ActivityTable.tsx
+++ b/packages/frontend/src/components/ActivityTable.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { TriggerTypeBadge, ResultBadge } from "./Badge";
+import { TriggerBadge, ResultBadge } from "./Badge";
 import type { ActivityRow } from "../lib/api";
 import { fmtSmartTime } from "../lib/format";
 import { agentHueStyle } from "../lib/color";
@@ -83,28 +83,32 @@ export function ActivityTable({
 
               {/* Trigger — links to trigger detail */}
               <td className="px-2 py-2.5">
-                {detailPath ? (
-                  <Link
-                    to={detailPath}
-                    className="inline-flex items-center gap-1.5 hover:underline"
-                  >
-                    <TriggerTypeBadge type={row.triggerType} />
-                    {row.triggerSource && (
+                {(() => {
+                  const badgeLabel =
+                    row.triggerType === "webhook" && row.triggerSource
+                      ? row.triggerSource
+                      : row.triggerType;
+                  const secondary =
+                    row.triggerType !== "webhook" && row.triggerSource ? (
                       <span className="text-xs text-slate-600 dark:text-slate-400">
                         {row.triggerSource}
                       </span>
-                    )}
-                  </Link>
-                ) : (
-                  <span className="inline-flex items-center gap-1.5">
-                    <TriggerTypeBadge type={row.triggerType} />
-                    {row.triggerSource && (
-                      <span className="text-xs text-slate-600 dark:text-slate-400">
-                        {row.triggerSource}
-                      </span>
-                    )}
-                  </span>
-                )}
+                    ) : null;
+                  return detailPath ? (
+                    <Link
+                      to={detailPath}
+                      className="inline-flex items-center gap-1.5 hover:underline"
+                    >
+                      <TriggerBadge label={badgeLabel} />
+                      {secondary}
+                    </Link>
+                  ) : (
+                    <span className="inline-flex items-center gap-1.5">
+                      <TriggerBadge label={badgeLabel} />
+                      {secondary}
+                    </span>
+                  );
+                })()}
               </td>
 
               {/* Instance — full instanceId, colored like its agent */}

--- a/packages/frontend/src/components/Badge.tsx
+++ b/packages/frontend/src/components/Badge.tsx
@@ -18,6 +18,10 @@ export function TriggerBadge({ label }: { label: string }) {
       "bg-sky-50 text-sky-600 dark:bg-sky-900/30 dark:text-sky-400",
     mintlify:
       "bg-teal-50 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400",
+    manual:
+      "bg-slate-100 text-slate-600 dark:bg-slate-800/50 dark:text-slate-400",
+    agent:
+      "bg-amber-50 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400",
   };
   const cls =
     colors[key] ??


### PR DESCRIPTION
Closes #454

## Summary

Uses the provider-colored `TriggerBadge` component (introduced in PR #453) everywhere activity is displayed, replacing the generic `TriggerTypeBadge`.

## Changes

### Backend fixes
- **`scheduler/index.ts`** & **`scheduler/watcher.ts`**: Fix webhook trigger source to store provider name (e.g. `github`) instead of event type (e.g. `issues`) — `context.event` → `context.source`
- **`execution/execution.ts`**: Same fix for queued webhook items in `fireQueuedItem()`
- **`control/routes/stats.ts`**: Fix pending queue item source access (`ctx.source` → `ctx.context?.source`); add batch enrichment step to supply correct provider name for historical webhook rows
- **`stats/store.ts`**: Add `getWebhookSourcesBatch()` method for bulk receipt source lookup

### Frontend changes
- **`components/Badge.tsx`**: Add `manual` and `agent` color variants to `TriggerBadge`
- **`components/ActivityTable.tsx`**: Replace `TriggerTypeBadge` with `TriggerBadge` — for webhook rows shows provider name badge (e.g. purple "github"), for other types shows type badge (e.g. "schedule", "manual", "agent")

Both `ActivityPage` and `AgentDetailPage` already share the `ActivityTable` component, so both pages now automatically show the new provider-colored badges.

### Tests
- Updated `stats.test.ts` mock fixtures to use correct `WorkItem` shape (`{ type: "webhook", context: { source, event } }`) and added `getWebhookSourcesBatch` to mock store