### PR TITLE
Fix: instance logs scan limit + preload scroll headroom

### DIFF
--- a/.changeset/fix-instance-logs-scan-and-preload.md
+++ b/.changeset/fix-instance-logs-scan-and-preload.md
@@ -1,0 +1,6 @@
+---
+"@action-llama/action-llama": patch
+"@action-llama/frontend": patch
+---
+
+Fix two instance log bugs: (1) older instance logs no longer disappear — backend `readLastEntries` now scans up to 50k lines instead of stopping at `limit*3`, so sparse instance entries are found even when many newer-instance lines follow; (2) the logs panel pre-fetches one older page on load to provide scroll headroom above the initially visible entries.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13292,7 +13292,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.26.0",
+      "version": "0.26.1",
       "license": "MIT",
       "dependencies": {
         "@action-llama/skill": "*",
@@ -13378,7 +13378,7 @@
     },
     "packages/frontend": {
       "name": "@action-llama/frontend",
-      "version": "0.19.5",
+      "version": "0.19.6",
       "dependencies": {
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -13400,7 +13400,7 @@
     },
     "packages/skill": {
       "name": "@action-llama/skill",
-      "version": "0.26.0",
+      "version": "0.26.1",
       "license": "MIT"
     }
   }

--- a/packages/action-llama/src/control/routes/log-helpers.ts
+++ b/packages/action-llama/src/control/routes/log-helpers.ts
@@ -140,12 +140,12 @@ export async function readLastEntries(
     const chunkSize = 8192;
     const buffer = Buffer.alloc(chunkSize);
     let remainder = "";
-    // We need more raw lines than limit because of filtering
-    const rawLimit = limit * 3;
+    // Safety cap to prevent scanning multi-GB files; generous enough for any real agent run
+    const MAX_SCAN_LINES = 50000;
     let rawCount = 0;
 
     try {
-      while (rawCount < rawLimit && position > 0) {
+      while (position > 0 && entries.length < limit && rawCount < MAX_SCAN_LINES) {
         const toRead = Math.min(chunkSize, position);
         position -= toRead;
         const { buffer: readBuf } = await fd.read(buffer, 0, toRead, position);

--- a/packages/action-llama/test/control/routes/logs.test.ts
+++ b/packages/action-llama/test/control/routes/logs.test.ts
@@ -296,6 +296,45 @@ describe("log API routes", () => {
       expect(data2.entries).toHaveLength(1);
       expect(data2.entries[0].msg).toBe("inst2-new");
     });
+
+    it("returns entries for an older instance when many newer instance entries follow", async () => {
+      // Target instance has 5 entries, followed by 500 entries from a newer instance
+      const lines: string[] = [];
+      for (let i = 0; i < 5; i++) {
+        lines.push(pinoLine(30, 1710700000000 + i * 1000, `target-${i}`, { instance: "dev-old11" }));
+      }
+      for (let i = 0; i < 500; i++) {
+        lines.push(pinoLine(30, 1710700100000 + i * 1000, `other-${i}`, { instance: "dev-new22" }));
+      }
+      writeFileSync(join(logsPath, "dev-2024-03-18.log"), lines.join("\n") + "\n");
+
+      const app = createTestApp(tmpDir);
+      const res = await app.request("/api/logs/agents/dev/dev-old11?lines=10");
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.entries).toHaveLength(5);
+      expect(data.entries[0].msg).toBe("target-0");
+      expect(data.entries[4].msg).toBe("target-4");
+    });
+
+    it("returns older entries for instance when using before parameter with many interleaved entries", async () => {
+      // 5 entries for target instance at the start, then 500 entries for another instance
+      const lines: string[] = [];
+      for (let i = 0; i < 5; i++) {
+        lines.push(pinoLine(30, 1710700000000 + i * 1000, `target-${i}`, { instance: "dev-old11" }));
+      }
+      for (let i = 0; i < 500; i++) {
+        lines.push(pinoLine(30, 1710700100000 + i * 1000, `other-${i}`, { instance: "dev-new22" }));
+      }
+      writeFileSync(join(logsPath, "dev-2024-03-18.log"), lines.join("\n") + "\n");
+
+      const app = createTestApp(tmpDir);
+      // Request older logs before a timestamp after all target entries
+      const res = await app.request("/api/logs/agents/dev/dev-old11?lines=10&before=1710700010000");
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.entries).toHaveLength(5);
+    });
   });
 
   // ── Time range filtering ────────────────────────────────────────────────

--- a/packages/frontend/src/pages/InstanceLogsPage.tsx
+++ b/packages/frontend/src/pages/InstanceLogsPage.tsx
@@ -97,6 +97,15 @@ export function InstanceLogsPage() {
     [name, id, isRunning],
   );
 
+  // Pre-fetch one older page after the initial logs arrive so there's scroll headroom
+  const didPreload = useRef(false);
+  useEffect(() => {
+    if (logs.length > 0 && !didPreload.current && hasOlderLogs) {
+      didPreload.current = true;
+      loadOlderLogs();
+    }
+  }, [logs.length, hasOlderLogs, loadOlderLogs]);
+
   // Scroll follow
   useEffect(() => {
     if (following && logContainerRef.current) {


### PR DESCRIPTION
Closes #523

## Problem

Two bugs with instance log viewing:

1. **Older instance logs disappear** — `readLastEntries()` used `rawLimit = limit * 3` as a stopping condition. When newer instances wrote many log lines after an older instance finished, the scan exhausted `rawLimit` before reaching any entries for the target instance, returning 0 results.

2. **"Beginning of logs" shown immediately / no scroll headroom** — The frontend starts by fetching the last 100 entries and scrolling to the bottom with no headroom above.

## Fixes

### Backend (`packages/action-llama/src/control/routes/log-helpers.ts`)
Changed the `readLastEntries()` loop to stop when `entries.length >= limit` (found enough matches), using a `MAX_SCAN_LINES = 50000` safety cap instead of `limit * 3`.

### Frontend (`packages/frontend/src/pages/InstanceLogsPage.tsx`)
Added a `useEffect` that fires once after the initial logs load to pre-fetch one older page via `loadOlderLogs()`, giving scroll headroom above the visible entries. Gated by `didPreload.current` to fire only once.

### Tests
Two new test cases covering sparse instance filtering with 500 interleaved newer-instance entries.