### PR TITLE
Fix activity rows: match agent index page row style

### DIFF
--- a/.changeset/fix-activity-rows-style.md
+++ b/.changeset/fix-activity-rows-style.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/frontend": patch
+---
+
+Fix activity rows to match agent index page row style: show instance ID in large, bold, colored text on top, with trigger badge below it

--- a/package-lock.json
+++ b/package-lock.json
@@ -13292,7 +13292,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.23.8",
+      "version": "0.24.3",
       "license": "MIT",
       "dependencies": {
         "@action-llama/skill": "*",
@@ -13378,7 +13378,7 @@
     },
     "packages/frontend": {
       "name": "@action-llama/frontend",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "dependencies": {
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -13400,7 +13400,7 @@
     },
     "packages/skill": {
       "name": "@action-llama/skill",
-      "version": "0.23.8",
+      "version": "0.24.3",
       "license": "MIT"
     }
   }

--- a/packages/frontend/src/components/ActivityTable.tsx
+++ b/packages/frontend/src/components/ActivityTable.tsx
@@ -70,11 +70,8 @@ export function ActivityTable({
           <th className="text-left pl-6 pr-1 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide w-[1%] whitespace-nowrap">
             Time
           </th>
-          <th className="text-left pl-2 pr-2 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide w-[1%] whitespace-nowrap">
-            Trigger
-          </th>
-          <th className="text-left pl-2 pr-2 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide hidden sm:table-cell">
-            Agent
+          <th className="text-left pl-2 pr-2 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">
+            Instance
           </th>
         </tr>
       </thead>
@@ -106,15 +103,15 @@ export function ActivityTable({
             </span>
           );
 
-          // Agent instance ID element (colored, linked)
+          // Agent instance ID element — large, colored, bold (matching dashboard agent row style)
           const agentEl = !isDeadLetter && row.agentName && row.instanceId ? (
             <Link
               to={`/dashboard/agents/${encodeURIComponent(row.agentName)}/instances/${encodeURIComponent(row.instanceId)}`}
-              className="hover:underline"
+              className="font-medium hover:underline truncate block"
             >
               <span
-                className="agent-color-text font-medium font-mono text-xs"
-                style={agentHueStyle(row.agentName, agentNames)}
+                className="agent-color-text truncate"
+                style={{ fontSize: "16px", ...agentHueStyle(row.agentName, agentNames) }}
               >
                 {row.instanceId}
               </span>
@@ -122,11 +119,11 @@ export function ActivityTable({
           ) : !isDeadLetter && row.agentName ? (
             <Link
               to={`/dashboard/agents/${encodeURIComponent(row.agentName)}`}
-              className="hover:underline"
+              className="font-medium hover:underline truncate block"
             >
               <span
-                className="agent-color-text font-medium text-xs"
-                style={agentHueStyle(row.agentName, agentNames)}
+                className="agent-color-text truncate"
+                style={{ fontSize: "16px", ...agentHueStyle(row.agentName, agentNames) }}
               >
                 {row.agentName}
               </span>
@@ -154,25 +151,22 @@ export function ActivityTable({
                 </span>
               </td>
 
-              {/* Trigger — badge with dead-letter reason; on mobile also shows agent below */}
-              <td className="pl-2 pr-2 py-2.5 whitespace-nowrap">
+              {/* Instance — instance ID (large, colored) on top, trigger badge below */}
+              <td className="pl-2 pr-2 py-2.5">
                 <div className="flex flex-col gap-0.5">
-                  {triggerEl}
+                  {/* Instance ID or agent name — large, colored, bold */}
+                  {agentEl}
+                  {/* Trigger badge below */}
+                  <div className="mt-0.5">
+                    {triggerEl}
+                  </div>
+                  {/* Dead letter reason if applicable */}
                   {isDeadLetter && row.deadLetterReason && (
                     <span className="text-xs text-red-500 dark:text-red-400">
                       {row.deadLetterReason.replace(/_/g, " ")}
                     </span>
                   )}
-                  {/* Mobile: show agent instance below trigger */}
-                  {agentEl && (
-                    <span className="sm:hidden">{agentEl}</span>
-                  )}
                 </div>
-              </td>
-
-              {/* Agent — instance ID (hidden on mobile, shown in trigger cell instead) */}
-              <td className="pl-2 pr-2 py-2.5 hidden sm:table-cell align-top">
-                {agentEl ?? <span className="text-slate-400 text-xs">{"\u2014"}</span>}
               </td>
             </tr>
           );
@@ -180,7 +174,7 @@ export function ActivityTable({
         {rows.length === 0 && loading && (
           <tr>
             <td
-              colSpan={3}
+              colSpan={2}
               className="px-4 py-8 text-center text-slate-500 dark:text-slate-400"
             >
               Loading...
@@ -190,7 +184,7 @@ export function ActivityTable({
         {rows.length === 0 && !loading && (
           <tr>
             <td
-              colSpan={3}
+              colSpan={2}
               className="px-4 py-8 text-center text-slate-500 dark:text-slate-400"
             >
               {emptyMessage}


### PR DESCRIPTION
Closes #479

## Changes

Restructured the  component so each row mirrors the agent index page () row style:

- **Instance ID** is now the primary visual element shown in large (16px), bold, colored text on top — using the same `agent-color-text` class and `agentHueStyle()` as the dashboard agent rows
- **Trigger badge** is rendered below the instance ID (as a secondary element)
- Collapsed from 3 columns (Time, Trigger, Agent) to 2 columns (Time, Instance)
- Removed the mobile `sm:hidden` workaround since instance ID and trigger are now in the same cell
- Dead-letter rows still display correctly (trigger badge as top-level element, reason below)
- Rows with agent name but no instance ID show the agent name in the large colored style
- Updated `colSpan` from 3 to 2 in loading/empty state rows
- Removed `font-mono` from instance ID to match the dashboard agent name style