### PR TITLE
fix: Update log summary prompt to be more specific

### DIFF
--- a/.changeset/update-summary-prompt.md
+++ b/.changeset/update-summary-prompt.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Update log summary prompt to produce more specific, structured summaries with 10-word constraints for what was operated on, what was done, and any errors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13292,7 +13292,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.26.0",
+      "version": "0.26.1",
       "license": "MIT",
       "dependencies": {
         "@action-llama/skill": "*",
@@ -13378,7 +13378,7 @@
     },
     "packages/frontend": {
       "name": "@action-llama/frontend",
-      "version": "0.19.5",
+      "version": "0.19.6",
       "dependencies": {
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -13400,7 +13400,7 @@
     },
     "packages/skill": {
       "name": "@action-llama/skill",
-      "version": "0.26.0",
+      "version": "0.26.1",
       "license": "MIT"
     }
   }

--- a/packages/action-llama/src/control/routes/log-summary.ts
+++ b/packages/action-llama/src/control/routes/log-summary.ts
@@ -136,7 +136,7 @@ export function registerLogSummaryRoutes(
       {
         role: "system",
         content:
-          "You are a concise technical assistant. Summarize the following agent run logs. In a few words describe: what triggered it, what resource it operated on, and what it did. If there are errors then mention the errors. Keep the summary to 1-3 sentences. Do not include timestamps or log formatting.",
+          "You are a concise technical assistant. Summarize the following agent run logs using this structure: Describe what the agent operated on in less than 10 words. Describe what it did in less than 10 words. If there were errors, describe them in less than 10 words. Output only the summary text — no timestamps, no log formatting, no bullet points or labels.",
       },
       {
         role: "user",


### PR DESCRIPTION
Closes #524

## Changes

Updated the LLM system prompt in `packages/action-llama/src/control/routes/log-summary.ts` to produce more specific, structured summaries with word-count constraints.

**Old prompt:**
> "You are a concise technical assistant. Summarize the following agent run logs. In a few words describe: what triggered it, what resource it operated on, and what it did. If there are errors then mention the errors. Keep the summary to 1-3 sentences. Do not include timestamps or log formatting."

**New prompt:**
> "You are a concise technical assistant. Summarize the following agent run logs using this structure: Describe what the agent operated on in less than 10 words. Describe what it did in less than 10 words. If there were errors, describe them in less than 10 words. Output only the summary text — no timestamps, no log formatting, no bullet points or labels."

This makes each component of the summary tightly constrained to ~10 words as requested in the issue.

## Testing

All log-summary unit tests pass. The 11 pre-existing test failures in `al-bash-init.test.ts` are environment-related (`bash` binary not available in CI) and unrelated to this change.