### PR TITLE
feat: add per-agent maxWorkQueueSize setting

### DIFF
--- a/.changeset/per-agent-max-work-queue-size.md
+++ b/.changeset/per-agent-max-work-queue-size.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": minor
+---
+
+Add per-agent `maxWorkQueueSize` setting in agent `config.toml`. Overrides the global `workQueueSize` for individual agents, allowing fine-grained control over work queue capacity. Oldest events are dropped to make room for newer ones when the queue is full. Closes #473.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "action-llama",
+  "name": "repo",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -13292,7 +13292,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.23.4",
+      "version": "0.23.8",
       "license": "MIT",
       "dependencies": {
         "@action-llama/skill": "*",
@@ -13400,7 +13400,7 @@
     },
     "packages/skill": {
       "name": "@action-llama/skill",
-      "version": "0.23.4",
+      "version": "0.23.8",
       "license": "MIT"
     }
   }

--- a/packages/action-llama/src/events/event-queue-sqlite.ts
+++ b/packages/action-llama/src/events/event-queue-sqlite.ts
@@ -25,6 +25,7 @@ export class SqliteWorkQueue<T> implements WorkQueue<T> {
   private db: AppDb;
   private ownDb: boolean;
   private maxSize: number;
+  private agentMaxSizes = new Map<string, number>();
 
   private _dequeueTransaction: (agent: string) => {
     id: string;
@@ -37,6 +38,7 @@ export class SqliteWorkQueue<T> implements WorkQueue<T> {
     id: string,
     payload: string,
     receivedAt: number,
+    maxSize: number,
   ) => { dropped?: { payload: string; received_at: number } };
 
   constructor(maxSize: number, dbOrPath: string | AppDb) {
@@ -65,11 +67,11 @@ export class SqliteWorkQueue<T> implements WorkQueue<T> {
 
     // Atomic enqueue with overflow: insert + conditionally drop oldest
     this._enqueueTransaction = client.transaction(
-      (agent: string, id: string, payload: string, receivedAt: number) => {
+      (agent: string, id: string, payload: string, receivedAt: number, maxSize: number) => {
         const sizeRow = client.prepare("SELECT COUNT(*) AS n FROM work_queue WHERE agent = ?").get(agent) as { n: number };
         let dropped: { payload: string; received_at: number } | undefined;
 
-        if (sizeRow.n >= this.maxSize) {
+        if (sizeRow.n >= maxSize) {
           const oldest = client
             .prepare("SELECT id, payload, received_at FROM work_queue WHERE agent = ? ORDER BY rowid ASC LIMIT 1")
             .get(agent) as { id: string; payload: string; received_at: number } | undefined;
@@ -85,14 +87,20 @@ export class SqliteWorkQueue<T> implements WorkQueue<T> {
     );
   }
 
+  setAgentMaxSize(agentName: string, maxSize: number): void {
+    this.agentMaxSizes.set(agentName, maxSize);
+  }
+
   enqueue(agentName: string, context: T, receivedAt?: Date): EnqueueResult<T> {
     const id = randomUUID();
     const ts = (receivedAt || new Date()).getTime();
+    const effectiveMax = this.agentMaxSizes.get(agentName) ?? this.maxSize;
     const { dropped: droppedRow } = this._enqueueTransaction(
       agentName,
       id,
       JSON.stringify(context),
       ts,
+      effectiveMax,
     );
 
     let dropped: QueuedWorkItem<T> | undefined;

--- a/packages/action-llama/src/events/event-queue-unified.ts
+++ b/packages/action-llama/src/events/event-queue-unified.ts
@@ -13,12 +13,17 @@ export class EventSourcedWorkQueue<T> implements WorkQueue<T> {
   private agentStreams = new Map<string, EventStreamWrapper>();
   private queueState = new Map<string, QueueState<T>>();
   private maxSize: number;
+  private agentMaxSizes = new Map<string, number>();
 
   constructor(
     private persistence: PersistenceStore,
     maxSize: number = 100
   ) {
     this.maxSize = maxSize;
+  }
+
+  setAgentMaxSize(agentName: string, maxSize: number): void {
+    this.agentMaxSizes.set(agentName, maxSize);
   }
 
   private getAgentStream(agentName: string): EventStreamWrapper {
@@ -83,8 +88,9 @@ export class EventSourcedWorkQueue<T> implements WorkQueue<T> {
     const workId = `${agentName}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     
     // Check if we need to drop oldest item
+    const effectiveMax = this.agentMaxSizes.get(agentName) ?? this.maxSize;
     let droppedItem: QueuedWorkItem<T> | undefined;
-    if (state.size() >= this.maxSize) {
+    if (state.size() >= effectiveMax) {
       const oldest = state.getOldest();
       if (oldest) {
         await stream.appendTyped(

--- a/packages/action-llama/src/events/event-queue.ts
+++ b/packages/action-llama/src/events/event-queue.ts
@@ -10,9 +10,14 @@ export type { QueuedWorkItem, EnqueueResult, WorkQueue } from "../shared/work-qu
 export class MemoryWorkQueue<T> implements WorkQueue<T> {
   private queues = new Map<string, QueuedWorkItem<T>[]>();
   private maxSize: number;
+  private agentMaxSizes = new Map<string, number>();
 
   constructor(maxSize = 100) {
     this.maxSize = maxSize;
+  }
+
+  setAgentMaxSize(agentName: string, maxSize: number): void {
+    this.agentMaxSizes.set(agentName, maxSize);
   }
 
   enqueue(agentName: string, context: T, receivedAt?: Date): EnqueueResult<T> {
@@ -22,7 +27,8 @@ export class MemoryWorkQueue<T> implements WorkQueue<T> {
       this.queues.set(agentName, queue);
     }
     let dropped: QueuedWorkItem<T> | undefined;
-    if (queue.length >= this.maxSize) {
+    const effectiveMax = this.agentMaxSizes.get(agentName) ?? this.maxSize;
+    if (queue.length >= effectiveMax) {
       dropped = queue.shift();
     }
     queue.push({ context, receivedAt: receivedAt || new Date() });

--- a/packages/action-llama/src/scheduler/index.ts
+++ b/packages/action-llama/src/scheduler/index.ts
@@ -69,6 +69,14 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
   };
   state.workQueue = workQueue;
 
+  // Apply per-agent work queue size overrides
+  for (const agentConfig of agentConfigs) {
+    if (agentConfig.maxWorkQueueSize !== undefined) {
+      workQueue.setAgentMaxSize(agentConfig.name, agentConfig.maxWorkQueueSize);
+      logger.info({ agent: agentConfig.name, maxWorkQueueSize: agentConfig.maxWorkQueueSize }, "per-agent work queue size configured");
+    }
+  }
+
   // === Phase 3: Create ingress (gateway + webhook bindings) ===
 
   // Start gateway early (before Docker builds) so users can see build status

--- a/packages/action-llama/src/scheduler/watcher.ts
+++ b/packages/action-llama/src/scheduler/watcher.ts
@@ -178,6 +178,10 @@ export function watchAgents(ctx: HotReloadContext): WatcherHandle {
     ctx.statusTracker?.registerAgent(agentName, scale, agentConfig.description);
     ctx.statusTracker?.setAgentTriggers(agentName, buildTriggerLabels(agentConfig));
 
+    if (agentConfig.maxWorkQueueSize !== undefined) {
+      ctx.schedulerCtx.workQueue.setAgentMaxSize(agentName, agentConfig.maxWorkQueueSize);
+    }
+
     if (scale === 0) {
       ctx.agentConfigs.push(agentConfig);
       ctx.logger.info({ agent: agentName }, "hot reload: agent registered (scale=0, disabled)");
@@ -414,6 +418,11 @@ export function watchAgents(ctx: HotReloadContext): WatcherHandle {
       } else {
         ctx.statusTracker?.setNextRunAt(agentName, null);
       }
+    }
+
+    // Apply per-agent work queue size override if changed
+    if (newConfig.maxWorkQueueSize !== undefined) {
+      ctx.schedulerCtx.workQueue.setAgentMaxSize(agentName, newConfig.maxWorkQueueSize);
     }
 
     // Handle webhook changes

--- a/packages/action-llama/src/shared/config/load-agent.ts
+++ b/packages/action-llama/src/shared/config/load-agent.ts
@@ -64,6 +64,7 @@ export function loadAgentConfig(projectPath: string, agentName: string): AgentCo
     params: runtime.params,
     scale: runtime.scale,
     timeout: runtime.timeout,
+    maxWorkQueueSize: runtime.maxWorkQueueSize,
     runtime: runtime.runtime,
   };
 

--- a/packages/action-llama/src/shared/config/types.ts
+++ b/packages/action-llama/src/shared/config/types.ts
@@ -127,6 +127,7 @@ export interface AgentRuntimeConfig {
   params?: Record<string, unknown>;
   scale?: number;
   timeout?: number;
+  maxWorkQueueSize?: number;
   runtime?: AgentRuntimeType;
 }
 
@@ -145,6 +146,7 @@ export interface AgentConfig {
   params?: Record<string, unknown>;
   scale?: number; // Number of concurrent runs allowed (default: 1)
   timeout?: number; // Max runtime in seconds (falls back to global local.timeout, then 900)
+  maxWorkQueueSize?: number; // Max queued work items (falls back to global workQueueSize)
   license?: string;
   compatibility?: string;
   runtime?: AgentRuntimeType;

--- a/packages/action-llama/src/shared/validation.ts
+++ b/packages/action-llama/src/shared/validation.ts
@@ -94,7 +94,7 @@ const AGENT_RUNTIME_CONFIG_SCHEMA: ConfigSchema = {
   required: new Set(),
   optional: new Set([
     "source", "credentials", "models", "schedule", "webhooks",
-    "hooks", "params", "scale", "timeout", "runtime"
+    "hooks", "params", "scale", "timeout", "maxWorkQueueSize", "runtime"
   ]),
   nested: {
     hooks: {

--- a/packages/action-llama/src/shared/work-queue.ts
+++ b/packages/action-llama/src/shared/work-queue.ts
@@ -17,4 +17,6 @@ export interface WorkQueue<T> {
   clear(agentName: string): void;
   clearAll(): void;
   close(): void;
+  /** Set a per-agent max queue size, overriding the global default. */
+  setAgentMaxSize(agentName: string, maxSize: number): void;
 }

--- a/packages/action-llama/test/events/event-queue.test.ts
+++ b/packages/action-llama/test/events/event-queue.test.ts
@@ -155,6 +155,36 @@ function workQueueSuite(
       expect(queue.dequeue("agent-a")?.context).toBe("event-2");
       expect(queue.dequeue("agent-a")).toBeUndefined();
     });
+
+    it("respects per-agent maxSize override", () => {
+      ({ queue, cleanup } = factory(100)); // global max = 100
+      queue.setAgentMaxSize("agent-a", 2);
+      queue.enqueue("agent-a", "event-1");
+      queue.enqueue("agent-a", "event-2");
+      const result = queue.enqueue("agent-a", "event-3");
+      expect(result.dropped?.context).toBe("event-1");
+      expect(queue.size("agent-a")).toBe(2);
+    });
+
+    it("per-agent maxSize does not affect other agents", () => {
+      ({ queue, cleanup } = factory(100));
+      queue.setAgentMaxSize("agent-a", 1);
+      queue.enqueue("agent-a", "a-1");
+      queue.enqueue("agent-b", "b-1");
+      queue.enqueue("agent-b", "b-2");
+      queue.enqueue("agent-b", "b-3");
+      expect(queue.size("agent-a")).toBe(1);
+      expect(queue.size("agent-b")).toBe(3);
+    });
+
+    it("falls back to global maxSize when no per-agent override", () => {
+      ({ queue, cleanup } = factory(2));
+      queue.enqueue("agent-a", "event-1");
+      queue.enqueue("agent-a", "event-2");
+      const result = queue.enqueue("agent-a", "event-3");
+      expect(result.dropped?.context).toBe("event-1");
+      expect(queue.size("agent-a")).toBe(2);
+    });
   });
 }
 

--- a/packages/action-llama/test/shared/config.test.ts
+++ b/packages/action-llama/test/shared/config.test.ts
@@ -13,7 +13,7 @@ function writeModelsConfig(dir: string, models: Record<string, unknown>, extra?:
 }
 
 /** Helper to write SKILL.md (portable fields only) and per-agent config.toml (runtime fields). */
-function writeSkillMd(dir: string, agentName: string, opts: { models: string[]; credentials?: string[]; schedule?: string; hooks?: unknown; description?: string; params?: unknown; scale?: number; timeout?: number }) {
+function writeSkillMd(dir: string, agentName: string, opts: { models: string[]; credentials?: string[]; schedule?: string; hooks?: unknown; description?: string; params?: unknown; scale?: number; timeout?: number; maxWorkQueueSize?: number }) {
   const agentDir = resolve(dir, "agents", agentName);
   mkdirSync(agentDir, { recursive: true });
 
@@ -32,6 +32,7 @@ function writeSkillMd(dir: string, agentName: string, opts: { models: string[]; 
   if (opts.params) runtime.params = opts.params;
   if (opts.scale !== undefined) runtime.scale = opts.scale;
   if (opts.timeout !== undefined) runtime.timeout = opts.timeout;
+  if (opts.maxWorkQueueSize !== undefined) runtime.maxWorkQueueSize = opts.maxWorkQueueSize;
   writeFileSync(resolve(agentDir, "config.toml"), stringifyTOML(runtime));
 }
 
@@ -248,6 +249,29 @@ name: [
 
     const loaded = loadAgentConfig(tmpDir, "dev");
     expect(loaded.description).toBe("Solves GitHub issues by writing code");
+  });
+
+  it("loads maxWorkQueueSize from agent config.toml", () => {
+    writeModelsConfig(tmpDir, { sonnet: SONNET_MODEL });
+    writeSkillMd(tmpDir, "dev", {
+      models: ["sonnet"],
+      credentials: ["github_token"],
+      maxWorkQueueSize: 50,
+    });
+
+    const loaded = loadAgentConfig(tmpDir, "dev");
+    expect(loaded.maxWorkQueueSize).toBe(50);
+  });
+
+  it("maxWorkQueueSize is undefined when not set in agent config.toml", () => {
+    writeModelsConfig(tmpDir, { sonnet: SONNET_MODEL });
+    writeSkillMd(tmpDir, "dev", {
+      models: ["sonnet"],
+      credentials: ["github_token"],
+    });
+
+    const loaded = loadAgentConfig(tmpDir, "dev");
+    expect(loaded.maxWorkQueueSize).toBeUndefined();
   });
 });
 

--- a/packages/docs/reference/agent-config.mdx
+++ b/packages/docs/reference/agent-config.mdx
@@ -80,6 +80,11 @@ scale = 2
 # Optional: max runtime in seconds (default: falls back to [local].timeout, then 900)
 timeout = 600
 
+# Optional: max queued work items for this agent (default: global workQueueSize)
+# When all runners are busy, incoming events are queued up to this limit.
+# Oldest events are dropped to make room for newer ones.
+maxWorkQueueSize = 50
+
 # Optional: webhook triggers (instead of or in addition to schedule)
 [[webhooks]]
 source = "my-github"
@@ -138,6 +143,7 @@ run_as = "al-agent"           # OS user to run as (default: "al-agent")
 | `schedule` | string | No* | Cron expression for polling |
 | `scale` | number | No | Number of concurrent runs allowed (default: 1). Set to `0` to disable the agent. Use lock skills in your actions to coordinate instances. See [Resource Locks](/concepts/resource-locks). |
 | `timeout` | number | No | Max runtime in seconds. Falls back to `[local].timeout` in project config, then `900`. See [Timeout](#timeout). |
+| `maxWorkQueueSize` | number | No | Maximum queued work items when all runners are busy. Falls back to global `workQueueSize` (default: 20). Oldest events are dropped to make room for newer ones. |
 | `webhooks` | array | No* | Array of webhook trigger objects. See [Webhooks](/reference/webhooks). |
 | `hooks` | table | No | Pre/post hooks that run around the LLM session. See [Hooks](#hooks). |
 | `params` | table | No | Custom key-value params for the agent prompt |

--- a/packages/docs/reference/project-config.mdx
+++ b/packages/docs/reference/project-config.mdx
@@ -66,7 +66,7 @@ samplingRate = 0.5
 |-------|------|---------|-------------|
 | `maxReruns` | number | `10` | Maximum consecutive reruns when an agent requests a rerun via `al-rerun` before stopping |
 | `maxCallDepth` | number | `3` | Maximum depth for agent-to-agent call chains (A calls B calls C = depth 2) |
-| `workQueueSize` | number | `100` | Maximum queued work items (webhook events + agent calls) per agent when all runners are busy |
+| `workQueueSize` | number | `100` | Maximum queued work items (webhook events + agent calls) per agent when all runners are busy. Can be overridden per-agent with `maxWorkQueueSize` in the agent's `config.toml`. |
 | `scale` | number | _(unlimited)_ | Project-wide cap on total concurrent runners across all agents |
 | `resourceLockTimeout` | number | `1800` | Default lock TTL in seconds. Locks expire automatically after this duration unless refreshed via heartbeat. See [Resource Locks](/concepts/resource-locks). |
 | `historyRetentionDays` | number | `14` | Number of days to retain run history and webhook receipts in the local SQLite stats database. Older entries are pruned automatically. |


### PR DESCRIPTION
Closes #473

## Summary

Adds a per-agent `maxWorkQueueSize` setting in agent `config.toml` that overrides the global `workQueueSize` for individual agents.

## Changes

- **Types** (`types.ts`): Added `maxWorkQueueSize?: number` to `AgentRuntimeConfig` and `AgentConfig`
- **Config loading** (`load-agent.ts`): Thread `maxWorkQueueSize` from runtime config into resolved `AgentConfig`
- **Validation** (`validation.ts`): Added `maxWorkQueueSize` to `AGENT_RUNTIME_CONFIG_SCHEMA`
- **WorkQueue interface** (`work-queue.ts`): Added `setAgentMaxSize(agentName, maxSize)` method
- **MemoryWorkQueue** (`event-queue.ts`): Implemented `setAgentMaxSize` + per-agent effective max in `enqueue`
- **SqliteWorkQueue** (`event-queue-sqlite.ts`): Implemented `setAgentMaxSize` + per-agent effective max in `enqueue` transaction
- **EventSourcedWorkQueue** (`event-queue-unified.ts`): Implemented `setAgentMaxSize` + per-agent effective max in `enqueueAsync`
- **Scheduler startup** (`index.ts`): Apply per-agent overrides after loading agent configs
- **Hot-reload** (`watcher.ts`): Apply per-agent override on new/changed agents
- **Tests**: Added 5 new test cases for per-agent max size in both MemoryWorkQueue and SqliteWorkQueue, plus 2 config loading tests
- **Docs**: Updated `agent-config.mdx` and `project-config.mdx`

## Usage

```toml
# agents/my-agent/config.toml
models = ["sonnet"]
credentials = ["github_token"]

# Optional: max queued work items for this agent (default: global workQueueSize)
maxWorkQueueSize = 50
```

## Notes

- Drop-oldest is the only overflow behavior (as per issue discussion: no config option needed)
- Falls back to global `workQueueSize` when not set per-agent
- Hot reload picks up changes without restarting the scheduler
- Pre-existing test failures (33) are unrelated to these changes (missing build for `@action-llama/skill` package)