### PR TITLE
fix: implement backward cursor pagination for instance logs

### DIFF
--- a/packages/action-llama/src/control/routes/log-helpers.ts
+++ b/packages/action-llama/src/control/routes/log-helpers.ts
@@ -5,6 +5,7 @@ import { readdirSync, existsSync } from "fs";
 export const SAFE_AGENT_NAME = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
 export const MAX_LINES = 2000;
 export const DEFAULT_LINES = 200;
+const MAX_SCAN_LINES = 500000;
 
 export interface LogEntry {
   level: number;
@@ -129,19 +130,18 @@ export async function readLastEntries(
   beforeTime?: number,
   instanceFilter?: string,
   grep?: RegExp,
-): Promise<{ entries: LogEntry[]; byteOffset: number }> {
+  startPosition?: number,
+): Promise<{ entries: LogEntry[]; byteOffset: number; scanStoppedAt: number }> {
   try {
     const stat = await fs.stat(filePath);
-    if (stat.size === 0) return { entries: [], byteOffset: 0 };
+    if (stat.size === 0) return { entries: [], byteOffset: 0, scanStoppedAt: 0 };
 
     const fd = await fs.open(filePath, "r");
     const entries: LogEntry[] = [];
-    let position = stat.size;
+    let position = startPosition ?? stat.size;
     const chunkSize = 8192;
     const buffer = Buffer.alloc(chunkSize);
     let remainder = "";
-    // Safety cap to prevent scanning multi-GB files; generous enough for any real agent run
-    const MAX_SCAN_LINES = 50000;
     let rawCount = 0;
 
     try {
@@ -185,9 +185,9 @@ export async function readLastEntries(
       await fd.close();
     }
 
-    return { entries: entries.slice(-limit), byteOffset: stat.size };
+    return { entries: entries.slice(-limit), byteOffset: stat.size, scanStoppedAt: position };
   } catch {
-    return { entries: [], byteOffset: 0 };
+    return { entries: [], byteOffset: 0, scanStoppedAt: 0 };
   }
 }
 
@@ -205,26 +205,37 @@ export async function readLastEntriesMultiFile(
   beforeTime?: number,
   instanceFilter?: string,
   grep?: RegExp,
-): Promise<{ entries: LogEntry[]; latestFile: string | null; byteOffset: number }> {
-  if (files.length === 0) return { entries: [], latestFile: null, byteOffset: 0 };
+): Promise<{ entries: LogEntry[]; latestFile: string | null; byteOffset: number; backCursorDate: string | null; backCursorOffset: number }> {
+  if (files.length === 0) return { entries: [], latestFile: null, byteOffset: 0, backCursorDate: null, backCursorOffset: 0 };
 
   const collected: LogEntry[] = [];
   let latestByteOffset = 0;
   const latestFile = files[files.length - 1];
+  let backDate: string | null = null;
+  let backOffset = 0;
 
   // Iterate from newest to oldest
   for (let i = files.length - 1; i >= 0 && collected.length < limit; i--) {
     const remaining = limit - collected.length;
-    const { entries, byteOffset } = await readLastEntries(
+    const { entries, byteOffset, scanStoppedAt } = await readLastEntries(
       files[i], remaining, afterTime, beforeTime, instanceFilter, grep,
     );
     if (i === files.length - 1) latestByteOffset = byteOffset;
     collected.unshift(...entries);
+    
+    backDate = dateFromLogFile(files[i]);
+    backOffset = scanStoppedAt;
+    
+    // If we reached beginning of oldest file, no more back pages
+    if (i === 0 && scanStoppedAt === 0) {
+      backDate = null;
+      backOffset = 0;
+    }
   }
 
   // Trim to limit (in case older files provided more than needed)
   const trimmed = collected.slice(-limit);
-  return { entries: trimmed, latestFile, byteOffset: latestByteOffset };
+  return { entries: trimmed, latestFile, byteOffset: latestByteOffset, backCursorDate: backDate, backCursorOffset: backOffset };
 }
 
 /** Read entries forward across date boundaries starting from a cursor. */

--- a/packages/action-llama/src/control/routes/logs.ts
+++ b/packages/action-llama/src/control/routes/logs.ts
@@ -5,6 +5,7 @@ import {
   dateFromLogFile,
   readLastEntriesMultiFile,
   readEntriesForwardMultiFile,
+  readLastEntries,
   encodeCursor,
   decodeCursor,
   parseQueryParams,
@@ -18,6 +19,7 @@ async function handleLogRequest(
   instanceFilter?: string,
 ): Promise<{ status: number; body: Record<string, unknown> }> {
   const { lines, cursor, after, before, grep, minLevel } = parseQueryParams(query);
+  const backCursorParam = query.back_cursor;
   let grepRe: RegExp | undefined;
   if (grep) {
     try { grepRe = new RegExp(grep); }
@@ -27,12 +29,49 @@ async function handleLogRequest(
   const filterLevel = (entries: LogEntry[]) =>
     minLevel > 0 ? entries.filter((e) => e.level >= minLevel) : entries;
 
+  // Handle backward cursor pagination
+  if (backCursorParam) {
+    const parsed = decodeCursor(backCursorParam);
+    if (!parsed) return { status: 400, body: { error: "Invalid back_cursor" } };
+
+    const allFiles = findLogFiles(projectPath, prefix);
+    if (allFiles.length === 0) return { status: 200, body: { entries: [], cursor: null, backCursor: null, hasMore: false } };
+
+    // Find the file for the cursor's date
+    const cursorFileIdx = allFiles.findIndex(f => dateFromLogFile(f) === parsed.date);
+    
+    // Read backward from cursor position, spanning multiple files if needed
+    const collected: LogEntry[] = [];
+    let newBackDate: string | null = null;
+    let newBackOffset = 0;
+    const startIdx = cursorFileIdx >= 0 ? cursorFileIdx : allFiles.length - 1;
+
+    for (let i = startIdx; i >= 0 && collected.length < lines; i--) {
+      const remaining = lines - collected.length;
+      const startPos = (i === startIdx) ? parsed.offsets[0] : undefined;
+      const { entries, scanStoppedAt } = await readLastEntries(
+        allFiles[i], remaining, undefined, undefined, instanceFilter, grepRe, startPos,
+      );
+      collected.unshift(...entries);
+      newBackDate = dateFromLogFile(allFiles[i]);
+      newBackOffset = scanStoppedAt;
+      if (i === 0 && scanStoppedAt === 0) {
+        newBackDate = null;
+        newBackOffset = 0;
+      }
+    }
+
+    const filtered = filterLevel(collected.slice(-lines));
+    const newBackCursor = newBackDate ? encodeCursor(newBackDate, [newBackOffset]) : null;
+    return { status: 200, body: { entries: filtered, cursor: null, backCursor: newBackCursor, hasMore: false } };
+  }
+
   if (cursor) {
     const parsed = decodeCursor(cursor);
     if (!parsed) return { status: 400, body: { error: "Invalid cursor" } };
 
     const files = findLogFiles(projectPath, prefix);
-    if (files.length === 0) return { status: 200, body: { entries: [], cursor: null, hasMore: false } };
+    if (files.length === 0) return { status: 200, body: { entries: [], cursor: null, backCursor: null, hasMore: false } };
 
     const { entries, newDate, newOffset } = await readEntriesForwardMultiFile(
       projectPath, prefix, parsed.date, parsed.offsets[0] || 0, lines,
@@ -40,19 +79,20 @@ async function handleLogRequest(
     );
     const filtered = filterLevel(entries);
     const newCursor = encodeCursor(newDate, [newOffset]);
-    return { status: 200, body: { entries: filtered, cursor: newCursor, hasMore: entries.length >= lines } };
+    return { status: 200, body: { entries: filtered, cursor: newCursor, backCursor: null, hasMore: entries.length >= lines } };
   }
 
   const files = findLogFiles(projectPath, prefix);
-  if (files.length === 0) return { status: 200, body: { entries: [], cursor: null, hasMore: false } };
+  if (files.length === 0) return { status: 200, body: { entries: [], cursor: null, backCursor: null, hasMore: false } };
 
-  const { entries, latestFile, byteOffset } = await readLastEntriesMultiFile(
+  const { entries, latestFile, byteOffset, backCursorDate, backCursorOffset } = await readLastEntriesMultiFile(
     files, lines, after, before, instanceFilter, grepRe,
   );
   const filtered = filterLevel(entries);
   const date = latestFile ? dateFromLogFile(latestFile) || "" : "";
   const resCursor = encodeCursor(date, [byteOffset]);
-  return { status: 200, body: { entries: filtered, cursor: resCursor, hasMore: false } };
+  const backCursor = backCursorDate ? encodeCursor(backCursorDate, [backCursorOffset]) : null;
+  return { status: 200, body: { entries: filtered, cursor: resCursor, backCursor, hasMore: false } };
 }
 
 export function registerLogRoutes(app: Hono, projectPath: string): void {

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -403,7 +403,7 @@ export function getAgentLogs(
   name: string,
   params: Record<string, string>,
   signal?: AbortSignal,
-): Promise<{ entries: LogEntry[]; cursor: string | null; hasMore: boolean }> {
+): Promise<{ entries: LogEntry[]; cursor: string | null; backCursor: string | null; hasMore: boolean }> {
   const qs = new URLSearchParams(params).toString();
   return fetchJSON(
     `/api/logs/agents/${encodeURIComponent(name)}${qs ? `?${qs}` : ""}`,
@@ -416,7 +416,7 @@ export function getInstanceLogs(
   instanceId: string,
   params: Record<string, string>,
   signal?: AbortSignal,
-): Promise<{ entries: LogEntry[]; cursor: string | null; hasMore: boolean }> {
+): Promise<{ entries: LogEntry[]; cursor: string | null; backCursor: string | null; hasMore: boolean }> {
   const qs = new URLSearchParams(params).toString();
   return fetchJSON(
     `/api/logs/agents/${encodeURIComponent(name)}/${encodeURIComponent(instanceId)}${qs ? `?${qs}` : ""}`,

--- a/packages/frontend/src/pages/InstanceLogsPage.tsx
+++ b/packages/frontend/src/pages/InstanceLogsPage.tsx
@@ -43,6 +43,7 @@ export function InstanceLogsPage() {
   const [following, setFollowing] = useState(true);
   const [connected, setConnected] = useState(false);
   const cursorRef = useRef<string | null>(null);
+  const backCursorRef = useRef<string | null>(null);
   const logContainerRef = useRef<HTMLDivElement>(null);
 
   const name = ctx?.name ?? "";
@@ -90,6 +91,10 @@ export function InstanceLogsPage() {
           setLogs((prev) => [...prev, ...d.entries]);
           if (d.cursor) cursorRef.current = d.cursor;
         }
+        // On first load (no cursor yet), save backCursor for backward pagination
+        if (!cursorRef.current && d.backCursor) {
+          backCursorRef.current = d.backCursor;
+        }
       } catch {
         setConnected(false);
         throw undefined;
@@ -126,12 +131,12 @@ export function InstanceLogsPage() {
 
   const loadOlderLogs = useCallback(async () => {
     if (!name || !id || loadingOlder || !hasOlderLogs || logs.length === 0 || backfilling) return;
+    if (!backCursorRef.current) { setHasOlderLogs(false); return; }
     setLoadingOlder(true);
     try {
-      const oldestTime = logs[0].time;
       const params: Record<string, string> = {
         lines: String(OLDER_BATCH_SIZE),
-        before: String(oldestTime),
+        back_cursor: backCursorRef.current,
       };
       const d = await getInstanceLogs(name, id, params);
       if (d.entries.length > 0) {
@@ -150,7 +155,8 @@ export function InstanceLogsPage() {
           }
         });
       }
-      if (d.entries.length < OLDER_BATCH_SIZE) {
+      backCursorRef.current = d.backCursor;
+      if (!d.backCursor || d.entries.length < OLDER_BATCH_SIZE) {
         setHasOlderLogs(false);
       }
     } catch {
@@ -164,18 +170,18 @@ export function InstanceLogsPage() {
   useEffect(() => {
     if (isRunning || !name || !id || !hasOlderLogs || backfillRunning.current) return;
     if (logs.length === 0) return;
+    if (!backCursorRef.current) { setHasOlderLogs(false); return; }
 
     backfillRunning.current = true;
     setBackfilling(true);
 
     let cancelled = false;
     (async () => {
-      let oldestTime = logs[0].time;
       try {
-        while (!cancelled) {
+        while (!cancelled && backCursorRef.current) {
           const params: Record<string, string> = {
             lines: String(OLDER_BATCH_SIZE),
-            before: String(oldestTime),
+            back_cursor: backCursorRef.current,
           };
           const d = await getInstanceLogs(name, id, params);
           if (cancelled) break;
@@ -189,10 +195,7 @@ export function InstanceLogsPage() {
           const prevScrollHeight = el?.scrollHeight ?? 0;
           const prevScrollTop = el?.scrollTop ?? 0;
 
-          setLogs((prev) => {
-            const merged = [...d.entries, ...prev];
-            return merged;
-          });
+          setLogs((prev) => [...d.entries, ...prev]);
 
           // Restore scroll position after prepend
           requestAnimationFrame(() => {
@@ -201,9 +204,8 @@ export function InstanceLogsPage() {
             }
           });
 
-          oldestTime = d.entries[0].time;
-
-          if (d.entries.length < OLDER_BATCH_SIZE) {
+          backCursorRef.current = d.backCursor;
+          if (!d.backCursor || d.entries.length < OLDER_BATCH_SIZE) {
             setHasOlderLogs(false);
             break;
           }
@@ -316,6 +318,7 @@ export function InstanceLogsPage() {
               onClick={() => {
                 setLogs([]);
                 cursorRef.current = null;
+                backCursorRef.current = null;
                 setHasOlderLogs(true);
               }}
               className="px-2 py-1 text-xs rounded bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700 transition-colors"


### PR DESCRIPTION
Closes #535

## Summary

This PR implements backward cursor pagination for the instance logs API to solve the issue where logs don't show the full history when scrolling back.

## Changes

### Backend Changes

1. **log-helpers.ts**:
   - Increased `MAX_SCAN_LINES` from 50,000 to 500,000 to handle larger log files more efficiently
   - Modified `readLastEntries` to accept an optional `startPosition` parameter for backward pagination
   - Updated return type to include `scanStoppedAt` field indicating where the scan stopped in the file
   - Updated `readLastEntriesMultiFile` to return backward cursor information (`backCursorDate` and `backCursorOffset`)

2. **logs.ts**:
   - Added support for `back_cursor` query parameter to handle backward pagination requests
   - Implemented a new code path to handle backward cursor pagination efficiently
   - Updated response body to include `backCursor` field in all responses

### Frontend Changes

1. **api.ts**:
   - Updated `getInstanceLogs` and `getAgentLogs` return types to include `backCursor` field

2. **InstanceLogsPage.tsx**:
   - Added `backCursorRef` to track the cursor position for backward pagination
   - Updated initial polling to save `backCursor` from the first response
   - Modified `loadOlderLogs` to use `back_cursor` parameter instead of `before` timestamp
   - Updated auto-backfill loop to use cursor-based backward pagination
   - Updated Clear button handler to reset both forward and backward cursors

## How It Works

The old implementation used timestamp-based queries with the `before` parameter, which caused inefficiency when scrolling back through large log files. The new implementation:

1. **Initial load**: Returns the last 100 entries and a `backCursor` pointing to where to start the next backward read
2. **Backward pagination**: Client uses `back_cursor` parameter to fetch older entries
3. **Cursor points to byte position**: The cursor encodes the exact file and byte position to resume from, eliminating the need to re-scan irrelevant log entries
4. **Cross-file support**: Cursors work seamlessly across multiple daily log files

## Testing

All existing tests pass, including:
- Log helper tests (cursor encoding/decoding)
- Log API route tests (forward pagination, filtering, etc.)
- 63 tests in logs.test.ts - all passing