### PR TITLE
feat: support instance ID as positional arg in `al logs`, remove --instance flag

### DIFF
--- a/.changeset/al-logs-instance-id-positional.md
+++ b/.changeset/al-logs-instance-id-positional.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": minor
+---
+
+`al logs` now accepts a full instance ID as the positional argument (e.g. `al logs e2e-coverage-improver-b80a62dd`), automatically detecting and extracting the agent name and instance suffix. The `-i, --instance` flag has been removed; use the positional instance ID instead.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13292,7 +13292,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.24.3",
+      "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
         "@action-llama/skill": "*",
@@ -13378,7 +13378,7 @@
     },
     "packages/frontend": {
       "name": "@action-llama/frontend",
-      "version": "0.19.3",
+      "version": "0.19.4",
       "dependencies": {
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -13400,7 +13400,7 @@
     },
     "packages/skill": {
       "name": "@action-llama/skill",
-      "version": "0.24.3",
+      "version": "0.25.0",
       "license": "MIT"
     }
   }

--- a/packages/action-llama/src/cli/commands/logs.ts
+++ b/packages/action-llama/src/cli/commands/logs.ts
@@ -3,6 +3,16 @@ import { createReadStream, readdirSync, existsSync, statSync } from "fs";
 import { createInterface } from "readline";
 import { logsDir } from "../../shared/paths.js";
 
+/**
+ * Detect if a string looks like an instance ID (agent-name + 8-char hex suffix).
+ * Returns { agent, instanceSuffix } if it matches, or null if it's a plain agent name.
+ */
+function parseInstanceId(value: string): { agent: string; instanceSuffix: string } | null {
+  const match = value.match(/^(.+)-([0-9a-f]{8})$/);
+  if (!match) return null;
+  return { agent: match[1], instanceSuffix: match[2] };
+}
+
 // ── ANSI helpers ──────────────────────────────────────────────────────────────
 
 const RESET = "\x1b[0m";
