### PR TITLE
feat: tabbed layout for agent pages (Activity / Stats / Settings)

### DIFF
--- a/.changeset/agent-tabbed-layout.md
+++ b/.changeset/agent-tabbed-layout.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/frontend": minor
+---
+
+Refactor agent pages into a tabbed layout with Activity, Stats, and Settings tabs. The agent header (name, state, Run/Kill buttons) is now shared via a new AgentLayout component and stays fixed across all tabs. This eliminates the page title jumping issue and provides cleaner navigation. The /admin route now redirects to /settings.

--- a/packages/action-llama/test/playwright/dashboard.spec.ts
+++ b/packages/action-llama/test/playwright/dashboard.spec.ts
@@ -237,10 +237,10 @@ test.describe("Agent detail", () => {
     await expect(page.locator("#agent-state")).toContainText("running", { timeout: 5000 });
   });
 
-  test("Admin link is visible", async ({ page }) => {
-    const link = page.locator('a[href="/dashboard/agents/single-agent/admin"]');
+  test("Settings tab is visible", async ({ page }) => {
+    const link = page.locator('a[href="/dashboard/agents/single-agent/settings"]');
     await expect(link).toBeVisible();
-    await expect(link).toContainText("Admin");
+    await expect(link).toContainText("Settings");
   });
 
   test("Kill All button is disabled when no instances running", async ({ page }) => {
@@ -287,12 +287,12 @@ test.describe("Agent admin", () => {
   test.beforeEach(async ({ page, request }) => {
     await resetState(request);
     await login(page);
-    await page.goto("/dashboard/agents/single-agent/admin");
+    await page.goto("/dashboard/agents/single-agent/settings");
   });
 
-  test("shows agent name and Admin subtitle", async ({ page }) => {
+  test("shows agent name and Settings tab", async ({ page }) => {
     await expect(page.locator("h1")).toContainText("single-agent");
-    await expect(page.locator("text=Admin")).toBeVisible();
+    await expect(page.locator("text=Settings")).toBeVisible();
   });
 
   test("scale input shows current value and Update button exists", async ({ page }) => {
@@ -319,9 +319,9 @@ test.describe("Agent admin", () => {
     await expect(btn).toContainText("Disable", { timeout: 5000 });
   });
 
-  test("skill route redirects to admin", async ({ page }) => {
+  test("skill route redirects to settings", async ({ page }) => {
     await page.goto("/dashboard/agents/single-agent/skill");
-    await page.waitForURL("**/dashboard/agents/single-agent/admin");
+    await page.waitForURL("**/dashboard/agents/single-agent/settings");
     await expect(page.locator("h1")).toContainText("single-agent");
   });
 });
@@ -332,7 +332,7 @@ test.describe("Agent detail — scaled agent", () => {
   test.beforeEach(async ({ page, request }) => {
     await resetState(request);
     await login(page);
-    await page.goto("/dashboard/agents/scaled-agent/admin");
+    await page.goto("/dashboard/agents/scaled-agent/settings");
   });
 
   test("shows scale=2 in the scale input", async ({ page }) => {

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route, Navigate, useParams } from "react-router-dom";
 import { Layout } from "./components/Layout";
+import { AgentLayout } from "./components/AgentLayout";
 import { LoginPage } from "./pages/LoginPage";
 import { DashboardPage } from "./pages/DashboardPage";
 import { AgentDetailPage } from "./pages/AgentDetailPage";
@@ -19,7 +20,7 @@ function AgentTriggersRedirect() {
 
 function AgentSkillRedirect() {
   const { name } = useParams<{ name: string }>();
-  return <Navigate to={`/dashboard/agents/${encodeURIComponent(name ?? "")}/admin`} replace />;
+  return <Navigate to={`/dashboard/agents/${encodeURIComponent(name ?? "")}/settings`} replace />;
 }
 
 export function App() {
@@ -30,26 +31,17 @@ export function App() {
       <Route path="/chat/:agent" element={<ChatPage />} />
       <Route element={<Layout />}>
         <Route path="/dashboard" element={<DashboardPage />} />
-        <Route path="/dashboard/agents/:name" element={<AgentDetailPage />} />
+        <Route path="/dashboard/agents/:name" element={<AgentLayout />}>
+          <Route index element={<AgentDetailPage />} />
+          <Route path="stats" element={<AgentStatsPage />} />
+          <Route path="settings" element={<AgentAdminPage />} />
+          <Route path="admin" element={<Navigate to="settings" replace />} />
+          <Route path="skill" element={<AgentSkillRedirect />} />
+          <Route path="triggers" element={<AgentTriggersRedirect />} />
+        </Route>
         <Route
           path="/dashboard/agents/:name/instances/:id"
           element={<InstanceDetailPage />}
-        />
-        <Route
-          path="/dashboard/agents/:name/triggers"
-          element={<AgentTriggersRedirect />}
-        />
-        <Route
-          path="/dashboard/agents/:name/admin"
-          element={<AgentAdminPage />}
-        />
-        <Route
-          path="/dashboard/agents/:name/skill"
-          element={<AgentSkillRedirect />}
-        />
-        <Route
-          path="/dashboard/agents/:name/stats"
-          element={<AgentStatsPage />}
         />
         <Route path="/dashboard/triggers" element={<Navigate to="/activity" replace />} />
         <Route path="/activity" element={<ActivityPage />} />

--- a/packages/frontend/src/components/AgentLayout.tsx
+++ b/packages/frontend/src/components/AgentLayout.tsx
@@ -1,0 +1,226 @@
+import { useState, useCallback, useEffect } from "react";
+import { useParams, Link, Outlet, useNavigate, useLocation } from "react-router-dom";
+import { useStatusStream } from "../hooks/StatusStreamContext";
+import { RunDropdown } from "./RunDropdown";
+import { RunModal } from "./RunModal";
+import { triggerAgent, killAgentInstances, getAgentDetail } from "../lib/api";
+import type { AgentDetailData } from "../lib/api";
+
+export function AgentLayout() {
+  const { name } = useParams<{ name: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { agents } = useStatusStream();
+
+  const [detail, setDetail] = useState<AgentDetailData | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [killingAll, setKillingAll] = useState(false);
+  const [showRunModal, setShowRunModal] = useState(false);
+
+  const agent = agents.find((a) => a.name === name) ?? detail?.agent ?? null;
+
+  // Load detail on mount
+  useEffect(() => {
+    if (!name) return;
+    getAgentDetail(name)
+      .then((d) => setDetail(d))
+      .catch(() => {});
+  }, [name]);
+
+  const handleAction = useCallback(async (fn: () => Promise<unknown>) => {
+    setActionError(null);
+    try {
+      await fn();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Action failed");
+    }
+  }, []);
+
+  if (!name) return null;
+
+  // Determine active tab
+  const basePath = `/dashboard/agents/${encodeURIComponent(name)}`;
+  const isActivity =
+    location.pathname === basePath || location.pathname === basePath + "/";
+  const isStats = location.pathname.endsWith("/stats");
+  const isSettings =
+    location.pathname.endsWith("/settings") ||
+    location.pathname.endsWith("/admin");
+
+  const tabClass = (active: boolean) =>
+    `pb-2 text-sm font-medium transition-colors ${
+      active
+        ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400"
+        : "text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
+    }`;
+
+  return (
+    <div className="space-y-4">
+      {/* Header row */}
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <div className="flex items-center gap-3">
+          <Link
+            to="/dashboard"
+            className="text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
+            aria-label="Back to dashboard"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </Link>
+          <h1 className="text-xl font-bold text-slate-900 dark:text-white">
+            {name}
+          </h1>
+          {agent && (
+            <span
+              id="agent-state"
+              className={`text-sm ${
+                agent.runningCount > 0
+                  ? "text-green-600 dark:text-green-400"
+                  : "text-slate-500 dark:text-slate-400"
+              }`}
+            >
+              <span
+                className={`inline-block w-1.5 h-1.5 rounded-full mr-1.5 ${
+                  agent.runningCount > 0 ? "bg-green-500" : "bg-slate-400"
+                }`}
+              />
+              {agent.runningCount > 0
+                ? agent.scale > 1
+                  ? `running ${agent.runningCount}/${agent.scale}`
+                  : "running"
+                : "idle"}
+              {agent.scale > 1 && agent.runningCount === 0 && (
+                <span className="text-xs text-slate-400 ml-1">×{agent.scale}</span>
+              )}
+            </span>
+          )}
+          {agent && !agent.enabled && (
+            <span className="text-xs text-slate-500 italic">(disabled)</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <RunDropdown
+            disabled={agent ? !agent.enabled : false}
+            onQuickRun={async () => {
+              try {
+                const result = await triggerAgent(name!, undefined);
+                if (result?.instanceId) {
+                  navigate(
+                    `/dashboard/agents/${encodeURIComponent(name!)}/instances/${encodeURIComponent(result.instanceId)}`
+                  );
+                }
+              } catch (err) {
+                setActionError(
+                  err instanceof Error ? err.message : "Action failed"
+                );
+              }
+            }}
+            onRunWithPrompt={() => setShowRunModal(true)}
+            onChat={() => navigate(`/chat/${encodeURIComponent(name!)}`)}
+          />
+          <button
+            id="agent-kill-btn"
+            onClick={async () => {
+              setKillingAll(true);
+              setActionError(null);
+              try {
+                await killAgentInstances(name);
+              } catch (err) {
+                setActionError(
+                  err instanceof Error ? err.message : "Action failed"
+                );
+              } finally {
+                setKillingAll(false);
+              }
+            }}
+            disabled={!agent || agent.runningCount === 0 || killingAll}
+            className="px-3 py-1.5 text-xs font-medium rounded-md bg-red-600 hover:bg-red-700 disabled:opacity-40 disabled:cursor-not-allowed text-white transition-colors"
+          >
+            {killingAll ? (
+              <span className="flex items-center gap-1">
+                <svg
+                  className="w-3 h-3 animate-spin"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                  />
+                </svg>
+                Killing…
+              </span>
+            ) : (
+              "Kill"
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Tab bar */}
+      <div className="flex gap-6 border-b border-slate-200 dark:border-slate-800">
+        <Link to={basePath} className={tabClass(isActivity)}>
+          Activity
+        </Link>
+        <Link to={`${basePath}/stats`} className={tabClass(isStats)}>
+          Stats
+        </Link>
+        <Link to={`${basePath}/settings`} className={tabClass(isSettings)}>
+          Settings
+        </Link>
+      </div>
+
+      {/* Action error banner */}
+      {actionError && (
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3 text-sm text-red-700 dark:text-red-400">
+          {actionError}
+        </div>
+      )}
+
+      {/* Tab content */}
+      <Outlet />
+
+      {/* Run modal */}
+      {showRunModal && name && (
+        <RunModal
+          agentName={name}
+          onClose={() => setShowRunModal(false)}
+          onRun={async (prompt) => {
+            try {
+              const result = await triggerAgent(name, prompt);
+              if (result?.instanceId) {
+                navigate(
+                  `/dashboard/agents/${encodeURIComponent(name)}/instances/${encodeURIComponent(result.instanceId)}`
+                );
+              }
+            } catch (err) {
+              setActionError(
+                err instanceof Error ? err.message : "Action failed"
+              );
+            }
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/AgentAdminPage.tsx
+++ b/packages/frontend/src/pages/AgentAdminPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useStatusStream } from "../hooks/StatusStreamContext";
 import {
   getAgentSkill,
@@ -231,44 +231,6 @@ export function AgentAdminPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between flex-wrap gap-3">
-        <div className="flex items-center gap-3">
-          <Link
-            to={`/dashboard/agents/${encodeURIComponent(name)}`}
-            className="text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
-          >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15 19l-7-7 7-7"
-              />
-            </svg>
-          </Link>
-          <div>
-            <h1 className="text-xl font-bold text-slate-900 dark:text-white">
-              {name}
-            </h1>
-            <div className="text-xs text-slate-500 dark:text-slate-400">
-              Admin
-            </div>
-          </div>
-        </div>
-        <Link
-          to={`/dashboard/agents/${encodeURIComponent(name)}`}
-          className="px-3 py-1.5 text-xs font-medium rounded-md bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700 transition-colors"
-        >
-          Back to Agent
-        </Link>
-      </div>
-
       {actionError && (
         <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3 text-sm text-red-700 dark:text-red-400">
           {actionError}

--- a/packages/frontend/src/pages/AgentDetailPage.tsx
+++ b/packages/frontend/src/pages/AgentDetailPage.tsx
@@ -1,22 +1,16 @@
 import { useEffect, useState, useCallback, useRef } from "react";
-import { useParams, Link, useNavigate } from "react-router-dom";
+import { useParams, Link } from "react-router-dom";
 import { useStatusStream } from "../hooks/StatusStreamContext";
 import { useInvalidation } from "../hooks/useInvalidation";
 import { ActivityTable } from "../components/ActivityTable";
 import {
-  getAgentDetail,
   getAgentLogs,
   getActivity,
-  triggerAgent,
-  killAgentInstances,
 } from "../lib/api";
 import type {
-  AgentDetailData,
   ActivityRow,
   LogEntry,
 } from "../lib/api";
-import { RunModal } from "../components/RunModal";
-import { RunDropdown } from "../components/RunDropdown";
 
 
 function formatLogEntry(entry: LogEntry): {
@@ -53,33 +47,14 @@ function formatLogEntry(entry: LogEntry): {
 
 export function AgentDetailPage() {
   const { name } = useParams<{ name: string }>();
-  const navigate = useNavigate();
   const { agents } = useStatusStream();
-  const [detail, setDetail] = useState<AgentDetailData | null>(null);
   const [activity, setActivity] = useState<ActivityRow[]>([]);
   const [logs, setLogs] = useState<LogEntry[]>([]);
-  const [actionError, setActionError] = useState<string | null>(null);
-  const [killingAll, setKillingAll] = useState(false);
-  const [showRunModal, setShowRunModal] = useState(false);
   const cursorRef = useRef<string | null>(null);
   const logContainerRef = useRef<HTMLDivElement>(null);
 
-  const agent = agents.find((a) => a.name === name) ?? detail?.agent ?? null;
+  const agent = agents.find((a) => a.name === name) ?? null;
   const agentNames = agents.map((a) => a.name);
-
-  // Load detail
-  const refetchDetail = useCallback(() => {
-    if (!name) return;
-    getAgentDetail(name)
-      .then((d) => {
-        setDetail(d);
-      })
-      .catch(() => {});
-  }, [name]);
-
-  useEffect(() => {
-    refetchDetail();
-  }, [refetchDetail]);
 
   // Load activity
   const refetchActivity = useCallback(() => {
@@ -89,7 +64,6 @@ export function AgentDetailPage() {
 
   useEffect(() => { refetchActivity(); }, [refetchActivity]);
 
-  useInvalidation("stats", name, refetchDetail);
   useInvalidation("runs", name, refetchActivity);
 
   // Poll logs
@@ -119,113 +93,10 @@ export function AgentDetailPage() {
     }
   }, [logs]);
 
-  const handleAction = useCallback(async (fn: () => Promise<unknown>) => {
-    setActionError(null);
-    try {
-      await fn();
-    } catch (err) {
-      setActionError(err instanceof Error ? err.message : "Action failed");
-    }
-  }, []);
-
   if (!name) return null;
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between flex-wrap gap-3">
-        <div className="flex items-center gap-3">
-          <Link
-            to="/dashboard"
-            className="text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
-          >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15 19l-7-7 7-7"
-              />
-            </svg>
-          </Link>
-          <h1 className="text-xl font-bold text-slate-900 dark:text-white">
-            {name}
-          </h1>
-          {agent && !agent.enabled && (
-            <span className="text-xs text-slate-500 italic">(disabled)</span>
-          )}
-        </div>
-        <div className="flex items-center gap-2 flex-wrap">
-          <RunDropdown
-            disabled={agent ? !agent.enabled : false}
-            onQuickRun={async () => {
-              try {
-                const result = await triggerAgent(name!, undefined);
-                if (result?.instanceId) {
-                  navigate(`/dashboard/agents/${encodeURIComponent(name!)}/instances/${encodeURIComponent(result.instanceId)}`);
-                }
-              } catch (err) {
-                setActionError(err instanceof Error ? err.message : "Action failed");
-              }
-            }}
-            onRunWithPrompt={() => setShowRunModal(true)}
-            onChat={() => navigate(`/chat/${encodeURIComponent(name!)}`)}
-          />
-          <button
-            id="agent-kill-btn"
-            onClick={async () => {
-              setKillingAll(true);
-              setActionError(null);
-              try { await killAgentInstances(name); }
-              catch (err) { setActionError(err instanceof Error ? err.message : "Action failed"); }
-              finally { setKillingAll(false); }
-            }}
-            disabled={!agent || agent.runningCount === 0 || killingAll}
-            className="px-3 py-1.5 text-xs font-medium rounded-md bg-red-600 hover:bg-red-700 disabled:opacity-40 disabled:cursor-not-allowed text-white transition-colors"
-          >
-            {killingAll ? (
-              <span className="flex items-center gap-1">
-                <svg className="w-3 h-3 animate-spin" viewBox="0 0 24 24" fill="none">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-                </svg>
-                Killing…
-              </span>
-            ) : "Kill"}
-          </button>
-          <Link
-            to={`/dashboard/agents/${encodeURIComponent(name)}/stats`}
-            className="px-3 py-1.5 text-xs font-medium rounded-md bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700 transition-colors flex items-center gap-1.5"
-          >
-            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-            </svg>
-            Stats
-          </Link>
-          <Link
-            to={`/dashboard/agents/${encodeURIComponent(name)}/admin`}
-            className="px-3 py-1.5 text-xs font-medium rounded-md bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700 transition-colors flex items-center gap-1"
-          >
-            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-            </svg>
-            Admin
-          </Link>
-        </div>
-      </div>
-
-      {actionError && (
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3 text-sm text-red-700 dark:text-red-400">
-          {actionError}
-        </div>
-      )}
-
       {/* Activity */}
       <div className="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden">
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-slate-200 dark:border-slate-800">
@@ -283,23 +154,6 @@ export function AgentDetailPage() {
           )}
         </div>
       </div>
-
-      {showRunModal && name && (
-        <RunModal
-          agentName={name}
-          onClose={() => setShowRunModal(false)}
-          onRun={async (prompt) => {
-            try {
-              const result = await triggerAgent(name, prompt);
-              if (result?.instanceId) {
-                navigate(`/dashboard/agents/${encodeURIComponent(name)}/instances/${encodeURIComponent(result.instanceId)}`);
-              }
-            } catch (err) {
-              setActionError(err instanceof Error ? err.message : "Action failed");
-            }
-          }}
-        />
-      )}
     </div>
   );
 }

--- a/packages/frontend/src/pages/AgentStatsPage.tsx
+++ b/packages/frontend/src/pages/AgentStatsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useStatusStream } from "../hooks/StatusStreamContext";
 import { useInvalidation } from "../hooks/useInvalidation";
 import { StatCard } from "../components/StatCard";
@@ -33,44 +33,6 @@ export function AgentStatsPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between flex-wrap gap-3">
-        <div className="flex items-center gap-3">
-          <Link
-            to={`/dashboard/agents/${encodeURIComponent(name)}`}
-            className="text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
-          >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15 19l-7-7 7-7"
-              />
-            </svg>
-          </Link>
-          <div>
-            <h1 className="text-xl font-bold text-slate-900 dark:text-white">
-              {name}
-            </h1>
-            <div className="text-xs text-slate-500 dark:text-slate-400">
-              Stats
-            </div>
-          </div>
-        </div>
-        <Link
-          to={`/dashboard/agents/${encodeURIComponent(name)}`}
-          className="px-3 py-1.5 text-xs font-medium rounded-md bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700 transition-colors"
-        >
-          Back to Agent
-        </Link>
-      </div>
-
       {/* Stats Grid */}
       {summary && (
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">


### PR DESCRIPTION
Closes #462

## Summary

Refactors the agent detail, stats, and admin pages into a clean tabbed layout, eliminating the page title jump and improving navigation.

## Changes

### New: `AgentLayout` component
A shared layout component using React Router nested routes with `<Outlet />`. It renders:
- **Top row**: Back arrow → Dashboard, agent name, state badge, disabled indicator (left); Run dropdown + Kill button (right)
- **Tab bar**: Activity / Stats / Settings tabs with active-tab highlight (same visual language as global nav)
- Tab content via `<Outlet />`

### Modified pages (content-only)
- **`AgentDetailPage`**: Removed header/action buttons — now renders only activity table + recent logs
- **`AgentStatsPage`**: Removed header/back link — now renders only stats grid  
- **`AgentAdminPage`**: Removed header/back link — now renders only controls, configuration, and skill content

### Route changes (`App.tsx`)
- Agent routes restructured as nested routes under `AgentLayout`
- New `/settings` route for agent settings (was `/admin`)
- `/admin` redirects to `/settings` for backward compatibility
- `AgentSkillRedirect` updated to point to `/settings`
- Instance detail page stays as a standalone page (not a tab)

### Test updates
- Updated Playwright tests: `/admin` → `/settings`, "Admin" → "Settings"