### PR TITLE
fix: add /stats SPA fallback route to fix 404 on refresh

### DIFF
--- a/.changeset/fix-stats-spa-fallback.md
+++ b/.changeset/fix-stats-spa-fallback.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Add /stats SPA fallback route to fix 404 on page refresh

--- a/packages/action-llama/src/gateway/frontend.ts
+++ b/packages/action-llama/src/gateway/frontend.ts
@@ -80,6 +80,7 @@ export function registerSpaRoutes(app: Hono, frontendDist: string, logger: Logge
   app.get("/activity", (c) => c.html(indexHtml));
   app.get("/triggers", (c) => c.html(indexHtml));
   app.get("/jobs", (c) => c.html(indexHtml));
+  app.get("/stats", (c) => c.html(indexHtml));
   app.get("/chat", (c) => c.html(indexHtml));
   app.get("/chat/*", (c) => c.html(indexHtml));
 }

--- a/packages/action-llama/test/gateway/frontend.test.ts
+++ b/packages/action-llama/test/gateway/frontend.test.ts
@@ -141,6 +141,14 @@ describe("registerSpaRoutes", () => {
     expect(text).toBe(INDEX_HTML);
   });
 
+  it("serves /stats with SPA index.html", async () => {
+    const app = buildApp();
+    const res = await app.request("/stats");
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toBe(INDEX_HTML);
+  });
+
   it("serves /chat with SPA index.html", async () => {
     const app = buildApp();
     const res = await app.request("/chat");


### PR DESCRIPTION
Closes #507

## Summary

The `/stats` page worked with client-side navigation but returned a 404 on refresh because the server-side SPA fallback in `registerSpaRoutes()` was missing the route.

## Changes

- **`packages/action-llama/src/gateway/frontend.ts`**: Added `app.get("/stats", (c) => c.html(indexHtml));` to the SPA fallback routes section.
- **`packages/action-llama/test/gateway/frontend.test.ts`**: Added a test case verifying that `/stats` returns 200 with the SPA index.html.
- **`.changeset/fix-stats-spa-fallback.md`**: Changeset for this patch release.

## Testing

All 18 unit tests pass:
```
npx vitest run packages/action-llama/test/gateway/frontend.test.ts
✓ 18 tests passed
```