### PR TITLE
fix: make al-bash-init.sh POSIX-compatible for sh runtimes

### DIFF
--- a/.changeset/posix-setenv-fix.md
+++ b/.changeset/posix-setenv-fix.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fix `setenv` not working in host-user runtimes where only `/bin/sh` (BusyBox/dash) is available. Rewrote `al-bash-init.sh` using POSIX-only syntax (no bash arrays, no `[[ =~ ]]`, no `printf %q`) so it works under any `/bin/sh`. Also added `sh` compatibility tests to prevent regression. Closes #525.

--- a/packages/action-llama/docker/bin/al-bash-init.sh
+++ b/packages/action-llama/docker/bin/al-bash-init.sh
@@ -1,58 +1,81 @@
-#!/bin/bash
-# Bash initialization script sourced before every agent command.
+#!/bin/sh
+# Shell initialization script sourced before every agent command.
 # Defines helpers and restores persisted environment variables.
 #
 # This file is sourced (not executed), so functions and exports
 # take effect in the caller's shell.
+#
+# Written in POSIX sh so it works under bash, dash, busybox sh, etc.
 
 # ---------- setenv ----------
-# Persist an environment variable across bash tool calls.
+# Persist an environment variable across shell tool calls.
 #
 # Usage:
 #   setenv NAME value
 #   setenv NAME1 value1 NAME2 value2   (multiple pairs)
 #   setenv NAME1 value1 setenv NAME2 value2   (tolerates stray "setenv" tokens)
 #
