### PR TITLE
feat: sort activity feed by status group then timestamp, remove status badge from agent header

### DIFF
--- a/.changeset/sort-activity-by-status.md
+++ b/.changeset/sort-activity-by-status.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Sort agent activity feed by status group (pending → running → completed/error) then by timestamp descending within each group. Also removes the status badge from the agent detail page header since the activity table provides sufficient status information. Closes #464.

--- a/packages/action-llama/src/control/routes/stats.ts
+++ b/packages/action-llama/src/control/routes/stats.ts
@@ -234,8 +234,14 @@ export function registerStatsRoutes(
       }
     }
 
-    // Sort all rows by ts descending
-    allRows.sort((a, b) => b.ts - a.ts);
+    // Sort rows by status group (pending → running → rest), then by ts descending within each group
+    const statusPriority: Record<string, number> = { pending: 0, running: 1 };
+    allRows.sort((a, b) => {
+      const pa = statusPriority[a.result] ?? 2;
+      const pb = statusPriority[b.result] ?? 2;
+      if (pa !== pb) return pa - pb;
+      return b.ts - a.ts;
+    });
 
     // Enrich webhook rows with provider name from receipts (handles pre-fix historical data)
     if (statsStore) {

--- a/packages/action-llama/test/control/routes/stats.test.ts
+++ b/packages/action-llama/test/control/routes/stats.test.ts
@@ -636,7 +636,7 @@ describe("stats routes", () => {
       );
     });
 
-    it("sorts all rows by ts descending", async () => {
+    it("sorts rows by status group (pending → running → rest) then ts descending", async () => {
       const stats = mockStatsStore();
       stats.queryTriggerHistory.mockReturnValue([
         { ts: 1000, triggerType: "schedule", agentName: "reporter", instanceId: "i1", result: "completed" },
@@ -651,10 +651,44 @@ describe("stats routes", () => {
       const res = await app.request("/api/stats/activity");
       const data = await res.json();
 
-      // Rows should be sorted newest first: ts=2000 (running), ts=1000 (completed), ts=300 (error)
+      // Rows should be sorted by group then ts: running (ts=2000), completed (ts=1000), error (ts=300)
+      expect(data.rows[0].result).toBe("running");
       expect(data.rows[0].ts).toBe(2000);
+      expect(data.rows[1].result).toBe("completed");
       expect(data.rows[1].ts).toBe(1000);
+      expect(data.rows[2].result).toBe("error");
       expect(data.rows[2].ts).toBe(300);
+    });
+
+    it("sorts pending rows before running, and running before completed/error", async () => {
+      const stats = mockStatsStore();
+      stats.queryTriggerHistory.mockReturnValue([
+        { ts: 5000, triggerType: "schedule", agentName: "reporter", instanceId: "i-completed", result: "completed" },
+        { ts: 1000, triggerType: "webhook", agentName: "reporter", instanceId: "i-error", result: "error" },
+      ]);
+
+      const tracker = mockStatusTracker([
+        { id: "i-running", agentName: "reporter", status: "running", startedAt: new Date(3000).toISOString(), trigger: "manual" },
+      ], [
+        { name: "reporter" },
+      ]);
+
+      const controlDeps = {
+        workQueue: {
+          size: vi.fn().mockReturnValue(1),
+          peek: vi.fn().mockReturnValue([
+            { context: { type: "webhook", source: "github" }, receivedAt: new Date(2000) },
+          ]),
+        },
+      };
+
+      const app = createApp(stats, tracker, controlDeps);
+      const res = await app.request("/api/stats/activity");
+      const data = await res.json();
+
+      // Expected order: pending (ts=2000), running (ts=3000), completed (ts=5000), error (ts=1000)
+      // pending and running come before completed/error regardless of their ts values
+      expect(data.rows.map((r: any) => r.result)).toEqual(["pending", "running", "completed", "error"]);
     });
 
     it("paginates results with limit and offset", async () => {

--- a/packages/frontend/src/pages/AgentDetailPage.tsx
+++ b/packages/frontend/src/pages/AgentDetailPage.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams, Link, useNavigate } from "react-router-dom";
 import { useStatusStream } from "../hooks/StatusStreamContext";
 import { useInvalidation } from "../hooks/useInvalidation";
-import { StateBadge } from "../components/Badge";
 import { ActivityTable } from "../components/ActivityTable";
 import {
   getAgentDetail,
@@ -157,7 +156,6 @@ export function AgentDetailPage() {
           <h1 className="text-xl font-bold text-slate-900 dark:text-white">
             {name}
           </h1>
-          {agent && <StateBadge state={agent.state} />}
           {agent && !agent.enabled && (
             <span className="text-xs text-slate-500 italic">(disabled)</span>
           )}


### PR DESCRIPTION
Closes #464

## Changes

### Sort order for activity feed
The activity feed (both the main Activity page and agent detail page) now sorts results by status group before sorting by timestamp:
1. **Pending** first (sorted by timestamp descending within group)
2. **Running** next (sorted by timestamp descending within group)
3. **Everything else** (completed, error, dead-letter, rerun) last (sorted by timestamp descending regardless of status)

This replaces the previous simple `ts DESC` sort.

### Agent detail page header
Removed the `<StateBadge>` status indicator from the agent detail page header. The activity table provides sufficient status information.

## Files changed
- `packages/action-llama/src/control/routes/stats.ts` — grouped sort logic
- `packages/frontend/src/pages/AgentDetailPage.tsx` — removed StateBadge from header
- `packages/action-llama/test/control/routes/stats.test.ts` — updated existing test + added new test for grouped sort
- `.changeset/sort-activity-by-status.md` — changeset