### PR TITLE
fix: activity page pending badge inconsistency with table

### DIFF
--- a/.changeset/fix-activity-pending-badge-consistency.md
+++ b/.changeset/fix-activity-pending-badge-consistency.md
@@ -1,0 +1,7 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fix Activity page pending badge showing stale count inconsistent with the table.
+
+The badge now derives its count from the same API response that populates the table (`pendingCount` field from `/api/stats/activity`), instead of the SSE-pushed `queuedWebhooks` value. This eliminates the race condition where the SSE stream and REST API could return different pending counts, causing the badge to say "1 Pending" while no pending row appeared below. Closes #502.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13292,7 +13292,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "license": "MIT",
       "dependencies": {
         "@action-llama/skill": "*",
@@ -13378,7 +13378,7 @@
     },
     "packages/frontend": {
       "name": "@action-llama/frontend",
-      "version": "0.19.4",
+      "version": "0.19.5",
       "dependencies": {
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -13400,7 +13400,7 @@
     },
     "packages/skill": {
       "name": "@action-llama/skill",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "license": "MIT"
     }
   }

--- a/packages/action-llama/src/control/routes/stats.ts
+++ b/packages/action-llama/src/control/routes/stats.ts
@@ -263,6 +263,7 @@ export function registerStatsRoutes(
 
     const memRows = buildMemRows();
     const memCount = memRows.length;
+    const pendingCount = memRows.filter((r) => r.result === "pending").length;
 
     let rows: any[];
     let total: number;
@@ -334,7 +335,7 @@ export function registerStatsRoutes(
       }
     }
 
-    return c.json({ rows, total, limit, offset });
+    return c.json({ rows, total, pendingCount, limit, offset });
   });
 
   // Single webhook receipt by ID

--- a/packages/action-llama/test/control/routes/stats.test.ts
+++ b/packages/action-llama/test/control/routes/stats.test.ts
@@ -1102,4 +1102,54 @@ describe("stats routes", () => {
       expect(pendingRows.some((r: any) => r.triggerType === "webhook")).toBe(false);
     });
   });
