### PR TITLE
perf: optimize activity page with SQL-level pagination

### DIFF
--- a/.changeset/activity-sql-pagination.md
+++ b/.changeset/activity-sql-pagination.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": minor
+---
+
+Optimize `/api/stats/activity` endpoint with SQL-level pagination instead of fetching all rows into memory. Adds `queryActivityRows` and `countActivityRows` methods to `StatsStore`, pushes filtering and pagination down to SQLite, and adds an index on `runs.result`. Running/pending items still appear at the top of page 1 only. This eliminates the O(n) full-table scan on every activity page load.

--- a/packages/action-llama/drizzle/0002_add_result_index.sql
+++ b/packages/action-llama/drizzle/0002_add_result_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS `idx_runs_result` ON `runs` (`result`, `started_at`);

--- a/packages/action-llama/drizzle/meta/_journal.json
+++ b/packages/action-llama/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1774906200000,
       "tag": "0001_add_trigger_context",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1775061000000,
+      "tag": "0002_add_result_index",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/action-llama/src/control/routes/stats.ts
+++ b/packages/action-llama/src/control/routes/stats.ts
@@ -143,122 +143,186 @@ export function registerStatsRoutes(
   app.get("/api/stats/activity", (c) => {
     const limit = Math.min(100, Math.max(1, parseInt(c.req.query("limit") || "50", 10) || 50));
     const offset = Math.max(0, parseInt(c.req.query("offset") || "0", 10) || 0);
-    const since = parseInt(c.req.query("since") || "0", 10) || 0;
     const agentFilter = c.req.query("agent") || undefined;
     const triggerTypeFilter = c.req.query("triggerType") || undefined;
     const statusFilter = c.req.query("status") || "all";
 
-    // Base rows from runs table (include dead letters)
-    const rows: any[] = statsStore
-      ? statsStore.queryTriggerHistory({
-          since,
-          limit: 10000, // fetch all then filter/paginate after merge
-          offset: 0,
-          includeDeadLetters: true,
-          agentName: agentFilter,
-          triggerType: triggerTypeFilter,
-        })
-      : [];
+    // Parse status filter into mem statuses (running/pending) and DB statuses (completed/error/etc)
+    const MEM_STATUSES = new Set(["running", "pending"]);
+    const DB_STATUSES = new Set(["completed", "error", "rerun", "dead-letter"]);
 
-    // Merge running instances (avoid duplicates)
-    let allRows: any[] = [...rows];
-    if (statusTracker) {
-      const runningInRows = new Set(rows.map((r: any) => r.instanceId).filter(Boolean));
-      const running = statusTracker
-        .getInstances()
-        .filter((inst) => {
-          if (inst.status !== "running") return false;
-          if (agentFilter && inst.agentName !== agentFilter) return false;
-          if (triggerTypeFilter) {
-            const sep = inst.trigger.indexOf(":");
-            const type = sep > -1 ? inst.trigger.slice(0, sep) : inst.trigger;
-            if (type !== triggerTypeFilter) return false;
-          }
-          return !runningInRows.has(inst.id);
-        })
-        .map((inst) => {
-          const sep = inst.trigger.indexOf(":");
-          return {
-            ts: new Date(inst.startedAt).getTime(),
-            triggerType: sep > -1 ? inst.trigger.slice(0, sep) : inst.trigger,
-            triggerSource: sep > -1 ? inst.trigger.slice(sep + 1).trim() : null,
-            agentName: inst.agentName,
-            instanceId: inst.id,
-            result: "running",
-            webhookReceiptId: null,
-            deadLetterReason: null,
-          };
-        });
-      allRows = [...running, ...allRows];
+    let requestedMemStatuses: string[] | undefined; // undefined = no filter on mem
+    let requestedDbStatuses: string[] | undefined;  // undefined = no filter on db
+
+    if (statusFilter && statusFilter !== "all") {
+      const requested = statusFilter.split(",").map((s: string) => s.trim()).filter(Boolean);
+      requestedMemStatuses = requested.filter((s) => MEM_STATUSES.has(s));
+      requestedDbStatuses = requested.filter((s) => DB_STATUSES.has(s));
     }
 
-    // Merge pending queue items
-    if (controlDeps?.workQueue) {
-      const agents = statusTracker ? statusTracker.getAllAgents() : [];
-      const agentsToCheck = agentFilter
-        ? agents.filter((a) => a.name === agentFilter)
-        : agents;
-      for (const agent of agentsToCheck) {
-        const items = controlDeps.workQueue!.peek(agent.name);
-        for (const item of items) {
-          const ctx = item.context as any;
-          let triggerType = "manual";
-          let triggerSource: string | null = null;
-          let eventSummary: string | null = null;
-          if (ctx && typeof ctx === "object") {
-            if (ctx.type === "webhook") {
-              triggerType = "webhook";
-              triggerSource = ctx.context?.source ?? null;
-              const wctx = ctx.context;
-              if (wctx?.event) {
-                const parts = [wctx.event];
-                if (wctx.action) parts.push(wctx.action);
-                eventSummary = parts.join(" ");
-              }
-            } else if (ctx.type === "schedule") {
-              triggerType = "schedule";
-            } else if (ctx.type === "agent-trigger" || ctx.type === "agent") {
-              triggerType = "agent";
-              triggerSource = ctx.sourceAgent ?? null;
-            } else if (ctx.type === "manual") {
-              triggerType = "manual";
-            } else if (ctx.type) {
-              triggerType = ctx.type;
+    const includeRunning = requestedMemStatuses === undefined || requestedMemStatuses.includes("running");
+    const includePending = requestedMemStatuses === undefined || requestedMemStatuses.includes("pending");
+    const includeDb = requestedDbStatuses === undefined || requestedDbStatuses.length > 0;
+    const includeDeadLetters = requestedDbStatuses === undefined || requestedDbStatuses.includes("dead-letter");
+
+    // Build in-memory rows (running + pending) applying filters
+    const buildMemRows = (): any[] => {
+      const memRows: any[] = [];
+
+      // Collect running instances
+      if (includeRunning && statusTracker) {
+        const running = statusTracker
+          .getInstances()
+          .filter((inst) => {
+            if (inst.status !== "running") return false;
+            if (agentFilter && inst.agentName !== agentFilter) return false;
+            if (triggerTypeFilter) {
+              const sep = inst.trigger.indexOf(":");
+              const type = sep > -1 ? inst.trigger.slice(0, sep) : inst.trigger;
+              if (type !== triggerTypeFilter) return false;
             }
-          }
-          if (triggerTypeFilter && triggerType !== triggerTypeFilter) continue;
-          allRows.push({
-            ts: item.receivedAt.getTime(),
-            triggerType,
-            triggerSource,
-            eventSummary,
-            agentName: agent.name,
-            instanceId: null,
-            result: "pending",
-            webhookReceiptId: null,
-            deadLetterReason: null,
+            return true;
+          })
+          .map((inst) => {
+            const sep = inst.trigger.indexOf(":");
+            return {
+              ts: new Date(inst.startedAt).getTime(),
+              triggerType: sep > -1 ? inst.trigger.slice(0, sep) : inst.trigger,
+              triggerSource: sep > -1 ? inst.trigger.slice(sep + 1).trim() : null,
+              agentName: inst.agentName,
+              instanceId: inst.id,
+              result: "running",
+              webhookReceiptId: null,
+              deadLetterReason: null,
+            };
           });
+        memRows.push(...running);
+      }
+
+      // Collect pending queue items
+      if (includePending && controlDeps?.workQueue) {
+        const agents = statusTracker ? statusTracker.getAllAgents() : [];
+        const agentsToCheck = agentFilter
+          ? agents.filter((a) => a.name === agentFilter)
+          : agents;
+        for (const agent of agentsToCheck) {
+          const items = controlDeps.workQueue!.peek(agent.name);
+          for (const item of items) {
+            const ctx = item.context as any;
+            let triggerType = "manual";
+            let triggerSource: string | null = null;
+            let eventSummary: string | null = null;
+            if (ctx && typeof ctx === "object") {
+              if (ctx.type === "webhook") {
+                triggerType = "webhook";
+                triggerSource = ctx.context?.source ?? null;
+                const wctx = ctx.context;
+                if (wctx?.event) {
+                  const parts = [wctx.event];
+                  if (wctx.action) parts.push(wctx.action);
+                  eventSummary = parts.join(" ");
+                }
+              } else if (ctx.type === "schedule") {
+                triggerType = "schedule";
+              } else if (ctx.type === "agent-trigger" || ctx.type === "agent") {
+                triggerType = "agent";
+                triggerSource = ctx.sourceAgent ?? null;
+              } else if (ctx.type === "manual") {
+                triggerType = "manual";
+              } else if (ctx.type) {
+                triggerType = ctx.type;
+              }
+            }
+            if (triggerTypeFilter && triggerType !== triggerTypeFilter) continue;
+            memRows.push({
+              ts: item.receivedAt.getTime(),
+              triggerType,
+              triggerSource,
+              eventSummary,
+              agentName: agent.name,
+              instanceId: null,
+              result: "pending",
+              webhookReceiptId: null,
+              deadLetterReason: null,
+            });
+          }
         }
       }
-    }
 
-    // Sort rows by status group (pending → running → rest), then by ts descending within each group
-    const statusPriority: Record<string, number> = { pending: 0, running: 1 };
-    allRows.sort((a, b) => {
-      const pa = statusPriority[a.result] ?? 2;
-      const pb = statusPriority[b.result] ?? 2;
-      if (pa !== pb) return pa - pb;
-      return b.ts - a.ts;
-    });
+      // Sort: pending first, then running, then by ts descending within each group
+      const statusPriority: Record<string, number> = { pending: 0, running: 1 };
+      memRows.sort((a, b) => {
+        const pa = statusPriority[a.result] ?? 2;
+        const pb = statusPriority[b.result] ?? 2;
+        if (pa !== pb) return pa - pb;
+        return b.ts - a.ts;
+      });
+
+      return memRows;
+    };
+
+    const memRows = buildMemRows();
+    const memCount = memRows.length;
+
+    let rows: any[];
+    let total: number;
+
+    if (!includeDb || !statsStore) {
+      // Only mem rows — no DB query needed
+      rows = memRows.slice(offset, offset + limit);
+      total = memCount;
+    } else {
+      // Determine which portion of mem rows to include on this page
+      const memSlice = memRows.slice(offset, offset + limit);
+      const memSliceLen = memSlice.length;
+
+      // DB pagination: adjust offset to account for mem rows that precede DB rows
+      const dbOffset = Math.max(0, offset - memCount);
+      const dbLimit = limit - memSliceLen;
+
+      let dbRows: any[] = [];
+      if (dbLimit > 0) {
+        dbRows = statsStore.queryActivityRows({
+          limit: dbLimit,
+          offset: dbOffset,
+          agentName: agentFilter,
+          triggerType: triggerTypeFilter,
+          dbStatuses: requestedDbStatuses,
+          includeDeadLetters,
+        });
+
+        // Dedup: remove DB rows that match a currently-running instance
+        // (a run may appear as "running" in tracker AND as "completed" in DB if it just finished)
+        const runningIds = new Set(
+          memRows
+            .filter((r) => r.result === "running")
+            .map((r) => r.instanceId)
+            .filter(Boolean)
+        );
+        if (runningIds.size > 0) {
+          dbRows = dbRows.filter((r) => !r.instanceId || !runningIds.has(r.instanceId));
+        }
+      }
+
+      const dbCount = statsStore.countActivityRows({
+        agentName: agentFilter,
+        triggerType: triggerTypeFilter,
+        dbStatuses: requestedDbStatuses,
+        includeDeadLetters,
+      });
+
+      rows = [...memSlice, ...dbRows];
+      total = memCount + dbCount;
+    }
 
     // Enrich webhook rows with provider name + event summary from receipts
     if (statsStore) {
-      const receiptIds = allRows
+      const receiptIds = rows
         .filter((r: any) => r.triggerType === "webhook" && r.webhookReceiptId)
         .map((r: any) => r.webhookReceiptId as string);
       if (receiptIds.length > 0) {
         const details = statsStore.getWebhookDetailsBatch(receiptIds);
-        for (const row of allRows) {
+        for (const row of rows) {
           if (row.webhookReceiptId && details[row.webhookReceiptId]) {
             const d = details[row.webhookReceiptId];
             row.triggerSource = d.source;
@@ -270,17 +334,7 @@ export function registerStatsRoutes(
       }
     }
 
-    // Apply status filter (supports comma-separated values, e.g. "pending,running,completed")
-    let filtered = allRows;
-    if (statusFilter && statusFilter !== "all") {
-      const statuses = new Set(statusFilter.split(",").map((s: string) => s.trim()));
-      filtered = allRows.filter((r) => statuses.has(r.result));
-    }
-
-    const total = filtered.length;
-    const paginated = filtered.slice(offset, offset + limit);
-
-    return c.json({ rows: paginated, total, limit, offset });
+    return c.json({ rows, total, limit, offset });
   });
 
   // Single webhook receipt by ID

--- a/packages/action-llama/src/db/schema.ts
+++ b/packages/action-llama/src/db/schema.ts
@@ -72,6 +72,7 @@ export const runsTable = sqliteTable(
   (t) => [
     index("idx_runs_agent").on(t.agentName, t.startedAt),
     index("idx_runs_started").on(t.startedAt),
+    index("idx_runs_result").on(t.result, t.startedAt),
   ]
 );
 

--- a/packages/action-llama/src/stats/store.ts
+++ b/packages/action-llama/src/stats/store.ts
@@ -407,6 +407,164 @@ export class StatsStore {
     `).all(since, limit, offset) as TriggerHistoryRow[];
   }
 
+  /**
+   * Query activity rows with SQL-level filtering and pagination.
+   * Used by the /api/stats/activity endpoint to avoid fetching all rows into memory.
+   *
+   * @param opts.limit       Maximum rows to return
+   * @param opts.offset      Row offset for pagination
+   * @param opts.agentName   Optional: filter by agent name (excludes dead-letters if set)
+   * @param opts.triggerType Optional: filter by trigger type
+   * @param opts.dbStatuses  Optional: if provided, only return rows with these result values.
+   *                         'dead-letter' is handled separately via includeDeadLetters.
+   *                         If the array is empty (after excluding 'dead-letter'), no runs rows are returned.
+   * @param opts.includeDeadLetters  Include dead-letter rows from webhook_receipts
+   */
+  queryActivityRows(opts: {
+    limit: number;
+    offset: number;
+    agentName?: string;
+    triggerType?: string;
+    dbStatuses?: string[];
+    includeDeadLetters: boolean;
+  }): TriggerHistoryRow[] {
+    const { limit, offset, agentName, triggerType, dbStatuses, includeDeadLetters } = opts;
+    const client = (this.db as any).$client;
+
+    // Determine which statuses to filter from runs table
+    const runsStatuses = dbStatuses
+      ? dbStatuses.filter((s) => s !== "dead-letter")
+      : undefined;
+
+    // Should we query runs?
+    const queryRuns = runsStatuses === undefined || runsStatuses.length > 0;
+
+    // Should we UNION dead-letters?
+    // Dead-letters are only webhooks and have no agentName, so skip if agentName filter is set
+    // Skip if triggerType filter is set to a non-webhook type
+    const wantDeadLetters =
+      includeDeadLetters &&
+      (dbStatuses === undefined || dbStatuses.includes("dead-letter")) &&
+      !agentName &&
+      (triggerType === undefined || triggerType === "webhook");
+
+    if (!queryRuns && !wantDeadLetters) {
+      return [];
+    }
+
+    // Build the runs sub-query
+    const runsWhere: string[] = [];
+    const runsParams: unknown[] = [];
+    if (agentName) {
+      runsWhere.push("agent_name = ?");
+      runsParams.push(agentName);
+    }
+    if (triggerType) {
+      runsWhere.push("trigger_type = ?");
+      runsParams.push(triggerType);
+    }
+    if (runsStatuses !== undefined && runsStatuses.length > 0) {
+      runsWhere.push(`result IN (${runsStatuses.map(() => "?").join(",")})`);
+      runsParams.push(...runsStatuses);
+    }
+
+    const runsWhereClause = runsWhere.length > 0 ? `WHERE ${runsWhere.join(" AND ")}` : "";
+    const runsSelect = `
+      SELECT started_at AS ts, instance_id AS instanceId, agent_name AS agentName,
+             trigger_type AS triggerType, trigger_source AS triggerSource,
+             result, webhook_receipt_id AS webhookReceiptId,
+             NULL AS deadLetterReason
+      FROM runs ${runsWhereClause}
+    `;
+
+    const dlSelect = `
+      SELECT timestamp AS ts, NULL AS instanceId, NULL AS agentName,
+             'webhook' AS triggerType, source AS triggerSource,
+             'dead-letter' AS result, id AS webhookReceiptId,
+             dead_letter_reason AS deadLetterReason
+      FROM webhook_receipts WHERE status = 'dead-letter'
+    `;
+
+    let sql: string;
+    const params: unknown[] = [...runsParams];
+
+    if (queryRuns && wantDeadLetters) {
+      sql = `${runsSelect} UNION ALL ${dlSelect} ORDER BY ts DESC LIMIT ? OFFSET ?`;
+    } else if (queryRuns) {
+      sql = `${runsSelect} ORDER BY ts DESC LIMIT ? OFFSET ?`;
+    } else {
+      // wantDeadLetters only
+      sql = `${dlSelect} ORDER BY ts DESC LIMIT ? OFFSET ?`;
+    }
+
+    params.push(limit, offset);
+    return client.prepare(sql).all(...params) as TriggerHistoryRow[];
+  }
+
+  /**
+   * Count activity rows with SQL-level filtering.
+   * Mirrors queryActivityRows but returns only a count.
+   */
+  countActivityRows(opts: {
+    agentName?: string;
+    triggerType?: string;
+    dbStatuses?: string[];
+    includeDeadLetters: boolean;
+  }): number {
+    const { agentName, triggerType, dbStatuses, includeDeadLetters } = opts;
+    const client = (this.db as any).$client;
+
+    const runsStatuses = dbStatuses
+      ? dbStatuses.filter((s) => s !== "dead-letter")
+      : undefined;
+
+    const queryRuns = runsStatuses === undefined || runsStatuses.length > 0;
+    const wantDeadLetters =
+      includeDeadLetters &&
+      (dbStatuses === undefined || dbStatuses.includes("dead-letter")) &&
+      !agentName &&
+      (triggerType === undefined || triggerType === "webhook");
+
+    if (!queryRuns && !wantDeadLetters) {
+      return 0;
+    }
+
+    const runsWhere: string[] = [];
+    const runsParams: unknown[] = [];
+    if (agentName) {
+      runsWhere.push("agent_name = ?");
+      runsParams.push(agentName);
+    }
+    if (triggerType) {
+      runsWhere.push("trigger_type = ?");
+      runsParams.push(triggerType);
+    }
+    if (runsStatuses !== undefined && runsStatuses.length > 0) {
+      runsWhere.push(`result IN (${runsStatuses.map(() => "?").join(",")})`);
+      runsParams.push(...runsStatuses);
+    }
+
+    const runsWhereClause = runsWhere.length > 0 ? `WHERE ${runsWhere.join(" AND ")}` : "";
+
+    if (queryRuns && wantDeadLetters) {
+      const row = client.prepare(
+        `SELECT (SELECT COUNT(*) FROM runs ${runsWhereClause}) + (SELECT COUNT(*) FROM webhook_receipts WHERE status = 'dead-letter') AS count`
+      ).get(...runsParams) as any;
+      return row?.count ?? 0;
+    }
+    if (queryRuns) {
+      const row = client.prepare(
+        `SELECT COUNT(*) AS count FROM runs ${runsWhereClause}`
+      ).get(...runsParams) as any;
+      return row?.count ?? 0;
+    }
+    // wantDeadLetters only
+    const row = client.prepare(
+      `SELECT COUNT(*) AS count FROM webhook_receipts WHERE status = 'dead-letter'`
+    ).get() as any;
+    return row?.count ?? 0;
+  }
+
   countTriggerHistory(since: number, includeDeadLetters: boolean, agentName?: string, triggerType?: string): number {
     const client = (this.db as any).$client;
     if (agentName && triggerType) {

--- a/packages/action-llama/test/control/routes/stats.test.ts
+++ b/packages/action-llama/test/control/routes/stats.test.ts
@@ -12,6 +12,8 @@ function mockStatsStore() {
     getWebhookDetailsBatch: vi.fn().mockReturnValue({}),
     queryTriggerHistory: vi.fn().mockReturnValue([]),
     countTriggerHistory: vi.fn().mockReturnValue(0),
+    queryActivityRows: vi.fn().mockReturnValue([]),
+    countActivityRows: vi.fn().mockReturnValue(0),
   } as any;
 }
 
@@ -517,8 +519,9 @@ describe("stats routes", () => {
     it("returns rows from the stats store including dead letters", async () => {
       const stats = mockStatsStore();
       const completedRow = { ts: 1000, triggerType: "schedule", agentName: "reporter", instanceId: "i1", result: "completed", webhookReceiptId: null, deadLetterReason: null };
-      const deadLetterRow = { ts: 500, triggerType: "webhook", agentName: "reporter", instanceId: null, result: "dead-letter", webhookReceiptId: "r1", deadLetterReason: "no_match" };
-      stats.queryTriggerHistory.mockReturnValue([completedRow, deadLetterRow]);
+      const deadLetterRow = { ts: 500, triggerType: "webhook", agentName: null, instanceId: null, result: "dead-letter", webhookReceiptId: "r1", deadLetterReason: "no_match" };
+      stats.queryActivityRows.mockReturnValue([completedRow, deadLetterRow]);
+      stats.countActivityRows.mockReturnValue(2);
       const app = createApp(stats);
 
       const res = await app.request("/api/stats/activity");
@@ -526,17 +529,18 @@ describe("stats routes", () => {
       const data = await res.json();
       expect(data.rows).toHaveLength(2);
       expect(data.total).toBe(2);
-      // Should always pass includeDeadLetters: true
-      expect(stats.queryTriggerHistory).toHaveBeenCalledWith(
+      // Should always pass includeDeadLetters: true (no status filter)
+      expect(stats.queryActivityRows).toHaveBeenCalledWith(
         expect.objectContaining({ includeDeadLetters: true })
       );
     });
 
     it("merges running instances from statusTracker", async () => {
       const stats = mockStatsStore();
-      stats.queryTriggerHistory.mockReturnValue([
+      stats.queryActivityRows.mockReturnValue([
         { ts: 500, triggerType: "schedule", agentName: "reporter", instanceId: "i1", result: "completed" },
       ]);
+      stats.countActivityRows.mockReturnValue(1);
 
       const tracker = mockStatusTracker([
         { id: "inst-running", agentName: "reporter", status: "running", startedAt: new Date(2000).toISOString(), trigger: "webhook:github" },
@@ -556,7 +560,7 @@ describe("stats routes", () => {
 
     it("merges pending queue items from controlDeps.workQueue.peek", async () => {
       const stats = mockStatsStore();
-      stats.queryTriggerHistory.mockReturnValue([]);
+      stats.queryActivityRows.mockReturnValue([]);
 
       const tracker = mockStatusTracker([], [
         { name: "reporter", queuedWebhooks: 1 },
@@ -586,7 +590,7 @@ describe("stats routes", () => {
 
     it("builds eventSummary from webhook context event and action when both are present", async () => {
       const stats = mockStatsStore();
-      stats.queryTriggerHistory.mockReturnValue([]);
+      stats.queryActivityRows.mockReturnValue([]);
 
       const tracker = mockStatusTracker([], [{ name: "reporter", queuedWebhooks: 1 }]);
       const controlDeps = {
@@ -617,9 +621,7 @@ describe("stats routes", () => {
 
     it("filters by status=pending returns only pending rows", async () => {
       const stats = mockStatsStore();
-      stats.queryTriggerHistory.mockReturnValue([
-        { ts: 500, triggerType: "schedule", agentName: "reporter", instanceId: "i1", result: "completed" },
-      ]);
+      // queryActivityRows should NOT be called when status=pending (no DB statuses requested)
 
       const tracker = mockStatusTracker([], [{ name: "reporter", queuedWebhooks: 1 }]);
       const controlDeps = {
@@ -636,14 +638,17 @@ describe("stats routes", () => {
       const data = await res.json();
 
       expect(data.rows.every((r: any) => r.result === "pending")).toBe(true);
+      // DB should NOT be queried for pending-only filter
+      expect(stats.queryActivityRows).not.toHaveBeenCalled();
     });
 
     it("filters by status=dead-letter returns only dead letters", async () => {
       const stats = mockStatsStore();
-      stats.queryTriggerHistory.mockReturnValue([
-        { ts: 1000, triggerType: "schedule", agentName: "reporter", instanceId: "i1", result: "completed" },
-        { ts: 500, triggerType: "webhook", agentName: "reporter", instanceId: null, result: "dead-letter", webhookReceiptId: "r1", deadLetterReason: "no_match" },
+      // With status=dead-letter, queryActivityRows is called with dbStatuses=['dead-letter']
+      stats.queryActivityRows.mockReturnValue([
+        { ts: 500, triggerType: "webhook", agentName: null, instanceId: null, result: "dead-letter", webhookReceiptId: "r1", deadLetterReason: "no_match" },
       ]);
+      stats.countActivityRows.mockReturnValue(1);
 
       const app = createApp(stats);
 
@@ -652,28 +657,33 @@ describe("stats routes", () => {
 
       expect(data.rows).toHaveLength(1);
       expect(data.rows[0].result).toBe("dead-letter");
+      expect(stats.queryActivityRows).toHaveBeenCalledWith(
+        expect.objectContaining({ dbStatuses: ["dead-letter"], includeDeadLetters: true })
+      );
     });
 
     it("filters by agent parameter", async () => {
       const stats = mockStatsStore();
-      stats.queryTriggerHistory.mockReturnValue([
+      stats.queryActivityRows.mockReturnValue([
         { ts: 1000, triggerType: "schedule", agentName: "reporter", instanceId: "i1", result: "completed" },
       ]);
+      stats.countActivityRows.mockReturnValue(1);
 
       const app = createApp(stats);
 
       await app.request("/api/stats/activity?agent=reporter");
-      expect(stats.queryTriggerHistory).toHaveBeenCalledWith(
+      expect(stats.queryActivityRows).toHaveBeenCalledWith(
         expect.objectContaining({ agentName: "reporter" })
       );
     });
 
     it("sorts rows by status group (pending → running → rest) then ts descending", async () => {
       const stats = mockStatsStore();
-      stats.queryTriggerHistory.mockReturnValue([
+      stats.queryActivityRows.mockReturnValue([
         { ts: 1000, triggerType: "schedule", agentName: "reporter", instanceId: "i1", result: "completed" },
         { ts: 300, triggerType: "webhook", agentName: "reporter", instanceId: "i2", result: "error" },
       ]);
+      stats.countActivityRows.mockReturnValue(2);
 
       const tracker = mockStatusTracker([
         { id: "r1", agentName: "reporter", status: "running", startedAt: new Date(2000).toISOString(), trigger: "manual" },
@@ -694,10 +704,11 @@ describe("stats routes", () => {
 
     it("sorts pending rows before running, and running before completed/error", async () => {
       const stats = mockStatsStore();
-      stats.queryTriggerHistory.mockReturnValue([
+      stats.queryActivityRows.mockReturnValue([
         { ts: 5000, triggerType: "schedule", agentName: "reporter", instanceId: "i-completed", result: "completed" },
         { ts: 1000, triggerType: "webhook", agentName: "reporter", instanceId: "i-error", result: "error" },
       ]);
+      stats.countActivityRows.mockReturnValue(2);
 
       const tracker = mockStatusTracker([
         { id: "i-running", agentName: "reporter", status: "running", startedAt: new Date(3000).toISOString(), trigger: "manual" },
@@ -725,11 +736,12 @@ describe("stats routes", () => {
 
     it("paginates results with limit and offset", async () => {
       const stats = mockStatsStore();
-      stats.queryTriggerHistory.mockReturnValue([
-        { ts: 3000, result: "completed", triggerType: "schedule", agentName: "a", instanceId: "i1" },
+      // With offset=1, limit=2, no mem rows: DB is queried with offset=1, limit=2
+      stats.queryActivityRows.mockReturnValue([
         { ts: 2000, result: "completed", triggerType: "schedule", agentName: "a", instanceId: "i2" },
         { ts: 1000, result: "completed", triggerType: "schedule", agentName: "a", instanceId: "i3" },
       ]);
+      stats.countActivityRows.mockReturnValue(3);
 
       const app = createApp(stats);
 
@@ -738,12 +750,16 @@ describe("stats routes", () => {
 
       expect(data.total).toBe(3);
       expect(data.rows).toHaveLength(2);
-      expect(data.rows[0].instanceId).toBe("i2"); // second row after sort
+      expect(data.rows[0].instanceId).toBe("i2");
+      // Verify DB was called with correct SQL-level pagination
+      expect(stats.queryActivityRows).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 2, offset: 1 })
+      );
     });
 
     it("filters out non-running instances from statusTracker in activity endpoint", async () => {
       const stats = mockStatsStore();
-      stats.queryTriggerHistory.mockReturnValue([]);
+      stats.queryActivityRows.mockReturnValue([]);
 
       // Provide one running and one non-running instance
       const tracker = mockStatusTracker([
@@ -763,7 +779,7 @@ describe("stats routes", () => {
 
     it("filters workQueue items by agent when agent param is provided", async () => {
       const stats = mockStatsStore();
-      stats.queryTriggerHistory.mockReturnValue([]);
+      stats.queryActivityRows.mockReturnValue([]);
 
       const tracker = mockStatusTracker([], [
         { name: "reporter" },
@@ -958,7 +974,7 @@ describe("stats routes", () => {
   describe("GET /api/stats/activity — filter coverage for uncovered paths", () => {
     it("filters running instances by agentName in activity endpoint (L171)", async () => {
       const stats = mockStatsStore();
-      stats.queryTriggerHistory.mockReturnValue([]);
+      stats.queryActivityRows.mockReturnValue([]);
 
       // Two instances with different agentNames; filter for "reporter" should exclude "other"
       const tracker = mockStatusTracker([
@@ -977,7 +993,7 @@ describe("stats routes", () => {
 
     it("filters running instances by triggerType in activity endpoint (L172-175)", async () => {
       const stats = mockStatsStore();
-      stats.queryTriggerHistory.mockReturnValue([]);
+      stats.queryActivityRows.mockReturnValue([]);
 
       // Two instances with different trigger types
       const tracker = mockStatusTracker([
@@ -997,7 +1013,7 @@ describe("stats routes", () => {
     it("enriches webhook rows with triggerSource and eventSummary from receipt details", async () => {
       const stats = mockStatsStore();
       // Return a webhook row with a webhookReceiptId
-      stats.queryTriggerHistory.mockReturnValue([
+      stats.queryActivityRows.mockReturnValue([
         {
           ts: 1000,
           triggerType: "webhook",
@@ -1009,6 +1025,7 @@ describe("stats routes", () => {
           deadLetterReason: null,
         },
       ]);
+      stats.countActivityRows.mockReturnValue(1);
       // Return details for that receipt with source + eventSummary
       stats.getWebhookDetailsBatch.mockReturnValue({
         "receipt-1": { source: "github", eventSummary: "issues opened" },
@@ -1029,7 +1046,7 @@ describe("stats routes", () => {
 
     it("sets triggerSource but not eventSummary when eventSummary equals source", async () => {
       const stats = mockStatsStore();
-      stats.queryTriggerHistory.mockReturnValue([
+      stats.queryActivityRows.mockReturnValue([
         {
           ts: 1000,
           triggerType: "webhook",
@@ -1041,6 +1058,7 @@ describe("stats routes", () => {
           deadLetterReason: null,
         },
       ]);
+      stats.countActivityRows.mockReturnValue(1);
       // eventSummary equals source — should set triggerSource but NOT set eventSummary
       stats.getWebhookDetailsBatch.mockReturnValue({
         "receipt-2": { source: "github", eventSummary: "github" },


### PR DESCRIPTION
Closes #493

## Summary

The `/api/stats/activity` endpoint was fetching up to 10,000 rows from SQLite into memory on every page load, then filtering and paginating in JavaScript. This caused slow page loads as activity history grew.

## Changes

### Backend performance fix
- **New `queryActivityRows()` and `countActivityRows()` methods** in `StatsStore` — push filtering (agent, triggerType, status) and pagination (LIMIT/OFFSET) down to SQL
- **Rewrote `/api/stats/activity` handler** to use SQL-level pagination instead of `slice()` on a 10K-row array
- Running/pending in-memory items still appear at the top of **page 1 only**; subsequent pages come entirely from the DB with correct offset adjustment
- Webhook row enrichment (`getWebhookDetailsBatch`) now runs on at most `limit` rows (50) instead of 10K rows
- Deduplication of running instances against DB rows still applied correctly

### Database index
- Added `idx_runs_result` index on `(result, started_at)` in the `runs` table
- New migration: `0002_add_result_index.sql`

### Tests
- Added `queryActivityRows` and `countActivityRows` to `mockStatsStore()`
- Updated all activity endpoint tests to use the new methods
- Added assertions verifying SQL pagination params and that DB is not queried for memory-only status filters (e.g., `status=pending`)