### PR TITLE
fix: add conclusions field to GitHub webhook trigger

### DIFF
--- a/.changeset/fix-github-conclusions-filter.md
+++ b/.changeset/fix-github-conclusions-filter.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Add `conclusions` field to GitHub webhook trigger validation and filter building. Previously, using `conclusions` in a GitHub webhook trigger config caused `al doctor` to report it as an unrecognized field. The field is now accepted during validation and correctly mapped when building the webhook filter.

--- a/packages/action-llama/src/events/webhook-setup.ts
+++ b/packages/action-llama/src/events/webhook-setup.ts
@@ -94,6 +94,7 @@ export function buildFilterFromTrigger(trigger: WebhookTrigger, providerType: st
     if (trigger.assignee) f.assignee = trigger.assignee;
     if (trigger.author) f.author = trigger.author;
     if (trigger.branches) f.branches = trigger.branches;
+    if (trigger.conclusions) f.conclusions = trigger.conclusions;
     return Object.keys(f).length > 0 ? f : undefined;
   }
   if (providerType === "sentry") {
@@ -148,7 +149,7 @@ export const KNOWN_PROVIDER_TYPES = new Set(["github", "sentry", "linear", "mint
 
 // Valid trigger fields per provider type (filter fields + source)
 const VALID_TRIGGER_FIELDS: Record<string, Set<string>> = {
-  github: new Set(["source", "events", "actions", "repos", "orgs", "org", "labels", "assignee", "author", "branches"]),
+  github: new Set(["source", "events", "actions", "repos", "orgs", "org", "labels", "assignee", "author", "branches", "conclusions"]),
   sentry: new Set(["source", "resources"]),
   linear: new Set(["source", "events", "actions", "organizations", "labels", "assignee", "author"]),
   test: new Set(["source", "events", "actions", "repos"]),

--- a/packages/action-llama/src/webhooks/types.ts
+++ b/packages/action-llama/src/webhooks/types.ts
@@ -91,6 +91,7 @@ export interface WebhookTrigger {
   assignee?: string;
   author?: string;
   branches?: string[];
+  conclusions?: string[];
   resources?: string[];
   guilds?: string[];     // Discord guild IDs
   channels?: string[];   // Discord channel IDs

--- a/packages/action-llama/test/events/webhook-setup.test.ts
+++ b/packages/action-llama/test/events/webhook-setup.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { resolveWebhookSource, buildFilterFromTrigger, validateTriggerFields, resolveCredentialInstance, PROVIDER_CREDENTIALS, PROVIDER_TO_CREDENTIAL, PROVIDER_TO_SECRET_FIELD, KNOWN_PROVIDER_TYPES, registerWebhookBindings, setupWebhookRegistry } from "../../src/events/webhook-setup.js";
 import type { WebhookSourceConfig } from "../../src/shared/config.js";
+import type { GitHubWebhookFilter } from "../../src/webhooks/types.js";
 import * as twitterSubscribeMod from "../../src/webhooks/providers/twitter-subscribe.js";
 
 vi.mock("../../src/shared/credentials.js", () => ({
@@ -128,12 +129,30 @@ describe("buildFilterFromTrigger", () => {
     );
     expect(filter).toEqual({ orgs: ["acme", "other-org"] });
   });
+
+  it("maps conclusions for github", () => {
+    const filter = buildFilterFromTrigger(
+      { source: "my-github", events: ["workflow_run"], actions: ["completed"], conclusions: ["failure", "cancelled"] },
+      "github"
+    ) as GitHubWebhookFilter;
+    expect(filter).toBeDefined();
+    expect(filter.conclusions).toEqual(["failure", "cancelled"]);
+  });
 });
 
 describe("validateTriggerFields", () => {
   it("returns no errors for valid github fields", () => {
     const errors = validateTriggerFields(
       { source: "my-github", events: ["issues"], repos: ["acme/app"], org: "acme" },
+      "github",
+      "agent1"
+    );
+    expect(errors).toEqual([]);
+  });
+
+  it("returns no errors for github conclusions field", () => {
+    const errors = validateTriggerFields(
+      { source: "my-github", events: ["workflow_run"], conclusions: ["failure"] },
       "github",
       "agent1"
     );


### PR DESCRIPTION
Closes #510

## Summary

The `conclusions` field was documented and partially implemented (in `GitHubWebhookFilter`, `WebhookContext`, and the GitHub provider's `matchesFilter`) but was missing from two critical places:

1. **`VALID_TRIGGER_FIELDS.github`** — causing `al doctor` to reject it as an unrecognized field
2. **`buildFilterFromTrigger`** — meaning the filter would be silently dropped even if validation passed
3. **`WebhookTrigger` interface** — the TypeScript type didn't include the field

## Changes

- `packages/action-llama/src/webhooks/types.ts` — Added `conclusions?: string[]` to `WebhookTrigger` interface
- `packages/action-llama/src/events/webhook-setup.ts` — Added `"conclusions"` to `VALID_TRIGGER_FIELDS.github`; added `conclusions` mapping in `buildFilterFromTrigger` for github
- `packages/action-llama/test/events/webhook-setup.test.ts` — Added tests for `conclusions` in both `validateTriggerFields` and `buildFilterFromTrigger`

## Testing

All 69 tests in `webhook-setup.test.ts` pass. The broader test suite passes (228/229 test files; 1 pre-existing failure in `al-bash-init.test.ts` due to `bash` not being available in the CI environment, unrelated to this change).