### PR TITLE
Make nice discrete breadcrumbs on top of page title

### DIFF
--- a/.changeset/breadcrumb-navigation.md
+++ b/.changeset/breadcrumb-navigation.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/frontend": patch
+---
+
+Replace back-arrow navigation with clickable breadcrumbs on agent and instance pages

--- a/packages/frontend/src/components/AgentLayout.tsx
+++ b/packages/frontend/src/components/AgentLayout.tsx
@@ -57,27 +57,16 @@ export function AgentLayout() {
   return (
     <div className="space-y-4">
       {/* Header row */}
+      <div className="space-y-1">
+        <nav className="flex items-center gap-1 text-xs text-slate-500 dark:text-slate-400">
+          <Link to="/dashboard" className="hover:text-slate-700 dark:hover:text-slate-300 transition-colors">
+            Agents
+          </Link>
+          <span>›</span>
+          <span className="text-slate-900 dark:text-white font-medium">{name}</span>
+        </nav>
       <div className="flex items-center justify-between flex-wrap gap-3">
         <div className="flex items-center gap-3">
-          <Link
-            to="/dashboard"
-            className="text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
-            aria-label="Back to dashboard"
-          >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15 19l-7-7 7-7"
-              />
-            </svg>
-          </Link>
           <h1 className="text-xl font-bold text-slate-900 dark:text-white">
             {name}
           </h1>
@@ -175,6 +164,7 @@ export function AgentLayout() {
             )}
           </button>
         </div>
+      </div>
       </div>
 
       {/* Tab bar */}

--- a/packages/frontend/src/components/InstanceLayout.tsx
+++ b/packages/frontend/src/components/InstanceLayout.tsx
@@ -72,27 +72,20 @@ export function InstanceLayout() {
     <InstanceContext.Provider value={contextValue}>
       <div className="space-y-4">
         {/* Header row */}
+        <div className="space-y-1">
+        <nav className="flex items-center gap-1 text-xs text-slate-500 dark:text-slate-400">
+          <Link to="/dashboard" className="hover:text-slate-700 dark:hover:text-slate-300 transition-colors">
+            Agents
+          </Link>
+          <span>›</span>
+          <Link to={`/dashboard/agents/${encodeURIComponent(name)}`} className="hover:text-slate-700 dark:hover:text-slate-300 transition-colors">
+            {name}
+          </Link>
+          <span>›</span>
+          <span className="text-slate-900 dark:text-white font-medium font-mono">{id}</span>
+        </nav>
         <div className="flex items-center justify-between flex-wrap gap-3">
           <div className="flex items-center gap-3">
-            <Link
-              to={`/dashboard/agents/${encodeURIComponent(name)}`}
-              className="text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
-              aria-label="Back to agent page"
-            >
-              <svg
-                className="w-5 h-5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15 19l-7-7 7-7"
-                />
-              </svg>
-            </Link>
             <div>
               <div className="flex items-center gap-1.5">
                 <h1 className="text-xl font-bold text-slate-900 dark:text-white font-mono break-all">
@@ -138,9 +131,6 @@ export function InstanceLayout() {
                   )}
                 </button>
               </div>
-              <div className="text-xs text-slate-500 dark:text-slate-400">
-                {name}
-              </div>
             </div>
             {run && <ResultBadge result={run.result} />}
             {isRunning && !run && (
@@ -183,6 +173,7 @@ export function InstanceLayout() {
               )}
             </button>
           )}
+        </div>
         </div>
 
         {/* Tab bar */}


### PR DESCRIPTION
Closes #497

## Changes

Replaced the back-arrow (`<`) navigation in `AgentLayout` and `InstanceLayout` with clickable breadcrumbs styled consistently with the existing small text.

### AgentLayout
- Adds breadcrumb nav: **Agents › agentName** above the page title
- `Agents` links to `/dashboard`
- Current page (agentName) shown in non-linked, slightly bolder text
- Removed the back-arrow SVG link

### InstanceLayout
- Adds breadcrumb nav: **Agents › agentName › instanceId** above the page title
- `Agents` links to `/dashboard`
- `agentName` links to the agent detail page
- Current page (instanceId) shown in non-linked monospace text
- Removed the back-arrow SVG link
- Removed the redundant agent-name subtitle below the instance ID (now shown in breadcrumbs)

### Styling
- Uses `text-xs text-slate-500 dark:text-slate-400` matching the existing instance page subtitle style
- Separator uses `›` for a clean look
- Links have hover transitions for interactivity feedback