### PR TITLE
feat: add Summary column to Activity table

### DIFF
--- a/.changeset/activity-summary-column.md
+++ b/.changeset/activity-summary-column.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Add Summary column to Activity table. On desktop, shows an AI-generated summary of each run with generate/regenerate buttons. On mobile, shows a collapsible summary below the trigger badge with a smaller instance ID font. Summaries are now persisted to the SQLite `runs` table so they survive server restarts. Also updates the summary prompt to describe what triggered the run, what resource it operated on, what it did, and any errors. Closes #513.

--- a/packages/action-llama/drizzle/0003_add_run_summary.sql
+++ b/packages/action-llama/drizzle/0003_add_run_summary.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `runs` ADD `summary` text;

--- a/packages/action-llama/drizzle/meta/_journal.json
+++ b/packages/action-llama/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1775061000000,
       "tag": "0002_add_result_index",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1775070000000,
+      "tag": "0003_add_run_summary",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/action-llama/src/control/routes/log-summary.ts
+++ b/packages/action-llama/src/control/routes/log-summary.ts
@@ -64,9 +64,20 @@ export function registerLogSummaryRoutes(
     // Check cache for completed runs (only for default request)
     const cacheKey = instanceId;
     if (!query.lines && !query.after && !query.before && !query.grep) {
+      // Check in-memory cache first (fast path)
       const cached = summaryCache.get(cacheKey);
       if (cached) {
         return c.json({ summary: cached, cached: true });
+      }
+      // Fall back to DB-persisted summary
+      try {
+        const run = statsStore?.queryRunByInstanceId(instanceId);
+        if (run?.summary) {
+          summaryCache.set(cacheKey, run.summary);
+          return c.json({ summary: run.summary, cached: true });
+        }
+      } catch {
+        // Non-critical — ignore cache errors
       }
     }
 
@@ -125,7 +136,7 @@ export function registerLogSummaryRoutes(
       {
         role: "system",
         content:
-          "You are a concise technical assistant. Summarize the following agent run logs in 2-4 sentences. Focus on what the agent did, whether it succeeded, and any notable errors or outcomes. Do not include timestamps or log formatting in your summary.",
+          "You are a concise technical assistant. Summarize the following agent run logs. In a few words describe: what triggered it, what resource it operated on, and what it did. If there are errors then mention the errors. Keep the summary to 1-3 sentences. Do not include timestamps or log formatting.",
       },
       {
         role: "user",
@@ -145,12 +156,13 @@ export function registerLogSummaryRoutes(
       return c.json({ error: msg }, 500);
     }
 
-    // Cache for completed runs
+    // Persist and cache for completed runs
     if (!query.lines && !query.after && !query.before && !query.grep) {
       try {
         const run = statsStore?.queryRunByInstanceId(instanceId);
         if (run && run.result) {
           summaryCache.set(cacheKey, summary);
+          statsStore?.updateRunSummary(instanceId, summary);
         }
       } catch {
         // Non-critical — ignore cache errors

--- a/packages/action-llama/src/db/schema.ts
+++ b/packages/action-llama/src/db/schema.ts
@@ -68,6 +68,7 @@ export const runsTable = sqliteTable(
     postHookMs: integer("post_hook_ms"),
     webhookReceiptId: text("webhook_receipt_id"),
     triggerContext: text("trigger_context"),
+    summary: text("summary"),
   },
   (t) => [
     index("idx_runs_agent").on(t.agentName, t.startedAt),

--- a/packages/action-llama/src/stats/store.ts
+++ b/packages/action-llama/src/stats/store.ts
@@ -49,6 +49,7 @@ export interface TriggerHistoryRow {
   result: string;
   webhookReceiptId: string | null;
   deadLetterReason: string | null;
+  summary?: string | null;
 }
 
 export interface CallEdgeRecord {
@@ -179,6 +180,12 @@ export class StatsStore {
     return (this.db as any).$client
       .prepare("SELECT * FROM runs WHERE instance_id = ? LIMIT 1")
       .get(instanceId) as any;
+  }
+
+  updateRunSummary(instanceId: string, summary: string): void {
+    (this.db as any).$client
+      .prepare("UPDATE runs SET summary = ? WHERE instance_id = ?")
+      .run(summary, instanceId);
   }
 
   queryCallEdgeByTargetInstance(targetInstance: string): { caller_agent: string; caller_instance: string; target_agent: string; target_instance: string; depth: number; started_at: number; duration_ms: number | null; status: string } | undefined {
@@ -473,7 +480,7 @@ export class StatsStore {
       SELECT started_at AS ts, instance_id AS instanceId, agent_name AS agentName,
              trigger_type AS triggerType, trigger_source AS triggerSource,
              result, webhook_receipt_id AS webhookReceiptId,
-             NULL AS deadLetterReason
+             NULL AS deadLetterReason, summary
       FROM runs ${runsWhereClause}
     `;
 
@@ -481,7 +488,7 @@ export class StatsStore {
       SELECT timestamp AS ts, NULL AS instanceId, NULL AS agentName,
              'webhook' AS triggerType, source AS triggerSource,
              'dead-letter' AS result, id AS webhookReceiptId,
-             dead_letter_reason AS deadLetterReason
+             dead_letter_reason AS deadLetterReason, NULL AS summary
       FROM webhook_receipts WHERE status = 'dead-letter'
     `;
 

--- a/packages/action-llama/test/control/routes/log-summary.test.ts
+++ b/packages/action-llama/test/control/routes/log-summary.test.ts
@@ -211,7 +211,7 @@ describe("log summary route", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
-  it("caches summary for completed runs", async () => {
+  it("caches summary for completed runs and persists to DB", async () => {
     createMinimalAgentProject(tmpDir, "my-agent");
     const instanceId = "inst-completed";
     const lines = [
@@ -235,6 +235,7 @@ describe("log summary route", () => {
         result: "ok",
         agentName: "my-agent",
       }),
+      updateRunSummary: vi.fn(),
     } as any;
 
     const app = createTestApp(tmpDir, statsStore);
@@ -250,6 +251,9 @@ describe("log summary route", () => {
     expect(data1.cached).toBe(false);
     expect(fetchMock).toHaveBeenCalledOnce();
 
+    // Verify summary was persisted to DB
+    expect(statsStore.updateRunSummary).toHaveBeenCalledWith(instanceId, "The agent completed.");
+
     // Second call — should be served from cache
     const res2 = await app.request(
       `/api/logs/agents/my-agent/${instanceId}/summarize`,
@@ -261,6 +265,45 @@ describe("log summary route", () => {
     expect(data2.cached).toBe(true);
     // fetch should not have been called again
     expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("returns DB-persisted summary as cached without calling the LLM", async () => {
+    createMinimalAgentProject(tmpDir, "my-agent");
+    const instanceId = "inst-db-cached";
+    const lines = [
+      pinoLine(30, 1710700000000, "Done", { instance: instanceId }),
+    ];
+    writeFileSync(
+      join(logsPath, "my-agent-2024-03-18.log"),
+      lines.join("\n") + "\n",
+    );
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    // statsStore returns a run with a pre-existing summary from DB
+    const statsStore = {
+      queryRunByInstanceId: vi.fn().mockReturnValue({
+        instanceId,
+        result: "completed",
+        agentName: "my-agent",
+        summary: "Pre-existing DB summary.",
+      }),
+      updateRunSummary: vi.fn(),
+    } as any;
+
+    const app = createTestApp(tmpDir, statsStore);
+
+    const res = await app.request(
+      `/api/logs/agents/my-agent/${instanceId}/summarize`,
+      { method: "POST" },
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.summary).toBe("Pre-existing DB summary.");
+    expect(data.cached).toBe(true);
+    // LLM should NOT have been called
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("does not cache for in-progress runs", async () => {

--- a/packages/frontend/src/components/ActivityTable.tsx
+++ b/packages/frontend/src/components/ActivityTable.tsx
@@ -1,6 +1,8 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import { TriggerBadge } from "./Badge";
 import type { ActivityRow } from "../lib/api";
+import { summarizeLogs } from "../lib/api";
 import { fmtSmartTime } from "../lib/format";
 import { agentHueStyle } from "../lib/color";
 
@@ -50,6 +52,16 @@ function triggerLabel(row: ActivityRow): string {
   return row.triggerType;
 }
 
+/** Whether a row can have a summary generated */
+function canGenerateSummary(row: ActivityRow): boolean {
+  return (
+    !!(row.agentName && row.instanceId) &&
+    row.result !== "pending" &&
+    row.result !== "running" &&
+    row.result !== "dead-letter"
+  );
+}
+
 interface ActivityTableProps {
   rows: ActivityRow[];
   agentNames: string[];
@@ -63,6 +75,53 @@ export function ActivityTable({
   loading = false,
   emptyMessage = "No activity found",
 }: ActivityTableProps) {
+  const [loadingIds, setLoadingIds] = useState<Set<string>>(new Set());
+  const [localSummaries, setLocalSummaries] = useState<Map<string, string>>(new Map());
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [mobileExpandedIds, setMobileExpandedIds] = useState<Set<string>>(new Set());
+
+  const handleGenerate = async (agentName: string, instanceId: string) => {
+    setLoadingIds((prev) => new Set(prev).add(instanceId));
+    try {
+      const result = await summarizeLogs(agentName, instanceId);
+      if (result.summary) {
+        setLocalSummaries((prev) => new Map(prev).set(instanceId, result.summary));
+      }
+    } catch {
+      // silently ignore errors
+    } finally {
+      setLoadingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(instanceId);
+        return next;
+      });
+    }
+  };
+
+  const toggleExpanded = (instanceId: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(instanceId)) {
+        next.delete(instanceId);
+      } else {
+        next.add(instanceId);
+      }
+      return next;
+    });
+  };
+
+  const toggleMobileExpanded = (instanceId: string) => {
+    setMobileExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(instanceId)) {
+        next.delete(instanceId);
+      } else {
+        next.add(instanceId);
+      }
+      return next;
+    });
+  };
+
   return (
     <table className="w-full text-sm">
       <thead>
@@ -73,12 +132,26 @@ export function ActivityTable({
           <th className="text-left pl-2 pr-2 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">
             Instance
           </th>
+          <th className="text-left px-2 py-2.5 text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide hidden md:table-cell">
+            Summary
+          </th>
         </tr>
       </thead>
       <tbody>
         {rows.map((row, i) => {
           const isDeadLetter = row.result === "dead-letter";
           const badge = triggerLabel(row);
+          const instanceId = row.instanceId ?? "";
+
+          // Effective summary: local (just generated) takes priority over DB value
+          const effectiveSummary = instanceId
+            ? (localSummaries.get(instanceId) ?? row.summary ?? null)
+            : null;
+
+          const isLoading = instanceId ? loadingIds.has(instanceId) : false;
+          const isExpanded = instanceId ? expandedIds.has(instanceId) : false;
+          const isMobileExpanded = instanceId ? mobileExpandedIds.has(instanceId) : false;
+          const canGenerate = canGenerateSummary(row);
 
           // Build trigger badge element (optionally wrapped in a link)
           const detailPath = row.instanceId
@@ -110,8 +183,8 @@ export function ActivityTable({
               className="font-medium hover:underline truncate block"
             >
               <span
-                className="agent-color-text truncate"
-                style={{ fontSize: "16px", ...agentHueStyle(row.agentName, agentNames) }}
+                className="agent-color-text truncate text-sm md:text-base"
+                style={agentHueStyle(row.agentName, agentNames)}
               >
                 {row.instanceId}
               </span>
@@ -122,13 +195,56 @@ export function ActivityTable({
               className="font-medium hover:underline truncate block"
             >
               <span
-                className="agent-color-text truncate"
-                style={{ fontSize: "16px", ...agentHueStyle(row.agentName, agentNames) }}
+                className="agent-color-text truncate text-sm md:text-base"
+                style={agentHueStyle(row.agentName, agentNames)}
               >
                 {row.agentName}
               </span>
             </Link>
           ) : null;
+
+          // Desktop summary cell content
+          const desktopSummaryCell = (
+            <td className="px-2 py-2.5 hidden md:table-cell align-top">
+              {isLoading ? (
+                <span className="text-xs text-slate-400 dark:text-slate-500 animate-pulse">
+                  Generating…
+                </span>
+              ) : effectiveSummary ? (
+                <div className="flex items-start gap-1.5">
+                  <button
+                    onClick={() => instanceId && toggleExpanded(instanceId)}
+                    className="text-xs text-slate-600 dark:text-slate-300 text-left hover:text-slate-900 dark:hover:text-white transition-colors"
+                    title={isExpanded ? "Collapse" : "Click to expand"}
+                  >
+                    {isExpanded ? (
+                      <span>{effectiveSummary}</span>
+                    ) : (
+                      <span className="line-clamp-1 max-w-xs">{effectiveSummary}</span>
+                    )}
+                  </button>
+                  {canGenerate && (
+                    <button
+                      onClick={() => row.agentName && instanceId && handleGenerate(row.agentName, instanceId)}
+                      className="shrink-0 text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300 transition-colors"
+                      title="Regenerate summary"
+                    >
+                      ↻
+                    </button>
+                  )}
+                </div>
+              ) : canGenerate ? (
+                <button
+                  onClick={() => row.agentName && instanceId && handleGenerate(row.agentName, instanceId)}
+                  className="text-xs text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 transition-colors"
+                >
+                  Generate
+                </button>
+              ) : (
+                <span className="text-xs text-slate-300 dark:text-slate-600">—</span>
+              )}
+            </td>
+          );
 
           return (
             <tr
@@ -166,15 +282,61 @@ export function ActivityTable({
                       {row.deadLetterReason.replace(/_/g, " ")}
                     </span>
                   )}
+                  {/* Mobile-only summary section */}
+                  {canGenerate && (
+                    <div className="md:hidden mt-1">
+                      {isLoading ? (
+                        <span className="text-xs text-slate-400 dark:text-slate-500 animate-pulse">
+                          Generating…
+                        </span>
+                      ) : effectiveSummary ? (
+                        <div>
+                          <button
+                            onClick={() => instanceId && toggleMobileExpanded(instanceId)}
+                            className="text-xs text-slate-500 dark:text-slate-400 text-left hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
+                          >
+                            {isMobileExpanded ? (
+                              <span>{effectiveSummary}</span>
+                            ) : (
+                              <span>
+                                {effectiveSummary.length > 60
+                                  ? `${effectiveSummary.slice(0, 60)}…`
+                                  : effectiveSummary}
+                              </span>
+                            )}
+                          </button>
+                          {isMobileExpanded && (
+                            <button
+                              onClick={() => row.agentName && instanceId && handleGenerate(row.agentName, instanceId)}
+                              className="ml-2 text-xs text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300 transition-colors"
+                              title="Regenerate summary"
+                            >
+                              ↻ Regenerate
+                            </button>
+                          )}
+                        </div>
+                      ) : (
+                        <button
+                          onClick={() => row.agentName && instanceId && handleGenerate(row.agentName, instanceId)}
+                          className="text-xs text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 transition-colors"
+                        >
+                          Generate summary
+                        </button>
+                      )}
+                    </div>
+                  )}
                 </div>
               </td>
+
+              {/* Summary column — desktop only */}
+              {desktopSummaryCell}
             </tr>
           );
         })}
         {rows.length === 0 && loading && (
           <tr>
             <td
-              colSpan={2}
+              colSpan={3}
               className="px-4 py-8 text-center text-slate-500 dark:text-slate-400"
             >
               Loading...
@@ -184,7 +346,7 @@ export function ActivityTable({
         {rows.length === 0 && !loading && (
           <tr>
             <td
-              colSpan={2}
+              colSpan={3}
               className="px-4 py-8 text-center text-slate-500 dark:text-slate-400"
             >
               {emptyMessage}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -158,6 +158,8 @@ export interface ActivityRow {
   result: string;
   webhookReceiptId?: string | null;
   deadLetterReason?: string | null;
+  /** AI-generated summary of the run, if available */
+  summary?: string | null;
 }
 
 export interface TriggerDetailData {


### PR DESCRIPTION
Closes #513

## Changes

### Backend
- **Migration**: Added `summary` (nullable text) column to the `runs` table via `0003_add_run_summary.sql`
- **Schema**: Updated `runsTable` in `schema.ts` to include the `summary` field
- **StatsStore**: Added `updateRunSummary(instanceId, summary)` method; updated `queryActivityRows()` to include `summary` in the SELECT
- **log-summary.ts**: Summaries persisted to DB after generation; cache check falls back to DB; updated system prompt to describe trigger, resource, action, and errors

### Frontend
- **ActivityRow type**: Added optional `summary` field
- **ActivityTable**: Summary column on desktop with generate/regenerate buttons and click-to-expand; collapsible mobile summary below triggers; smaller instance ID font on mobile via Tailwind responsive classes; colSpan updated to 3

### Tests
- Added test verifying DB persistence via `statsStore.updateRunSummary`
- Added test verifying DB-persisted summary is returned as cached without LLM call