### PR TITLE
fix: style Stats page Token Usage as tab instead of button

### DIFF
--- a/.changeset/stats-tab-style.md
+++ b/.changeset/stats-tab-style.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/frontend": patch
+---
+
+Replace button-styled "Token Usage" subnav on Stats page with underline tab style matching AgentLayout tabs

--- a/package-lock.json
+++ b/package-lock.json
@@ -13292,7 +13292,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "license": "MIT",
       "dependencies": {
         "@action-llama/skill": "*",
@@ -13378,7 +13378,7 @@
     },
     "packages/frontend": {
       "name": "@action-llama/frontend",
-      "version": "0.19.4",
+      "version": "0.19.5",
       "dependencies": {
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -13400,7 +13400,7 @@
     },
     "packages/skill": {
       "name": "@action-llama/skill",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "license": "MIT"
     }
   }

--- a/packages/frontend/src/pages/StatsPage.tsx
+++ b/packages/frontend/src/pages/StatsPage.tsx
@@ -29,9 +29,9 @@ export function StatsPage() {
         </h1>
       </div>
 
-      {/* Subnav */}
-      <div className="flex items-center gap-2">
-        <span className="px-3 py-1.5 text-xs font-medium rounded-md bg-blue-600 text-white">
+      {/* Tab bar */}
+      <div className="flex gap-6 border-b border-slate-200 dark:border-slate-800">
+        <span className="pb-2 text-sm font-medium text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400">
           Token Usage
         </span>
       </div>


### PR DESCRIPTION
Closes #504

## Changes

Replaced the button-styled "Token Usage" subnav in the Stats page with an underline tab bar matching the style used by `AgentLayout` and other pages.

**Before:** Big blue filled button with rounded corners  
**After:** Underlined tab with blue text and bottom border, consistent with the rest of the UI

### Implementation
- Updated `packages/frontend/src/pages/StatsPage.tsx` to use the same tab bar pattern as `AgentLayout.tsx`
- Uses a `<span>` instead of `<Link>` since there is currently only one tab (can be converted to `<Link>` when additional tabs are added)

### Testing
- ✅ `vite build` completes with no errors