### PR TITLE
On mobile hide the "0 lines" in the log panel header

### DIFF
--- a/.changeset/hide-log-lines-mobile.md
+++ b/.changeset/hide-log-lines-mobile.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/frontend": patch
+---
+
+Hide "0 lines" line count indicator in log panel header on mobile viewports

--- a/packages/frontend/src/pages/InstanceLogsPage.tsx
+++ b/packages/frontend/src/pages/InstanceLogsPage.tsx
@@ -210,7 +210,7 @@ export function InstanceLogsPage() {
             Logs
           </h2>
           <div className="flex items-center gap-3">
-            <span className="text-xs text-slate-500 dark:text-slate-400">
+            <span className="hidden sm:inline text-xs text-slate-500 dark:text-slate-400">
               {logs.length} lines
             </span>
             <span


### PR DESCRIPTION
Closes #515

## Changes

Added `hidden sm:inline` Tailwind classes to the line count `<span>` in the log panel header in `InstanceLogsPage.tsx`. This hides the element on screens below the `sm` breakpoint (640px) and shows it as `inline` on `sm` and above.

## Testing

- Build verified with `npm run build -w packages/frontend` — no errors
- On mobile viewports (<640px), the line count indicator will be hidden
- On desktop viewports (≥640px), the line count indicator will appear as normal