@@ -437,7 +447,7 @@ async function followFile(filePath: string, lastN: number, fmt: Formatter, showR
 
 export async function execute(
   agent: string,
-  opts: { project: string; lines: string; follow?: boolean; date?: string; raw?: boolean; all?: boolean; env?: string; instance?: string; grep?: string; after?: string; before?: string }
+  opts: { project: string; lines: string; follow?: boolean; date?: string; raw?: boolean; all?: boolean; env?: string; grep?: string; after?: string; before?: string }
 ): Promise<void> {
   const projectPath = resolve(opts.project);
   const fmt: Formatter = opts.raw
@@ -445,10 +455,15 @@ export async function execute(
     : opts.all
       ? (entry) => formatConversationEntry(entry, true)
       : formatConversationEntry;
-  // --instance accepts a full instance ID (e.g. "dev-a1b2c3d4") or just the suffix ("a1b2c3d4")
-  const instanceSuffix = opts.instance
-    ? (opts.instance.startsWith(`${agent}-`) ? opts.instance.slice(agent.length + 1) : opts.instance)
-    : undefined;
+
+  // Auto-detect if the positional agent arg is a full instance ID (e.g. "dev-a1b2c3d4")
+  let resolvedAgent = agent;
+  let instanceSuffix: string | undefined;
+  const parsed = parseInstanceId(agent);
+  if (parsed) {
+    resolvedAgent = parsed.agent;
+    instanceSuffix = parsed.instanceSuffix;
+  }
 
   const n = parseInt(opts.lines, 10);
 
@@ -472,12 +487,12 @@ export async function execute(
 
   // Build API path
   let apiPath: string;
-  if (agent === "scheduler") {
+  if (resolvedAgent === "scheduler") {
     apiPath = "/api/logs/scheduler";
   } else if (instanceSuffix !== undefined) {
-    apiPath = `/api/logs/agents/${encodeURIComponent(agent)}/${instanceSuffix}`;
+    apiPath = `/api/logs/agents/${encodeURIComponent(resolvedAgent)}/${instanceSuffix}`;
   } else {
-    apiPath = `/api/logs/agents/${encodeURIComponent(agent)}`;
+    apiPath = `/api/logs/agents/${encodeURIComponent(resolvedAgent)}`;
   }
 
   try {
@@ -548,7 +563,7 @@ export async function execute(
       const data = await res.json() as { entries: LogEntry[]; cursor: string | null; hasMore: boolean };
       const filtered = applyGrepFilter(data.entries);
       if (filtered.length === 0) {
-        console.log(`No log entries found for "${agent}".`);
+        console.log(`No log entries found for "${resolvedAgent}".`);
       } else {
         formatAndPrintEntries(filtered);
       }
@@ -556,16 +571,16 @@ export async function execute(
   } catch {
     // Gateway not running — fall back to direct file reading
     const dir = logsDir(projectPath);
-    const logFile = findLogFile(dir, agent, opts.date);
+    const logFile = findLogFile(dir, resolvedAgent, opts.date);
 
     if (!logFile) {
       const dateStr = opts.date || "today";
-      console.error(`No log file found for agent "${agent}" (${dateStr}) in ${dir}`);
+      console.error(`No log file found for agent "${resolvedAgent}" (${dateStr}) in ${dir}`);
       process.exit(1);
     }
 
-    // When --instance / --after / --before / --grep are specified, wrap the formatter
-    const instanceFilter = instanceSuffix !== undefined ? `${agent}-${instanceSuffix}` : undefined;
+    // When instance / --after / --before / --grep are specified, wrap the formatter
+    const instanceFilter = instanceSuffix !== undefined ? `${resolvedAgent}-${instanceSuffix}` : undefined;
     const filteredFmt: Formatter = (entry) => {
       if (instanceFilter && entry.instance !== instanceFilter) return null;
       if (afterTs !== undefined && entry.time <= afterTs) return null;

--- a/packages/action-llama/src/cli/main.ts
+++ b/packages/action-llama/src/cli/main.ts
@@ -112,7 +112,7 @@ program
 program
   .command("logs")
   .description("View agent log files (defaults to scheduler logs)")
-  .argument("[agent]", "agent name (omit for scheduler logs)", "scheduler")
+  .argument("[agent]", "agent name or instance ID (omit for scheduler logs)", "scheduler")
   .option("-p, --project <dir>", "project directory", ".")
   .option("-n, --lines <N>", "number of log entries to show", "50")
   .option("-f, --follow", "tail mode — watch for new log entries")
@@ -120,7 +120,6 @@ program
   .option("-r, --raw", "show raw JSON log entries instead of conversation view")
   .option("-a, --all", "show all log levels (no filtering)")
   .option("-E, --env <name>", "use named environment")
-  .option("-i, --instance <N>", "instance number (for agents with scale > 1)")
   .option("-g, --grep <pattern>", "filter log lines matching regex pattern (searches full JSON line)")
   .option("--after <time>", "show entries after this time (ISO date or relative: 2h, 7d)")
   .option("--before <time>", "show entries before this time (ISO date or relative: 2h, 7d)")

--- a/packages/action-llama/test/cli/commands/logs-gateway.test.ts
+++ b/packages/action-llama/test/cli/commands/logs-gateway.test.ts
@@ -113,7 +113,7 @@ describe("logs command — gateway path", () => {
       expect(calledPath).toContain("/api/logs/scheduler");
     });
 
-    it("includes instance suffix in API path when --instance is provided", async () => {
+    it("includes instance suffix in API path when full instance ID is passed as positional arg", async () => {
       let calledPath = "";
       mockGatewayFetch.mockImplementation(async (opts: { path: string }) => {
         calledPath = opts.path;
@@ -123,7 +123,8 @@ describe("logs command — gateway path", () => {
       const output: string[] = [];
       const origLog = console.log;
       console.log = (...args: any[]) => output.push(args.join(" "));
-      await execute("dev", { project: tmpDir, lines: "10", instance: "a1b2c3d4" });
+      // Pass the full instance ID as the positional agent arg
+      await execute("dev-a1b2c3d4", { project: tmpDir, lines: "10" });
       console.log = origLog;
 
       expect(calledPath).toContain("/api/logs/agents/dev/a1b2c3d4");

--- a/packages/action-llama/test/cli/commands/logs.test.ts
+++ b/packages/action-llama/test/cli/commands/logs.test.ts
@@ -777,8 +777,8 @@ describe("logs command", () => {
 
   // ── Instance filtering ────────────────────────────────────────────────────
 
-  describe("instance filtering (--instance)", () => {
-    it("filters to only entries matching the instance suffix", async () => {
+  describe("instance filtering", () => {
+    it("filters to only entries matching the instance suffix via positional instance ID", async () => {
       const date = new Date().toISOString().slice(0, 10);
       const logFile = resolve(tmpDir, ".al", "logs", `dev-${date}.log`);
       const content = [
@@ -791,14 +791,15 @@ describe("logs command", () => {
       const output: string[] = [];
       const origLog = console.log;
       console.log = (...args: any[]) => output.push(args.join(" "));
-      await execute("dev", { project: tmpDir, lines: "50", instance: "aabbccdd" });
+      // Pass the full instance ID as the positional agent arg
+      await execute("dev-aabbccdd", { project: tmpDir, lines: "50" });
       console.log = origLog;
 
       expect(output).toHaveLength(1);
       expect(output[0]).toContain("echo from instance 1");
     });
 
-    it("accepts full instance ID (with agent prefix)", async () => {
+    it("accepts full instance ID as the positional agent argument", async () => {
       const date = new Date().toISOString().slice(0, 10);
       const logFile = resolve(tmpDir, ".al", "logs", `dev-${date}.log`);
       const content = [
@@ -810,12 +811,26 @@ describe("logs command", () => {
       const output: string[] = [];
       const origLog = console.log;
       console.log = (...args: any[]) => output.push(args.join(" "));
-      // Pass the full instance ID "dev-aabbccdd" (with agent prefix)
-      await execute("dev", { project: tmpDir, lines: "50", instance: "dev-aabbccdd" });
+      // Pass the full instance ID "dev-aabbccdd" as the positional arg
+      await execute("dev-aabbccdd", { project: tmpDir, lines: "50" });
       console.log = origLog;
 
       expect(output).toHaveLength(1);
       expect(output[0]).toContain("echo target");
+    });
+
+    it("treats agent name without hex suffix as plain agent name", async () => {
+      const date = new Date().toISOString().slice(0, 10);
+      const logFile = resolve(tmpDir, ".al", "logs", `my-agent-${date}.log`);
+      writeFileSync(logFile, makePinoLine({ msg: "bash", cmd: "echo hello" }) + "\n");
+
+      const output: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: any[]) => output.push(args.join(" "));
+      await execute("my-agent", { project: tmpDir, lines: "50" });
+      console.log = origLog;
+
+      expect(output.some((l) => l.includes("echo hello"))).toBe(true);
     });
   });
 
@@ -1353,13 +1368,14 @@ describe("logs command", () => {
       expect(callArg.path).toContain("/api/logs/scheduler");
     });
 
-    it("uses instance-specific path when instanceSuffix is set", async () => {
+    it("uses instance-specific path when full instance ID is passed as positional arg", async () => {
       mockGatewayFetch.mockResolvedValue({
         ok: true,
         json: async () => ({ entries: [], cursor: null, hasMore: false }),
       } as any);
 
-      await execute("dev", { project: tmpDir, lines: "50", instance: "abc12345" });
+      // Pass the full instance ID as the positional agent arg
+      await execute("dev-abc12345", { project: tmpDir, lines: "50" });
 
       const callArg = mockGatewayFetch.mock.calls[0][0];
       expect(callArg.path).toContain("/api/logs/agents/dev/abc12345");


### PR DESCRIPTION
Closes #492

## Changes

- ****: Added `parseInstanceId` helper that detects if the positional `agent` argument is a full instance ID (ending in 8 hex chars). When detected, the agent name and instance suffix are extracted automatically.
- ****: Removed the `-i, --instance <N>` option and updated the argument description to mention instance IDs.
- ****: Rewrote instance filtering tests to use positional instance ID (instead of `--instance` flag). Added test for plain agent name without hex suffix.
- ****: Updated gateway instance test to use positional instance ID.

## Usage

```
# Before (--instance flag, now removed)
al logs dev --instance abc12345

# After (full instance ID as positional arg)
al logs dev-abc12345
```

## Breaking Change

The `-i, --instance` flag has been removed. Pass the full instance ID as the positional argument instead.