### PR TITLE
fix: create StatusTracker in harness when webUI is enabled so dashboard routes are registered

### DIFF
--- a/.changeset/fix-dashboard-harness-status-tracker.md
+++ b/.changeset/fix-dashboard-harness-status-tracker.md
@@ -1,0 +1,7 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fix dashboard integration tests by creating StatusTracker in harness when webUI is enabled
+
+The integration harness now creates a StatusTracker instance when `start({ webUI: true })` is called, ensuring dashboard API routes (/api/dashboard/*) are properly registered by the gateway. The three dashboard integration test files have been updated to pass `{ webUI: true }` to `harness.start()`.

--- a/packages/action-llama/package.json
+++ b/packages/action-llama/package.json
@@ -34,7 +34,8 @@
     "./internals/config": "./dist/shared/config.js",
     "./internals/webhook-types": "./dist/webhooks/types.js",
     "./internals/execution": "./dist/execution/execution.js",
-    "./internals/scheduler-events": "./dist/scheduler/events.js"
+    "./internals/scheduler-events": "./dist/scheduler/events.js",
+    "./internals/status-tracker": "./dist/tui/status-tracker.js"
   },
   "files": [
     "dist",

--- a/packages/e2e/src/integration/dashboard-agent-trigger-api.test.ts
+++ b/packages/e2e/src/integration/dashboard-agent-trigger-api.test.ts
@@ -76,7 +76,7 @@ describe.skipIf(!DOCKER)(
         ],
       });
 
-      await harness.start();
+      await harness.start({ webUI: true });
 
       // Trigger the caller which will subagent the callee
       await harness.triggerAgent("dashboard-caller");
@@ -154,7 +154,7 @@ describe.skipIf(!DOCKER)(
         ],
       });
 
-      await harness.start();
+      await harness.start({ webUI: true });
 
       await harness.triggerAgent("trigger-caller");
 

--- a/packages/e2e/src/integration/dashboard-instance-api.test.ts
+++ b/packages/e2e/src/integration/dashboard-instance-api.test.ts
@@ -49,7 +49,7 @@ describe.skipIf(!DOCKER)("integration: dashboard instance detail API", { timeout
       ],
     });
 
-    await harness.start();
+    await harness.start({ webUI: true });
 
     // Trigger the agent and wait for it to complete
     await harness.triggerAgent("instance-detail-agent");
@@ -113,7 +113,7 @@ describe.skipIf(!DOCKER)("integration: dashboard instance detail API", { timeout
       ],
     });
 
-    await harness.start();
+    await harness.start({ webUI: true });
 
     // Trigger the agent manually and wait for it to complete
     await harness.triggerAgent("trigger-detail-agent");
@@ -168,7 +168,7 @@ describe.skipIf(!DOCKER)("integration: dashboard instance detail API", { timeout
       ],
     });
 
-    await harness.start();
+    await harness.start({ webUI: true });
 
     const res = await gatewayFetch(
       harness,
@@ -191,7 +191,7 @@ describe.skipIf(!DOCKER)("integration: dashboard instance detail API", { timeout
       ],
     });
 
-    await harness.start();
+    await harness.start({ webUI: true });
 
     // Fetch with a nonexistent instanceId — should return run: null
     const detailRes = await gatewayFetch(

--- a/packages/e2e/src/integration/dashboard-webhook-trigger-api.test.ts
+++ b/packages/e2e/src/integration/dashboard-webhook-trigger-api.test.ts
@@ -51,7 +51,7 @@ describe.skipIf(!DOCKER)(
         },
       });
 
-      await harness.start();
+      await harness.start({ webUI: true });
 
       // Send a webhook to trigger the agent
       const webhookRes = await harness.sendWebhook({
@@ -118,7 +118,7 @@ describe.skipIf(!DOCKER)(
         },
       });
 
-      await harness.start();
+      await harness.start({ webUI: true });
 
       // Trigger via webhook
       const webhookRes = await harness.sendWebhook({

--- a/packages/e2e/src/integration/harness.ts
+++ b/packages/e2e/src/integration/harness.ts
@@ -199,7 +199,7 @@ export class IntegrationHarness {
   /**
    * Start the scheduler (triggers real Docker builds, gateway, cron, webhooks).
    *
-   * @param opts.webUI - Enable web UI routes including chat session management (default: false)
+   * @param opts.webUI - Enable web UI routes including chat session management and dashboard API (default: false)
    */
   async start(opts?: { webUI?: boolean }): Promise<void> {
     const { startScheduler } = await import("@action-llama/action-llama/internals/scheduler");
@@ -211,11 +211,20 @@ export class IntegrationHarness {
     const { loadGlobalConfig } = await import("@action-llama/action-llama/internals/config");
     const loadedConfig = loadGlobalConfig(this.projectPath);
 
+    // Create a StatusTracker when webUI is enabled so dashboard routes are registered.
+    // gateway/index.ts only registers /api/dashboard/* when both webUI and statusTracker
+    // are provided, so we must supply one when tests need those endpoints.
+    let statusTracker: import("@action-llama/action-llama/internals/status-tracker").StatusTracker | undefined;
+    if (opts?.webUI) {
+      const { StatusTracker } = await import("@action-llama/action-llama/internals/status-tracker");
+      statusTracker = new StatusTracker();
+    }
+
     this._scheduler = await startScheduler(
       this.projectPath,
       loadedConfig,
-      undefined,            // no status tracker
-      opts?.webUI ?? false, // web UI (enables chat routes when true)
+      statusTracker,        // status tracker (required for dashboard routes when webUI is true)
+      opts?.webUI ?? false, // web UI (enables chat routes and dashboard API when true)
       true,                 // expose — bind to 0.0.0.0 so Docker containers can reach gateway via host-gateway
     );
 


### PR DESCRIPTION
Closes #488

## Problem

Dashboard integration tests were calling `/api/dashboard/*` endpoints that were never registered because:
1. `gateway/index.ts` only registers dashboard routes when `opts.webUI && opts.statusTracker`
2. The integration harness called `startScheduler` with `statusTracker: undefined` and `webUI: false`

This caused the three dashboard test files to receive 404s instead of 200s.

## Fix

**`packages/action-llama/package.json`**: Added `./internals/status-tracker` export so `StatusTracker` can be imported in the harness.

**`packages/e2e/src/integration/harness.ts`**: Modified `start()` to create a `StatusTracker` instance when `webUI: true` is requested and pass it to `startScheduler`. This ensures the gateway registers `/api/dashboard/*` routes when needed.

**Dashboard test files**: Updated all three dashboard integration test files to call `harness.start({ webUI: true })` so the dashboard routes are registered:
- `dashboard-instance-api.test.ts`
- `dashboard-agent-trigger-api.test.ts`
- `dashboard-webhook-trigger-api.test.ts`