### PR TITLE
Fix: Tighten label/value table layout on trigger and webhook pages

### DIFF
--- a/.changeset/tighten-table-layout.md
+++ b/.changeset/tighten-table-layout.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/frontend": patch
+---
+
+Tighten label/value tables on InstanceTriggerPage, TriggerDetailPage, and WebhookReceiptPage by replacing full-width flex justify-between rows with a two-column grid layout, so labels and values sit close together and are easier to read.

--- a/packages/frontend/src/pages/InstanceTriggerPage.tsx
+++ b/packages/frontend/src/pages/InstanceTriggerPage.tsx
@@ -66,15 +66,15 @@ export function InstanceTriggerPage() {
               Overview
             </h2>
           </div>
-          <div className="divide-y divide-slate-100 dark:divide-slate-800/50">
-            <div className="px-4 py-3 flex items-center justify-between">
+          <div className="divide-y divide-slate-100 dark:divide-slate-800/50 max-w-2xl">
+            <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
               <span className="text-xs text-slate-500 dark:text-slate-400">
                 Trigger Type
               </span>
               <TriggerTypeBadge type={run.trigger_type} />
             </div>
             {run.trigger_source && (
-              <div className="px-4 py-3 flex items-center justify-between">
+              <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
                 <span className="text-xs text-slate-500 dark:text-slate-400">
                   Source
                 </span>
@@ -98,14 +98,14 @@ export function InstanceTriggerPage() {
             Overview
           </h2>
         </div>
-        <div className="divide-y divide-slate-100 dark:divide-slate-800/50">
-          <div className="px-4 py-3 flex items-center justify-between">
+        <div className="divide-y divide-slate-100 dark:divide-slate-800/50 max-w-2xl">
+          <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
             <span className="text-xs text-slate-500 dark:text-slate-400">
               Trigger Type
             </span>
             <TriggerTypeBadge type={trigger.triggerType} />
           </div>
-          <div className="px-4 py-3 flex items-center justify-between">
+          <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
             <span className="text-xs text-slate-500 dark:text-slate-400">
               Agent
             </span>
@@ -121,7 +121,7 @@ export function InstanceTriggerPage() {
               </span>
             </Link>
           </div>
-          <div className="px-4 py-3 flex items-center justify-between">
+          <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
             <span className="text-xs text-slate-500 dark:text-slate-400">
               Instance
             </span>
@@ -129,7 +129,7 @@ export function InstanceTriggerPage() {
               {trigger.instanceId}
             </span>
           </div>
-          <div className="px-4 py-3 flex items-center justify-between">
+          <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
             <span className="text-xs text-slate-500 dark:text-slate-400">
               Time
             </span>
@@ -138,7 +138,7 @@ export function InstanceTriggerPage() {
             </span>
           </div>
           {trigger.triggerSource && (
-            <div className="px-4 py-3 flex items-center justify-between">
+            <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
               <span className="text-xs text-slate-500 dark:text-slate-400">
                 Source
               </span>
@@ -158,8 +158,8 @@ export function InstanceTriggerPage() {
               Webhook Details
             </h2>
           </div>
-          <div className="divide-y divide-slate-100 dark:divide-slate-800/50">
-            <div className="px-4 py-3 flex items-center justify-between">
+          <div className="divide-y divide-slate-100 dark:divide-slate-800/50 max-w-2xl">
+            <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
               <span className="text-xs text-slate-500 dark:text-slate-400">
                 Receipt ID
               </span>
@@ -170,7 +170,7 @@ export function InstanceTriggerPage() {
                 {shortId(trigger.webhook.receiptId)}
               </Link>
             </div>
-            <div className="px-4 py-3 flex items-center justify-between">
+            <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
               <span className="text-xs text-slate-500 dark:text-slate-400">
                 Source
               </span>
@@ -179,7 +179,7 @@ export function InstanceTriggerPage() {
               </span>
             </div>
             {trigger.webhook.eventSummary && (
-              <div className="px-4 py-3 flex items-center justify-between">
+              <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
                 <span className="text-xs text-slate-500 dark:text-slate-400">
                   Event
                 </span>
@@ -189,7 +189,7 @@ export function InstanceTriggerPage() {
               </div>
             )}
             {trigger.webhook.deliveryId && (
-              <div className="px-4 py-3 flex items-center justify-between">
+              <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
                 <span className="text-xs text-slate-500 dark:text-slate-400">
                   Delivery ID
                 </span>
@@ -198,7 +198,7 @@ export function InstanceTriggerPage() {
                 </span>
               </div>
             )}
-            <div className="px-4 py-3 flex items-center justify-between">
+            <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
               <span className="text-xs text-slate-500 dark:text-slate-400">
                 Status
               </span>
@@ -210,7 +210,7 @@ export function InstanceTriggerPage() {
                 }
               />
             </div>
-            <div className="px-4 py-3 flex items-center justify-between">
+            <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
               <span className="text-xs text-slate-500 dark:text-slate-400">
                 Matched Agents
               </span>
@@ -276,10 +276,10 @@ export function InstanceTriggerPage() {
               Agent Trigger Details
             </h2>
           </div>
-          <div className="divide-y divide-slate-100 dark:divide-slate-800/50">
+          <div className="divide-y divide-slate-100 dark:divide-slate-800/50 max-w-2xl">
             {trigger.callerAgent ? (
               <>
-                <div className="px-4 py-3 flex items-center justify-between">
+                <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
                   <span className="text-xs text-slate-500 dark:text-slate-400">
                     Called by
                   </span>
@@ -296,7 +296,7 @@ export function InstanceTriggerPage() {
                   </Link>
                 </div>
                 {trigger.callerInstance && (
-                  <div className="px-4 py-3 flex items-center justify-between">
+                  <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
                     <span className="text-xs text-slate-500 dark:text-slate-400">
                       Caller Instance
                     </span>
@@ -309,7 +309,7 @@ export function InstanceTriggerPage() {
                   </div>
                 )}
                 {trigger.callDepth !== undefined && (
-                  <div className="px-4 py-3 flex items-center justify-between">
+                  <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
                     <span className="text-xs text-slate-500 dark:text-slate-400">
                       Call Depth
                     </span>

--- a/packages/frontend/src/pages/TriggerDetailPage.tsx
+++ b/packages/frontend/src/pages/TriggerDetailPage.tsx
@@ -124,12 +124,12 @@ export function TriggerDetailPage() {
         <div className="px-4 py-2.5 border-b border-slate-200 dark:border-slate-800">
           <h2 className="text-sm font-medium text-slate-900 dark:text-white">Overview</h2>
         </div>
-        <div className="divide-y divide-slate-100 dark:divide-slate-800/50">
-          <div className="px-4 py-3 flex items-center justify-between">
+        <div className="divide-y divide-slate-100 dark:divide-slate-800/50 max-w-2xl">
+          <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
             <span className="text-xs text-slate-500 dark:text-slate-400">Trigger Type</span>
             <TriggerTypeBadge type={trigger.triggerType} />
           </div>
-          <div className="px-4 py-3 flex items-center justify-between">
+          <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
             <span className="text-xs text-slate-500 dark:text-slate-400">Agent</span>
             <Link
               to={`/dashboard/agents/${encodeURIComponent(trigger.agentName)}`}
@@ -140,7 +140,7 @@ export function TriggerDetailPage() {
               </span>
             </Link>
           </div>
-          <div className="px-4 py-3 flex items-center justify-between">
+          <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
             <span className="text-xs text-slate-500 dark:text-slate-400">Instance</span>
             <Link
               to={`/dashboard/agents/${encodeURIComponent(trigger.agentName)}/instances/${encodeURIComponent(trigger.instanceId)}`}
@@ -149,14 +149,14 @@ export function TriggerDetailPage() {
               {trigger.instanceId}
             </Link>
           </div>
-          <div className="px-4 py-3 flex items-center justify-between">
+          <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
             <span className="text-xs text-slate-500 dark:text-slate-400">Time</span>
             <span className="text-xs text-slate-700 dark:text-slate-300">
               {fmtDateTime(trigger.startedAt)}
             </span>
           </div>
           {trigger.triggerSource && (
-            <div className="px-4 py-3 flex items-center justify-between">
+            <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
               <span className="text-xs text-slate-500 dark:text-slate-400">Source</span>
               <span className="text-xs text-slate-700 dark:text-slate-300">{trigger.triggerSource}</span>
             </div>
@@ -170,8 +170,8 @@ export function TriggerDetailPage() {
           <div className="px-4 py-2.5 border-b border-slate-200 dark:border-slate-800">
             <h2 className="text-sm font-medium text-slate-900 dark:text-white">Webhook Details</h2>
           </div>
-          <div className="divide-y divide-slate-100 dark:divide-slate-800/50">
-            <div className="px-4 py-3 flex items-center justify-between">
+          <div className="divide-y divide-slate-100 dark:divide-slate-800/50 max-w-2xl">
+            <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
               <span className="text-xs text-slate-500 dark:text-slate-400">Receipt ID</span>
               <Link
                 to={`/dashboard/webhooks/${encodeURIComponent(trigger.webhook.receiptId)}`}
@@ -180,27 +180,27 @@ export function TriggerDetailPage() {
                 {shortId(trigger.webhook.receiptId)}
               </Link>
             </div>
-            <div className="px-4 py-3 flex items-center justify-between">
+            <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
               <span className="text-xs text-slate-500 dark:text-slate-400">Source</span>
               <span className="text-xs text-slate-700 dark:text-slate-300">{trigger.webhook.source}</span>
             </div>
             {trigger.webhook.eventSummary && (
-              <div className="px-4 py-3 flex items-center justify-between">
+              <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
                 <span className="text-xs text-slate-500 dark:text-slate-400">Event</span>
                 <span className="text-xs text-slate-700 dark:text-slate-300">{trigger.webhook.eventSummary}</span>
               </div>
             )}
             {trigger.webhook.deliveryId && (
-              <div className="px-4 py-3 flex items-center justify-between">
+              <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
                 <span className="text-xs text-slate-500 dark:text-slate-400">Delivery ID</span>
                 <span className="font-mono text-xs text-slate-700 dark:text-slate-300">{trigger.webhook.deliveryId}</span>
               </div>
             )}
-            <div className="px-4 py-3 flex items-center justify-between">
+            <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
               <span className="text-xs text-slate-500 dark:text-slate-400">Status</span>
               <ResultBadge result={trigger.webhook.status === "processed" ? "completed" : "dead-letter"} />
             </div>
-            <div className="px-4 py-3 flex items-center justify-between">
+            <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
               <span className="text-xs text-slate-500 dark:text-slate-400">Matched Agents</span>
               <span className="text-xs text-slate-700 dark:text-slate-300">{trigger.webhook.matchedAgents}</span>
             </div>
@@ -253,10 +253,10 @@ export function TriggerDetailPage() {
           <div className="px-4 py-2.5 border-b border-slate-200 dark:border-slate-800">
             <h2 className="text-sm font-medium text-slate-900 dark:text-white">Agent Trigger Details</h2>
           </div>
-          <div className="divide-y divide-slate-100 dark:divide-slate-800/50">
+          <div className="divide-y divide-slate-100 dark:divide-slate-800/50 max-w-2xl">
             {trigger.callerAgent ? (
               <>
-                <div className="px-4 py-3 flex items-center justify-between">
+                <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
                   <span className="text-xs text-slate-500 dark:text-slate-400">Called by</span>
                   <Link
                     to={`/dashboard/agents/${encodeURIComponent(trigger.callerAgent)}`}
@@ -268,7 +268,7 @@ export function TriggerDetailPage() {
                   </Link>
                 </div>
                 {trigger.callerInstance && (
-                  <div className="px-4 py-3 flex items-center justify-between">
+                  <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
                     <span className="text-xs text-slate-500 dark:text-slate-400">Caller Instance</span>
                     <Link
                       to={`/dashboard/agents/${encodeURIComponent(trigger.callerAgent)}/instances/${encodeURIComponent(trigger.callerInstance)}`}
@@ -279,7 +279,7 @@ export function TriggerDetailPage() {
                   </div>
                 )}
                 {trigger.callDepth !== undefined && (
-                  <div className="px-4 py-3 flex items-center justify-between">
+                  <div className="px-4 py-3 grid grid-cols-[8rem_1fr] gap-x-4 items-center">
                     <span className="text-xs text-slate-500 dark:text-slate-400">Call Depth</span>
                     <span className="text-xs text-slate-700 dark:text-slate-300">{trigger.callDepth}</span>
                   </div>

--- a/packages/frontend/src/pages/WebhookReceiptPage.tsx
+++ b/packages/frontend/src/pages/WebhookReceiptPage.tsx
@@ -114,46 +114,46 @@ export function WebhookReceiptPage() {
         </div>
       </div>
 
-      {/* Info cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {/* Info card */}
+      <div className="max-w-2xl">
         <div className="bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 p-4">
           <h2 className="text-sm font-medium text-slate-900 dark:text-white mb-3">Receipt Info</h2>
-          <dl className="space-y-2 text-sm">
-            <div className="flex justify-between">
+          <dl className="text-sm">
+            <div className="grid grid-cols-[8rem_1fr] gap-x-4 py-1 items-center">
               <dt className="text-slate-500 dark:text-slate-400">Source</dt>
               <dd className="text-slate-700 dark:text-slate-300">{receipt.source}</dd>
             </div>
             {receipt.eventSummary && (
-              <div className="flex justify-between">
+              <div className="grid grid-cols-[8rem_1fr] gap-x-4 py-1 items-center">
                 <dt className="text-slate-500 dark:text-slate-400">Event</dt>
                 <dd className="text-slate-700 dark:text-slate-300">{receipt.eventSummary}</dd>
               </div>
             )}
             {receipt.deliveryId && (
-              <div className="flex justify-between">
+              <div className="grid grid-cols-[8rem_1fr] gap-x-4 py-1 items-center">
                 <dt className="text-slate-500 dark:text-slate-400">Delivery ID</dt>
                 <dd className="text-slate-700 dark:text-slate-300 font-mono text-xs">{receipt.deliveryId}</dd>
               </div>
             )}
-            <div className="flex justify-between">
+            <div className="grid grid-cols-[8rem_1fr] gap-x-4 py-1 items-center">
               <dt className="text-slate-500 dark:text-slate-400">Timestamp</dt>
               <dd className="text-slate-700 dark:text-slate-300">{fmtDateTime(receipt.timestamp)}</dd>
             </div>
-            <div className="flex justify-between">
+            <div className="grid grid-cols-[8rem_1fr] gap-x-4 py-1 items-center">
               <dt className="text-slate-500 dark:text-slate-400">Status</dt>
               <dd><ResultBadge result={resultForBadge} /></dd>
             </div>
-            <div className="flex justify-between">
+            <div className="grid grid-cols-[8rem_1fr] gap-x-4 py-1 items-center">
               <dt className="text-slate-500 dark:text-slate-400">Matched Agents</dt>
               <dd className="text-slate-700 dark:text-slate-300">{receipt.matchedAgents}</dd>
             </div>
             {receipt.deadLetterReason && (
-              <div className="flex justify-between">
+              <div className="grid grid-cols-[8rem_1fr] gap-x-4 py-1 items-center">
                 <dt className="text-slate-500 dark:text-slate-400">Dead Letter Reason</dt>
                 <dd className="text-red-600 dark:text-red-400 text-xs">{receipt.deadLetterReason}</dd>
               </div>
             )}
-            <div className="flex flex-col gap-1 pt-1 border-t border-slate-200 dark:border-slate-800">
+            <div className="grid grid-cols-[8rem_1fr] gap-x-4 py-1 items-start pt-2 mt-1 border-t border-slate-200 dark:border-slate-800">
               <dt className="text-slate-500 dark:text-slate-400">Receipt ID</dt>
               <dd className="text-slate-700 dark:text-slate-300 font-mono text-xs break-all">{receipt.id}</dd>
             </div>


### PR DESCRIPTION
Closes #499

## Changes

Replaced full-width `flex justify-between` row layout with a two-column `grid grid-cols-[8rem_1fr]` layout in the info cards on three pages:

- **InstanceTriggerPage.tsx** — Overview, Webhook Details, and Agent Trigger Details cards
- **TriggerDetailPage.tsx** — Overview, Webhook Details, and Agent Trigger Details cards  
- **WebhookReceiptPage.tsx** — Receipt Info card (also simplified outer wrapper from `grid grid-cols-1 md:grid-cols-2` to `max-w-2xl` since the second column was empty)

Labels are now fixed at 8rem width and values sit left-aligned right next to them, making the tables much easier to read at any screen width. `<pre>` blocks for headers/body remain full-width and are unaffected.