### PR TITLE
feat: add top-level Stats page with per-agent token usage

### DIFF
--- a/.changeset/top-level-stats-page.md
+++ b/.changeset/top-level-stats-page.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/frontend": minor
+---
+
+Add top-level Stats page with per-agent token usage bar charts sorted by highest to lowest usage. Remove token usage bar from Dashboard page.

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { ActivityPage } from "./pages/ActivityPage";
 import { TriggerDetailPage } from "./pages/TriggerDetailPage";
 import { ProjectConfigPage } from "./pages/ProjectConfigPage";
 import { AgentStatsPage } from "./pages/AgentStatsPage";
+import { StatsPage } from "./pages/StatsPage";
 import { ChatPage } from "./pages/ChatPage";
 import { WebhookReceiptPage } from "./pages/WebhookReceiptPage";
 
@@ -53,6 +54,7 @@ export function App() {
         />
         <Route path="/dashboard/triggers" element={<Navigate to="/activity" replace />} />
         <Route path="/activity" element={<ActivityPage />} />
+        <Route path="/stats" element={<StatsPage />} />
         <Route path="/triggers" element={<Navigate to="/activity" replace />} />
         <Route path="/jobs" element={<Navigate to="/activity" replace />} />
         <Route path="/dashboard/triggers/:instanceId" element={<TriggerDetailPage />} />

--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -34,6 +34,7 @@ function Navbar() {
   const isSettings = location.pathname === "/dashboard/config";
   const isAgents = location.pathname === "/dashboard" || location.pathname.startsWith("/dashboard/agents");
   const isActivity = location.pathname === "/activity";
+  const isStats = location.pathname === "/stats";
 
   return (
     <header className="border-b border-slate-200 dark:border-slate-800 px-4 sm:px-6 py-3">
@@ -74,6 +75,19 @@ function Navbar() {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
             </svg>
             <span className="hidden sm:inline">Activity</span>
+          </Link>
+          <Link
+            to="/stats"
+            className={`flex items-center gap-1.5 text-sm transition-colors ${
+              isStats
+                ? "text-blue-600 dark:text-blue-400"
+                : "text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
+            }`}
+          >
+            <svg className="w-5 h-5 sm:w-4 sm:h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+            </svg>
+            <span className="hidden sm:inline">Stats</span>
           </Link>
           <Link
             to="/dashboard/config"

--- a/packages/frontend/src/pages/DashboardPage.tsx
+++ b/packages/frontend/src/pages/DashboardPage.tsx
@@ -10,7 +10,6 @@ import {
 } from "../lib/api";
 import type { AgentStatus } from "../lib/api";
 import { RunModal } from "../components/RunModal";
-import { fmtTokens, fmtSessionTime } from "../lib/format";
 import { agentHueStyle } from "../lib/color";
 
 function formatScale(agent: AgentStatus): string {
@@ -123,11 +122,6 @@ export function DashboardPage() {
     return () => clearTimeout(debounceRef.current);
   }, [searchQuery]);
 
-  const totalTokens = agents.reduce(
-    (sum, a) => sum + (a.cumulativeUsage?.totalTokens ?? 0),
-    0,
-  );
-
   const handleAction = useCallback(
     async (fn: () => Promise<unknown>) => {
       setActionError(null);
@@ -187,47 +181,6 @@ export function DashboardPage() {
       <div className="flex items-center justify-between flex-wrap gap-3">
         <h1 className="text-xl font-bold text-slate-900 dark:text-white">Agents</h1>
       </div>
-
-      {/* Token usage bar */}
-      {totalTokens > 0 && (
-        <div className="hidden md:block bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 p-3">
-          <div className="text-xs text-slate-500 dark:text-slate-400 mb-2">
-            Token Usage by Agent{schedulerInfo?.startedAt ? ` (${fmtSessionTime(schedulerInfo.startedAt)})` : ""}
-          </div>
-          <div className="flex h-3 rounded-full overflow-hidden bg-slate-200 dark:bg-slate-800">
-            {agents
-              .filter((a) => (a.cumulativeUsage?.totalTokens ?? 0) > 0)
-              .map((a) => {
-                const pct =
-                  ((a.cumulativeUsage?.totalTokens ?? 0) / totalTokens) * 100;
-                return (
-                  <div
-                    key={a.name}
-                    className="agent-color-bg transition-all"
-                    style={{ width: `${pct}%`, ...agentHueStyle(a.name, agentNames) }}
-                    title={`${a.name}: ${fmtTokens(a.cumulativeUsage?.totalTokens ?? 0)}`}
-                  />
-                );
-              })}
-          </div>
-          <div className="flex flex-wrap gap-3 mt-2">
-            {agents
-              .filter((a) => (a.cumulativeUsage?.totalTokens ?? 0) > 0)
-              .map((a) => (
-                  <span
-                    key={a.name}
-                    className="flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400"
-                  >
-                    <span className="agent-color-text" style={agentHueStyle(a.name, agentNames)}>
-                      {a.name}
-                    </span>
-                    :{" "}
-                    {fmtTokens(a.cumulativeUsage?.totalTokens ?? 0)}
-                  </span>
-                ))}
-          </div>
-        </div>
-      )}
 
       {/* Agents table — full width */}
       <div className="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden">

--- a/packages/frontend/src/pages/StatsPage.tsx
+++ b/packages/frontend/src/pages/StatsPage.tsx
@@ -1,0 +1,89 @@
+import { Link } from "react-router-dom";
+import { useStatusStream } from "../hooks/StatusStreamContext";
+import { fmtTokens, fmtSessionTime } from "../lib/format";
+import { agentHueStyle } from "../lib/color";
+
+export function StatsPage() {
+  const { agents, schedulerInfo } = useStatusStream();
+  const agentNames = agents.map((a) => a.name);
+
+  const totalTokens = agents.reduce(
+    (sum, a) => sum + (a.cumulativeUsage?.totalTokens ?? 0),
+    0,
+  );
+
+  const sortedAgents = agents
+    .filter((a) => (a.cumulativeUsage?.totalTokens ?? 0) > 0)
+    .sort(
+      (a, b) =>
+        (b.cumulativeUsage?.totalTokens ?? 0) -
+        (a.cumulativeUsage?.totalTokens ?? 0),
+    );
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <h1 className="text-xl font-bold text-slate-900 dark:text-white">
+          Stats
+        </h1>
+      </div>
+
+      {/* Subnav */}
+      <div className="flex items-center gap-2">
+        <span className="px-3 py-1.5 text-xs font-medium rounded-md bg-blue-600 text-white">
+          Token Usage
+        </span>
+      </div>
+
+      {/* Session time range */}
+      {schedulerInfo?.startedAt && (
+        <div className="text-sm text-slate-500 dark:text-slate-400">
+          Session: {fmtSessionTime(schedulerInfo.startedAt)}
+        </div>
+      )}
+
+      {/* Agent usage list */}
+      <div className="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800">
+        {totalTokens === 0 ? (
+          <div className="px-4 py-8 text-center text-slate-500 dark:text-slate-400">
+            No token usage recorded yet
+          </div>
+        ) : (
+          sortedAgents.map((agent) => {
+            const tokens = agent.cumulativeUsage?.totalTokens ?? 0;
+            const pct = (tokens / totalTokens) * 100;
+            return (
+              <div
+                key={agent.name}
+                className="px-4 py-3 border-b border-slate-100 dark:border-slate-800/50 last:border-0"
+              >
+                <div className="flex items-center justify-between mb-1.5">
+                  <Link
+                    to={`/dashboard/agents/${encodeURIComponent(agent.name)}`}
+                    className="agent-color-text text-sm font-medium hover:underline"
+                    style={agentHueStyle(agent.name, agentNames)}
+                  >
+                    {agent.name}
+                  </Link>
+                  <span className="text-xs text-slate-500 dark:text-slate-400">
+                    {fmtTokens(tokens)} ({pct.toFixed(1)}%)
+                  </span>
+                </div>
+                <div className="h-2 rounded-full overflow-hidden bg-slate-200 dark:bg-slate-800">
+                  <div
+                    className="h-full rounded-full agent-color-bg transition-all"
+                    style={{
+                      width: `${pct}%`,
+                      ...agentHueStyle(agent.name, agentNames),
+                    }}
+                  />
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #468

## Changes

- **New ** (): Top-level stats page with:
  - Subnav with "Token Usage" tab (pill-style, matches agent detail page)
  - Session time range display (e.g. "Session: last 3h")
  - List of agents sorted by highest to lowest token usage
  - Per-agent horizontal bar graph showing percentage of total token usage
  - Agent names are colored and linked to their detail pages
  - Empty state message when no token usage data exists

- ****: Added  route

- ****: Added "Stats" link to navbar (between Activity and Settings) with bar-chart icon

- ****: Removed the token usage bar section and unused imports (, )

## Notes
No backend changes needed — data comes from the existing SSE status stream ( hook).