### PR TITLE
Fix: Hide kill button when run is complete or errored

### DIFF
--- a/.changeset/fix-kill-button-hidden-when-complete.md
+++ b/.changeset/fix-kill-button-hidden-when-complete.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Hide kill button when run is complete or errored by filtering the instance detail endpoint to only return running instances

--- a/package-lock.json
+++ b/package-lock.json
@@ -13292,7 +13292,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.23.8",
+      "version": "0.24.3",
       "license": "MIT",
       "dependencies": {
         "@action-llama/skill": "*",
@@ -13378,7 +13378,7 @@
     },
     "packages/frontend": {
       "name": "@action-llama/frontend",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "dependencies": {
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -13400,7 +13400,7 @@
     },
     "packages/skill": {
       "name": "@action-llama/skill",
-      "version": "0.23.8",
+      "version": "0.24.3",
       "license": "MIT"
     }
   }

--- a/packages/action-llama/src/control/routes/dashboard-api.ts
+++ b/packages/action-llama/src/control/routes/dashboard-api.ts
@@ -125,7 +125,7 @@ export function registerDashboardApiRoutes(
   app.get("/api/dashboard/agents/:name/instances/:id", (c) => {
     const instanceId = c.req.param("id");
     const run = statsStore ? statsStore.queryRunByInstanceId(instanceId) : null;
-    const runningInstance = statusTracker.getInstances().find((i) => i.id === instanceId) || null;
+    const runningInstance = statusTracker.getInstances().find((i) => i.id === instanceId && i.status === "running") || null;
 
     let parentEdge: { caller_agent: string; caller_instance: string } | undefined;
     let webhookReceipt: { source: string; eventSummary?: string; deliveryId?: string } | undefined;

--- a/packages/action-llama/test/control/routes/dashboard.test.ts
+++ b/packages/action-llama/test/control/routes/dashboard.test.ts
@@ -408,6 +408,26 @@ describe("registerDashboardApiRoutes — extended coverage", () => {
     expect(data.runningInstance.id).toBe("inst-1");
   });
 
+  it("GET /api/dashboard/agents/:name/instances/:id returns null runningInstance for completed instance", async () => {
+    const instances = [{ id: "inst-1", agentName: "test-agent", status: "completed" }];
+    const app = createApp(undefined, undefined, instances);
+
+    const res = await app.request("/api/dashboard/agents/test-agent/instances/inst-1");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.runningInstance).toBeNull();
+  });
+
+  it("GET /api/dashboard/agents/:name/instances/:id returns null runningInstance for errored instance", async () => {
+    const instances = [{ id: "inst-1", agentName: "test-agent", status: "error" }];
+    const app = createApp(undefined, undefined, instances);
+
+    const res = await app.request("/api/dashboard/agents/test-agent/instances/inst-1");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.runningInstance).toBeNull();
+  });
+
   it("GET /api/dashboard/agents/:name/instances/:id includes parent edge for agent-triggered runs", async () => {
     const stats = makeStatsStore();
     stats.queryRunByInstanceId.mockReturnValue({


### PR DESCRIPTION
Closes #477

## Summary

The kill button on the instance detail page was staying visible after a run completed because the instance detail endpoint returned instances regardless of their status.

## Changes

- packages/action-llama/src/control/routes/dashboard-api.ts: Added status === 'running' filter to the instance detail endpoint so that completed, errored, and killed instances return null for runningInstance.

- packages/action-llama/test/control/routes/dashboard.test.ts: Added two new tests verifying that completed and errored instances return null for runningInstance.

## Testing

All dashboard tests pass (50/50).