### PR TITLE
Breadcrumb: don't show the current page

### DIFF
--- a/.changeset/breadcrumb-hide-current-page.md
+++ b/.changeset/breadcrumb-hide-current-page.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/frontend": patch
+---
+
+Breadcrumb no longer shows the current page title, preventing duplicate display with the h1 heading below

--- a/packages/frontend/src/components/AgentLayout.tsx
+++ b/packages/frontend/src/components/AgentLayout.tsx
@@ -63,7 +63,6 @@ export function AgentLayout() {
             Agents
           </Link>
           <span>›</span>
-          <span className="text-slate-900 dark:text-white font-medium">{name}</span>
         </nav>
       <div className="flex items-center justify-between flex-wrap gap-3">
         <div className="flex items-center gap-3">

--- a/packages/frontend/src/components/InstanceLayout.tsx
+++ b/packages/frontend/src/components/InstanceLayout.tsx
@@ -82,7 +82,6 @@ export function InstanceLayout() {
             {name}
           </Link>
           <span>›</span>
-          <span className="text-slate-900 dark:text-white font-medium font-mono">{id}</span>
         </nav>
         <div className="flex items-center justify-between flex-wrap gap-3">
           <div className="flex items-center gap-3">


### PR DESCRIPTION
Closes #520

## Changes

Removed the current page title from the breadcrumb in both  and . The current page is already shown as the `<h1>` heading directly below the breadcrumb, so showing it in the breadcrumb was redundant and made it overly wide.

### Before
- **Agent page:** breadcrumb = `Agents › agent-name`
- **Instance page:** breadcrumb = `Agents › agent-name › instance-id`

### After
- **Agent page:** breadcrumb = `Agents ›`
- **Instance page:** breadcrumb = `Agents › agent-name ›`

The trailing `›` separator is intentional — it visually connects the breadcrumb to the `<h1>` title below.