+
+  describe("GET /api/stats/activity — pendingCount field", () => {
+    it("returns pendingCount=0 when there are no pending items", async () => {
+      const stats = mockStatsStore();
+      stats.queryActivityRows.mockReturnValue([
+        { ts: 1000, triggerType: "schedule", agentName: "reporter", instanceId: "i1", result: "completed" },
+      ]);
+      stats.countActivityRows.mockReturnValue(1);
+
+      const app = createApp(stats);
+      const res = await app.request("/api/stats/activity");
+      const data = await res.json();
+
+      expect(data.pendingCount).toBe(0);
+    });
+
+    it("returns pendingCount matching actual pending queue items so badge and table stay consistent", async () => {
+      const stats = mockStatsStore();
+      stats.queryActivityRows.mockReturnValue([]);
+      stats.countActivityRows.mockReturnValue(0);
+
+      const tracker = mockStatusTracker([], [{ name: "reporter", queuedWebhooks: 2 }]);
+      const controlDeps = {
+        workQueue: {
+          size: vi.fn().mockReturnValue(2),
+          peek: vi.fn().mockReturnValue([
+            { context: { type: "webhook", context: { source: "github" } }, receivedAt: new Date(3000) },
+            { context: { type: "schedule" }, receivedAt: new Date(2000) },
+          ]),
+        },
+      };
+
+      const app = createApp(stats, tracker, controlDeps);
+      const res = await app.request("/api/stats/activity");
+      const data = await res.json();
+
+      expect(data.pendingCount).toBe(2);
+      // Verify badge source matches table rows
+      const pendingRows = data.rows.filter((r: any) => r.result === "pending");
+      expect(pendingRows).toHaveLength(data.pendingCount);
+    });
+
+    it("returns pendingCount=0 when no stats store is provided", async () => {
+      const app = createApp();
+      const res = await app.request("/api/stats/activity");
+      const data = await res.json();
+
+      expect(data.pendingCount).toBe(0);
+    });
+  });
 });

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -348,7 +348,7 @@ export function getActivity(
   triggerType?: string,
   statuses?: string[],
   signal?: AbortSignal,
-): Promise<{ rows: ActivityRow[]; total: number }> {
+): Promise<{ rows: ActivityRow[]; total: number; pendingCount: number }> {
   let url = `/api/stats/activity?limit=${limit}&offset=${offset}`;
   if (agent) url += `&agent=${encodeURIComponent(agent)}`;
   if (triggerType) url += `&triggerType=${encodeURIComponent(triggerType)}`;

--- a/packages/frontend/src/pages/ActivityPage.tsx
+++ b/packages/frontend/src/pages/ActivityPage.tsx
@@ -48,7 +48,7 @@ export function ActivityPage() {
   const statusFilterKey = statusFilters.join(",");
   const statusesToSend = statusFilters.length === STATUS_OPTIONS.length ? undefined : statusFilters;
 
-  const { data, isLoading } = useQuery<{ rows: ActivityRow[]; total: number }>({
+  const { data, isLoading } = useQuery<{ rows: ActivityRow[]; total: number; pendingCount: number }>({
     key: `activity:${offset}:${agentFilter ?? ""}:${triggerTypeFilter ?? ""}:${statusFilterKey}`,
     fetcher: (signal) => getActivity(PAGE_SIZE, offset, agentFilter, triggerTypeFilter, statusesToSend, signal),
     invalidateOn: ["runs", "triggers"],
@@ -57,6 +57,7 @@ export function ActivityPage() {
 
   const rows = data?.rows ?? [];
   const total = data?.total ?? 0;
+  const pendingCount = data?.pendingCount ?? 0;
 
   // Reset offset when filters change
   useEffect(() => {
@@ -98,10 +99,6 @@ export function ActivityPage() {
   const page = Math.floor(offset / PAGE_SIZE) + 1;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
-  const livePendingCount = agentFilter
-    ? agents.find((a) => a.name === agentFilter)?.queuedWebhooks ?? 0
-    : agents.reduce((sum, a) => sum + (a.queuedWebhooks || 0), 0);
-
   const agentOptions = [
     { value: "", label: "All Agents" },
     ...agents.map((a) => ({ value: a.name, label: a.name })),
@@ -113,9 +110,9 @@ export function ActivityPage() {
       <div className="flex items-center justify-between flex-wrap gap-3">
         <div className="flex items-center gap-3">
           <h1 className="text-xl font-bold text-slate-900 dark:text-white">Activity</h1>
-          {livePendingCount > 0 && (
+          {pendingCount > 0 && (
             <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">
-              {livePendingCount} pending
+              {pendingCount} pending
             </span>
           )}
         </div>


### PR DESCRIPTION
Closes #502

## Problem

The Activity page badge ("N pending") used the SSE-pushed `queuedWebhooks` count while the table rows came from the REST API `/api/stats/activity`. These two data sources could be out of sync due to a race condition: the SSE event delivering `queuedWebhooks=1` might arrive before (or after) the REST response is fetched, causing the badge to show "1 Pending" while no pending row appeared in the table below.

## Fix

**Backend:** `/api/stats/activity` now returns a `pendingCount` field — the count of pending rows in the current filtered in-memory result set (computed from the same `buildMemRows()` call that populates the table).

**Frontend:** `ActivityPage` uses `data.pendingCount` from the API response instead of the SSE-derived `livePendingCount`. Since both the badge count and the table rows now come from the same HTTP response, they are always consistent.

## Changes

- `packages/action-llama/src/control/routes/stats.ts` — compute and return `pendingCount` in activity response
- `packages/frontend/src/lib/api.ts` — add `pendingCount` to return type of `getActivity`
- `packages/frontend/src/pages/ActivityPage.tsx` — use `pendingCount` from API response for badge
- `packages/action-llama/test/control/routes/stats.test.ts` — 3 new tests for `pendingCount`