### PR TITLE
Remove logs from agent page activity tab

### DIFF
--- a/.changeset/remove-agent-page-logs.md
+++ b/.changeset/remove-agent-page-logs.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/frontend": patch
+---
+
+Remove logs section from agent page activity tab

--- a/package-lock.json
+++ b/package-lock.json
@@ -13292,7 +13292,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.23.8",
+      "version": "0.24.3",
       "license": "MIT",
       "dependencies": {
         "@action-llama/skill": "*",
@@ -13378,7 +13378,7 @@
     },
     "packages/frontend": {
       "name": "@action-llama/frontend",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "dependencies": {
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -13400,7 +13400,7 @@
     },
     "packages/skill": {
       "name": "@action-llama/skill",
-      "version": "0.23.8",
+      "version": "0.24.3",
       "license": "MIT"
     }
   }

--- a/packages/frontend/src/pages/AgentDetailPage.tsx
+++ b/packages/frontend/src/pages/AgentDetailPage.tsx
@@ -1,62 +1,17 @@
-import { useEffect, useState, useRef } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useAgents } from "../hooks/StatusStreamContext";
 import { useQuery } from "../hooks/useQuery";
-import { usePolling } from "../hooks/usePolling";
 import { ActivityTable } from "../components/ActivityTable";
-import {
-  getAgentLogs,
-  getActivity,
-} from "../lib/api";
-import type {
-  ActivityRow,
-  LogEntry,
-} from "../lib/api";
-
-
-function formatLogEntry(entry: LogEntry): {
-  text: string;
-  className: string;
-} {
-  const msg = entry.msg || "";
-  if (entry.text && (msg.includes("assistant") || msg.includes("response"))) {
-    return {
-      text: `${msg}: ${entry.text}`,
-      className: "text-white font-bold",
-    };
-  }
-  if (entry.cmd || msg.includes("bash") || msg.includes("command")) {
-    return {
-      text: entry.cmd ? `$ ${entry.cmd}` : msg,
-      className: "text-cyan-400",
-    };
-  }
-  if (entry.tool || msg.includes("tool")) {
-    return {
-      text: entry.tool ? `[tool] ${entry.tool}: ${entry.result ?? ""}` : msg,
-      className: "text-blue-400",
-    };
-  }
-  if (entry.level >= 50 || entry.err) {
-    return { text: msg, className: "text-red-400" };
-  }
-  if (entry.level >= 40) {
-    return { text: msg, className: "text-yellow-400" };
-  }
-  return { text: msg, className: "text-slate-300" };
-}
+import { getActivity } from "../lib/api";
+import type { ActivityRow } from "../lib/api";
 
 export function AgentDetailPage() {
   const { name } = useParams<{ name: string }>();
   const agents = useAgents();
-  const [logs, setLogs] = useState<LogEntry[]>([]);
-  const cursorRef = useRef<string | null>(null);
-  const logContainerRef = useRef<HTMLDivElement>(null);
 
   const agent = agents.find((a) => a.name === name) ?? null;
   const agentNames = agents.map((a) => a.name);
 
-  // Load activity
   const { data: activityData } = useQuery<{ rows: ActivityRow[]; total: number }>({
     key: `agent-activity:${name}`,
     fetcher: (signal) => getActivity(5, 0, name!, undefined, undefined, signal),
@@ -65,29 +20,6 @@ export function AgentDetailPage() {
     enabled: !!name,
   });
   const activity = activityData?.rows ?? [];
-
-  // Poll logs
-  usePolling(
-    async (signal) => {
-      if (!name) return;
-      const params: Record<string, string> = { limit: "50" };
-      if (cursorRef.current) params.cursor = cursorRef.current;
-      const d = await getAgentLogs(name, params, signal);
-      if (d.entries.length > 0) {
-        setLogs((prev) => [...prev, ...d.entries].slice(-200));
-        if (d.cursor) cursorRef.current = d.cursor;
-      }
-    },
-    { intervalMs: 4000, enabled: !!name },
-    [name],
-  );
-
-  // Scroll logs to bottom on new entries
-  useEffect(() => {
-    if (logContainerRef.current) {
-      logContainerRef.current.scrollTop = logContainerRef.current.scrollHeight;
-    }
-  }, [logs]);
 
   if (!name) return null;
 
@@ -117,37 +49,6 @@ export function AgentDetailPage() {
             agentNames={agentNames}
             emptyMessage="No activity yet"
           />
-        </div>
-      </div>
-
-      {/* Recent Logs */}
-      <div className="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden">
-        <div className="px-4 py-2.5 border-b border-slate-200 dark:border-slate-800">
-          <h2 className="text-sm font-medium text-slate-900 dark:text-white">
-            Recent Logs
-          </h2>
-        </div>
-        <div
-          ref={logContainerRef}
-          className="max-h-80 overflow-y-auto scrollbar-thin bg-slate-950 p-3"
-        >
-          {logs.length > 0 ? (
-            logs.map((entry, i) => {
-              const { text, className } = formatLogEntry(entry);
-              return (
-                <div key={i} className="text-xs font-mono leading-5">
-                  <span className="text-slate-600">
-                    {new Date(entry.time).toLocaleTimeString()}
-                  </span>{" "}
-                  <span className={className}>{text}</span>
-                </div>
-              );
-            })
-          ) : (
-            <div className="text-xs text-slate-500 text-center py-4">
-              No log entries
-            </div>
-          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes #480

## Changes

Removed the "Recent Logs" section from the agent page activity tab (). The activity table remains; only the log viewer has been removed along with all supporting code:

- Removed `formatLogEntry` helper function
- Removed log-related state (`logs`, `cursorRef`, `logContainerRef`)
- Removed log polling via `usePolling` / `getAgentLogs`
- Removed auto-scroll `useEffect`
- Cleaned up unused imports (`useEffect`, `useState`, `useRef`, `usePolling`, `getAgentLogs`, `LogEntry`)

The `getAgentLogs` function in `api.ts` and `usePolling` hook are still used by `InstanceDetailPage.tsx` and were not removed.

## Validation

Frontend builds successfully with `npm run build -w packages/shared && npm run build -w packages/frontend`.