### PR TITLE
Fix: make running status colour blue everywhere

### DIFF
--- a/.changeset/fix-status-colours.md
+++ b/.changeset/fix-status-colours.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/frontend": patch
+---
+
+Change running state colour from green to blue across agent index, agent detail, instance detail pages and StateBadge component to be consistent with the activity table.

--- a/packages/frontend/src/components/AgentLayout.tsx
+++ b/packages/frontend/src/components/AgentLayout.tsx
@@ -86,13 +86,13 @@ export function AgentLayout() {
               id="agent-state"
               className={`text-sm ${
                 agent.runningCount > 0
-                  ? "text-green-600 dark:text-green-400"
+                  ? "text-blue-600 dark:text-blue-400"
                   : "text-slate-500 dark:text-slate-400"
               }`}
             >
               <span
                 className={`inline-block w-1.5 h-1.5 rounded-full mr-1.5 ${
-                  agent.runningCount > 0 ? "bg-green-500" : "bg-slate-400"
+                  agent.runningCount > 0 ? "bg-blue-500" : "bg-slate-400"
                 }`}
               />
               {agent.runningCount > 0

--- a/packages/frontend/src/components/Badge.tsx
+++ b/packages/frontend/src/components/Badge.tsx
@@ -104,8 +104,8 @@ export function ResultBadge({ result, deadLetterReason }: { result: string; dead
 export function StateBadge({ state }: { state: string }) {
   const colors: Record<string, { dot: string; text: string }> = {
     running: {
-      dot: "bg-green-500",
-      text: "text-green-600 dark:text-green-400",
+      dot: "bg-blue-500",
+      text: "text-blue-600 dark:text-blue-400",
     },
     building: {
       dot: "bg-yellow-500",

--- a/packages/frontend/src/components/InstanceLayout.tsx
+++ b/packages/frontend/src/components/InstanceLayout.tsx
@@ -144,7 +144,7 @@ export function InstanceLayout() {
             </div>
             {run && <ResultBadge result={run.result} />}
             {isRunning && !run && (
-              <span className="text-xs text-green-600 dark:text-green-400 font-medium">
+              <span className="text-xs text-blue-600 dark:text-blue-400 font-medium">
                 running
               </span>
             )}

--- a/packages/frontend/src/pages/DashboardPage.tsx
+++ b/packages/frontend/src/pages/DashboardPage.tsx
@@ -14,7 +14,7 @@ import { agentHueStyle } from "../lib/color";
 
 const ROW_STATE_STYLES: Record<string, string> = {
   running:
-    "border-l-2 border-l-green-500 dark:border-l-green-400 bg-green-50/40 dark:bg-green-950/20",
+    "border-l-2 border-l-blue-500 dark:border-l-blue-400 bg-blue-50/40 dark:bg-blue-950/20",
   building:
     "border-l-2 border-l-yellow-500 dark:border-l-yellow-400 bg-yellow-50/40 dark:bg-yellow-950/20",
   error:
@@ -23,7 +23,7 @@ const ROW_STATE_STYLES: Record<string, string> = {
 };
 
 const STATE_DOT_COLORS: Record<string, string> = {
-  running: "bg-green-500",
+  running: "bg-blue-500",
   building: "bg-yellow-500",
   error: "bg-red-500",
   idle: "bg-slate-400",


### PR DESCRIPTION
Closes #485

## Changes

Updated the running state colour from green to blue across all components to be consistent with the activity table:

- **DashboardPage.tsx**: Changed `ROW_STATE_STYLES.running` border/background and `STATE_DOT_COLORS.running` dot from green → blue
- **AgentLayout.tsx**: Changed running state text colour and dot from green → blue  
- **InstanceLayout.tsx**: Changed running fallback text from green → blue
- **Badge.tsx**: Changed `StateBadge` running dot and text from green → blue

The activity table (`ActivityTable.tsx`) and `ResultBadge` already used blue for running — these are now consistent across the whole app.

## Colour reference
- Pending: amber/yellow ✅
- Running: **blue** (was green on agent views) ✅
- Completed: green ✅
- Error: red ✅