-# Each bash tool call spawns a fresh shell, so variables set with plain
+# Each shell tool call spawns a fresh shell, so variables set with plain
 # `export` are lost. setenv writes them to a file that this init script
 # re-sources on each call.
 
 _AL_ENV_FILE="${AL_ENV_FILE:-/tmp/env.sh}"
 
 setenv() {
-  # Strip any stray "setenv" tokens (LLMs sometimes repeat the command name
-  # between pairs: `setenv A 1 setenv B 2`).
-  local args=()
-  for _x in "$@"; do
-    [ "$_x" != "setenv" ] && args+=("$_x")
-  done
-  set -- "${args[@]}"
-
   if [ $# -lt 2 ]; then
     echo 'usage: setenv NAME value [NAME2 value2 ...]' >&2
     return 1
   fi
 
-  local _count=0
+  _al_count=0
 
-  # Process NAME VALUE pairs.
-  while [ $# -ge 2 ]; do
-    # Stop if the key isn't a valid variable name.
-    if [[ ! "$1" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
-      echo "setenv: invalid variable name: $1" >&2
+  while [ $# -ge 1 ]; do
+    # Skip stray "setenv" tokens (LLMs sometimes repeat the command name
+    # between pairs: `setenv A 1 setenv B 2`).
+    if [ "$1" = "setenv" ]; then
+      shift
+      continue
+    fi
+
+    if [ $# -lt 2 ]; then
+      echo 'usage: setenv NAME value [NAME2 value2 ...]' >&2
       return 1
     fi
-    printf 'export %s=%q\n' "$1" "$2" >> "$_AL_ENV_FILE"
-    export "$1"="$2"
-    _count=$((_count + 1))
+
+    # Validate variable name using case (POSIX replacement for [[ =~ ]]).
+    # Rejects names that start with a non-letter/underscore, or contain
+    # any non-alphanumeric/underscore character.
+    case "$1" in
+      [!a-zA-Z_]* | *[!a-zA-Z0-9_]*)
+        echo "setenv: invalid variable name: $1" >&2
+        return 1
+        ;;
+    esac
+
+    _al_name="$1"
+    _al_value="$2"
     shift 2
+
+    # Write to env file using single-quote escaping (POSIX-safe alternative
+    # to printf %q, which is a bash extension).
+    # Replaces every ' in the value with '\'', then wraps in single quotes.
+    _al_escaped=$(printf '%s' "$_al_value" | sed "s/'/'\\\\''/g")
+    printf "export %s='%s'\n" "$_al_name" "$_al_escaped" >> "$_AL_ENV_FILE"
+
+    # Set the variable in the current shell.
+    # eval with $name=$value (unquoted RHS) is safe: variable assignment
+    # does not perform word-splitting, so spaces are preserved.
+    eval "$_al_name=\$_al_value"
+    export "$_al_name"
+
+    _al_count=$((_al_count + 1))
   done
 
   # Confirm so the agent knows it worked.
-  if [ $_count -eq 1 ]; then
+  if [ "$_al_count" -eq 1 ]; then
     echo "set 1 variable"
   else
-    echo "set $_count variables"
+    echo "set $_al_count variables"
   fi
 }
 

--- a/packages/action-llama/test/agents/al-bash-init.test.ts
+++ b/packages/action-llama/test/agents/al-bash-init.test.ts
@@ -1,9 +1,11 @@
 /**
  * End-to-end tests for al-bash-init.sh and the setenv command.
  *
- * These tests exercise the actual bash flow: source al-bash-init.sh, call setenv,
- * and verify persistence across separate bash -c invocations — exactly how the
+ * These tests exercise the actual shell flow: source al-bash-init.sh, call setenv,
+ * and verify persistence across separate shell invocations — exactly how the
  * agent's bash tool works at runtime.
+ *
+ * Tests run under both bash and sh to ensure POSIX compatibility.
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { spawnSync } from "child_process";
@@ -12,39 +14,46 @@ import { join, resolve, dirname } from "path";
 import { tmpdir } from "os";
 import { fileURLToPath } from "url";
 
+const hasBash = existsSync("/bin/bash") || existsSync("/usr/bin/bash");
+
 const thisDir = dirname(fileURLToPath(import.meta.url));
 const binDir = resolve(thisDir, "../../docker/bin");
 
 /**
- * Run a bash -c command with al-bash-init.sh on PATH, simulating the agent's
+ * Run a shell command with al-bash-init.sh on PATH, simulating the agent's
  * bash tool. Uses spawnSync with an array to preserve literal newlines — this
  * matches how pi-coding-agent's bash tool calls spawn(shell, ["-c", command]).
  */
-function agentBash(command: string, env: Record<string, string> = {}): string {
-  const fullEnv: Record<string, string> = {
-    PATH: `${binDir}:/usr/bin:/bin`,
-    HOME: tmpdir(),
-    ...env,
+function makeRunner(shell: string) {
+  return function runShell(command: string, env: Record<string, string> = {}): string {
+    const fullEnv: Record<string, string> = {
+      PATH: `${binDir}:/usr/bin:/bin`,
+      HOME: tmpdir(),
+      ...env,
+    };
+    // Simulate the commandPrefix + agent command (newline between prefix and command)
+    const prefixedCommand = `. al-bash-init.sh\n${command}`;
+    const result = spawnSync(shell, ["-c", prefixedCommand], {
+      encoding: "utf-8",
+      env: fullEnv,
+      timeout: 5000,
+    });
+    if (result.error) throw result.error;
+    const combined = (result.stdout || "") + (result.stderr || "");
+    if (result.status !== 0) {
+      const err = new Error(`${shell} exited with ${result.status}: ${combined}`);
+      (err as any).stdout = result.stdout;
+      (err as any).stderr = result.stderr;
+      throw err;
+    }
+    return result.stdout.trim();
   };
-  // Simulate the commandPrefix + agent command (newline between prefix and command)
-  const prefixedCommand = `. al-bash-init.sh\n${command}`;
-  const result = spawnSync("bash", ["-c", prefixedCommand], {
-    encoding: "utf-8",
-    env: fullEnv,
-    timeout: 5000,
-  });
-  if (result.error) throw result.error;
-  const combined = (result.stdout || "") + (result.stderr || "");
-  if (result.status !== 0) {
-    const err = new Error(`bash exited with ${result.status}: ${combined}`);
-    (err as any).stdout = result.stdout;
-    (err as any).stderr = result.stderr;
-    throw err;
-  }
-  return result.stdout.trim();
 }
 
-describe("al-bash-init.sh", () => {
+const agentBash = makeRunner("bash");
+const agentSh = makeRunner("sh");
+
+describe.skipIf(!hasBash)("al-bash-init.sh (bash)", () => {
   let workDir: string;
   let envFile: string;
 
@@ -192,6 +201,132 @@ describe("al-bash-init.sh", () => {
 
       const outB = agentBash('echo "A=$INSTANCE_A B=$INSTANCE_B"', { AL_ENV_FILE: envFile2 });
       expect(outB).toBe("A= B=yes");
+    });
+  });
+});
+
+describe("al-bash-init.sh (sh compatibility)", () => {
+  let workDir: string;
+  let envFile: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "al-bash-init-sh-test-"));
+    envFile = join(workDir, ".env.sh");
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  describe("setenv under sh", () => {
+    it("sets a variable in the current shell", () => {
+      const out = agentSh(
+        'setenv REPO "Action-Llama/action-llama"\necho "REPO=$REPO"',
+        { AL_ENV_FILE: envFile },
+      );
+      expect(out).toContain("set 1 variable");
+      expect(out).toContain("REPO=Action-Llama/action-llama");
+    });
+
+    it("persists variables across separate sh invocations", () => {
+      agentSh(
+        'setenv REPO "Action-Llama/action-llama"',
+        { AL_ENV_FILE: envFile },
+      );
+
+      const out = agentSh(
+        'echo "REPO=$REPO"',
+        { AL_ENV_FILE: envFile },
+      );
+      expect(out).toBe("REPO=Action-Llama/action-llama");
+    });
+
+    it("handles multiple key-value pairs in a single call", () => {
+      const out = agentSh(
+        'setenv REPO "Action-Llama/action-llama" ISSUE_NUMBER 473\necho "REPO=$REPO ISSUE=$ISSUE_NUMBER"',
+        { AL_ENV_FILE: envFile },
+      );
+      expect(out).toContain("set 2 variables");
+      expect(out).toContain("REPO=Action-Llama/action-llama ISSUE=473");
+    });
+
+    it("tolerates stray 'setenv' tokens between pairs (LLM quirk)", () => {
+      const out = agentSh(
+        'setenv REPO val1 setenv NUM 42\necho "REPO=$REPO NUM=$NUM"',
+        { AL_ENV_FILE: envFile },
+      );
+      expect(out).toContain("set 2 variables");
+      expect(out).toContain("REPO=val1 NUM=42");
+    });
+
+    it("writes the env file to the configured AL_ENV_FILE path", () => {
+      agentSh(
+        'setenv MY_VAR hello',
+        { AL_ENV_FILE: envFile },
+      );
+      expect(existsSync(envFile)).toBe(true);
+      const content = readFileSync(envFile, "utf-8");
+      expect(content).toContain("MY_VAR");
+      expect(content).toContain("hello");
+    });
+
+    it("accumulates variables across multiple calls", () => {
+      agentSh('setenv A 1', { AL_ENV_FILE: envFile });
+      agentSh('setenv B 2', { AL_ENV_FILE: envFile });
+      agentSh('setenv C 3', { AL_ENV_FILE: envFile });
+
+      const out = agentSh(
+        'echo "A=$A B=$B C=$C"',
+        { AL_ENV_FILE: envFile },
+      );
+      expect(out).toBe("A=1 B=2 C=3");
+    });
+
+    it("handles values with spaces", () => {
+      agentSh(
+        'setenv MSG "hello world"',
+        { AL_ENV_FILE: envFile },
+      );
+
+      const out = agentSh(
+        'echo "$MSG"',
+        { AL_ENV_FILE: envFile },
+      );
+      expect(out).toContain("hello world");
+    });
+
+    it("handles values with special characters (URLs)", () => {
+      agentSh(
+        'setenv URL "https://example.com/path?q=1&r=2"',
+        { AL_ENV_FILE: envFile },
+      );
+
+      const out = agentSh(
+        'echo "$URL"',
+        { AL_ENV_FILE: envFile },
+      );
+      expect(out).toContain("https://example.com/path?q=1&r=2");
+    });
+
+    it("rejects invalid variable names", () => {
+      try {
+        const out = agentSh(
+          'setenv "123invalid" value 2>&1',
+          { AL_ENV_FILE: envFile },
+        );
+        expect(out).toContain("invalid variable name");
+      } catch {
+        // Non-zero exit is also acceptable
+      }
+    });
+
+    it("prints usage error when called with no arguments", () => {
+      try {
+        const out = agentSh('setenv 2>&1', { AL_ENV_FILE: envFile });
+        expect(out).toContain("usage:");
+      } catch (e: any) {
+        expect(e.stderr?.toString() || e.stdout?.toString() || "").toContain("usage:");
+      }
     });
   });
 });


### PR DESCRIPTION
Closes #525

## Problem

`setenv` failed silently in host-user runtimes where only `/bin/sh` (BusyBox/dash) is available instead of bash. The script used bash-specific constructs:
- `local args=()` / `args+=()` / `"${args[@]}"` — bash arrays
- `[[ =~ ]]` — bash regex conditional
- `printf %q` — bash extension

When sourced in `sh`, the syntax errors silently and `setenv` is never defined.

## Fix

Rewrote `packages/action-llama/docker/bin/al-bash-init.sh` using only POSIX-compatible syntax:
- Replaced bash arrays with in-loop `shift` to skip stray `setenv` tokens
- Replaced `[[ =~ ]]` with `case` glob pattern for variable name validation
- Replaced `printf %q` with single-quote escaping via `sed` for the env file
- Replaced `local` vars with `_al_`-prefixed names to avoid namespace pollution
- Uses `eval "$name=$value"` + `export "$name"` for safe variable setting

## Tests

Added a new `describe("al-bash-init.sh (sh compatibility)")` block that runs the core test cases under `/bin/sh`. The existing bash tests are now wrapped in `describe.skipIf(!hasBash)` so they're skipped gracefully in environments without bash (like the agent runtime itself) while still running in CI environments that have bash.