### PR TITLE
fix: replace State column with inline status dot and row tinting on agent index page

### DIFF
--- a/.changeset/agent-index-status-dot.md
+++ b/.changeset/agent-index-status-dot.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/frontend": patch
+---
+
+Agent index page: replace State column with inline status dot next to agent name and add row background tinting by state

--- a/packages/frontend/src/pages/DashboardPage.tsx
+++ b/packages/frontend/src/pages/DashboardPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useStatusStream } from "../hooks/StatusStreamContext";
-import { StateBadge, TriggerBadge } from "../components/Badge";
+import { TriggerBadge } from "../components/Badge";
 import {
   triggerAgent,
   killAgentInstances,
@@ -12,6 +12,23 @@ import type { AgentStatus } from "../lib/api";
 import { RunModal } from "../components/RunModal";
 import { fmtTokens, fmtSessionTime } from "../lib/format";
 import { agentHueStyle } from "../lib/color";
+
+const ROW_STATE_STYLES: Record<string, string> = {
+  running:
+    "border-l-2 border-l-green-500 dark:border-l-green-400 bg-green-50/40 dark:bg-green-950/20",
+  building:
+    "border-l-2 border-l-yellow-500 dark:border-l-yellow-400 bg-yellow-50/40 dark:bg-yellow-950/20",
+  error:
+    "border-l-2 border-l-red-500 dark:border-l-red-400 bg-red-50/30 dark:bg-red-950/20",
+  idle: "",
+};
+
+const STATE_DOT_COLORS: Record<string, string> = {
+  running: "bg-green-500",
+  building: "bg-yellow-500",
+  error: "bg-red-500",
+  idle: "bg-slate-400",
+};
 
 function formatScale(agent: AgentStatus): string {
   if (agent.state === "running" && agent.scale > 1) {
@@ -264,9 +281,6 @@ export function DashboardPage() {
                 <th className="hidden lg:table-cell text-left px-4 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">
                   Description
                 </th>
-                <th className="text-left px-4 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">
-                  State
-                </th>
                 <th className="text-right px-4 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">
                   Actions
                 </th>
@@ -276,7 +290,7 @@ export function DashboardPage() {
               {filteredAgents.map((agent) => (
                 <tr
                   key={agent.name}
-                  className="border-b border-slate-100 dark:border-slate-800/50 last:border-0 hover:bg-slate-100/50 dark:hover:bg-slate-800/30"
+                  className={`border-b border-slate-100 dark:border-slate-800/50 last:border-0 hover:bg-slate-100/50 dark:hover:bg-slate-800/30 ${ROW_STATE_STYLES[agent.state] ?? ""}`}
                 >
                   <td className="px-4 py-2.5 min-w-0 max-w-[240px]">
                     <Link
@@ -284,10 +298,23 @@ export function DashboardPage() {
                       className="font-medium hover:underline truncate flex items-center gap-1.5"
                       title={agent.name}
                     >
+                      <span
+                        className={`w-2 h-2 rounded-full shrink-0 ${STATE_DOT_COLORS[agent.state] ?? "bg-slate-400"}`}
+                      />
                       <span className="agent-color-text truncate" style={{ fontSize: "16px", ...agentHueStyle(agent.name, agentNames) }}>
                         {agent.name}
                       </span>
                     </Link>
+                    {agent.scale > 1 && (
+                      <span className="ml-1 text-xs text-slate-500">
+                        {formatScale(agent)}
+                      </span>
+                    )}
+                    {!agent.enabled && (
+                      <span className="ml-1 text-xs text-slate-500 italic">
+                        (disabled)
+                      </span>
+                    )}
                     {/* Trigger badges (schedule, webhook labels) */}
                     {(agent.triggers?.length ?? 0) > 0 && (
                       <div className="flex flex-wrap gap-1 mt-0.5">
@@ -305,19 +332,6 @@ export function DashboardPage() {
                   </td>
                   <td className="hidden lg:table-cell px-4 py-2.5 text-xs text-slate-500 dark:text-slate-400 min-w-0 max-w-[300px] truncate">
                     {agent.description ?? "\u2014"}
-                  </td>
-                  <td className="px-4 py-2.5 whitespace-nowrap">
-                    <StateBadge state={agent.state} />
-                    {agent.scale > 1 && (
-                      <span className="ml-1 text-xs text-slate-500">
-                        {formatScale(agent)}
-                      </span>
-                    )}
-                    {!agent.enabled && (
-                      <span className="ml-1 text-xs text-slate-500 italic">
-                        (disabled)
-                      </span>
-                    )}
                   </td>
                   <td className="px-4 py-2.5 text-right">
                     {/* Desktop: inline buttons */}
@@ -370,7 +384,7 @@ export function DashboardPage() {
               {filteredAgents.length === 0 && debouncedQuery && (
                 <tr>
                   <td
-                    colSpan={4}
+                    colSpan={3}
                     className="px-4 py-8 text-center text-slate-500 dark:text-slate-400"
                   >
                     No agents matching &lsquo;{debouncedQuery}&rsquo;
@@ -380,7 +394,7 @@ export function DashboardPage() {
               {filteredAgents.length === 0 && !debouncedQuery && (
                 <tr>
                   <td
-                    colSpan={4}
+                    colSpan={3}
                     className="px-4 py-8 text-center text-slate-500 dark:text-slate-400"
                   >
                     No agents found


### PR DESCRIPTION
Closes #467

## Changes

- **Removed** the State column from the agents table header and rows
- **Added** a small status dot (w-2 h-2 rounded-full) tight against the agent name inside the existing Link element
- **Added**  constant: applies  + background tint per agent state (green=running, yellow=building, red=error, none=idle) — matching the pattern from ActivityTable.tsx
- **Added**  constant: maps agent states to dot fill colors (green/yellow/red/gray)
- **Moved** scale and disabled indicators from the State cell into the Agent name cell, inline after the Link
- **Updated** empty-state colSpan from 4 to 3 (table now has 3 columns: Agent, Description, Actions)
- **Removed** unused `StateBadge` import

Build verified with `npx vite build` — no errors.