### PR TITLE
Fix: merge gateway and scheduler logs, show summary generation errors

### DIFF
--- a/.changeset/fix-generate-500.md
+++ b/.changeset/fix-generate-500.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Merge gateway and scheduler log files into a single log so `al logs` shows all system messages. Show error feedback in the dashboard when summary generation fails instead of silently swallowing errors. Closes #533.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "action-llama",
+  "name": "repo",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packages/action-llama/src/scheduler/gateway-setup.ts
+++ b/packages/action-llama/src/scheduler/gateway-setup.ts
@@ -14,7 +14,6 @@ import type { StatusTracker } from "../tui/status-tracker.js";
 import type { StateStore } from "../shared/state-store.js";
 import type { StatsStore } from "../stats/store.js";
 import type { Logger } from "../shared/logger.js";
-import { createLogger, createFileOnlyLogger } from "../shared/logger.js";
 import { ensureGatewayApiKey, loadGatewayApiKey } from "../control/api-key.js";
 import type { SchedulerEventBus } from "./events.js";
 import type { SchedulerState } from "./state.js";
@@ -45,7 +44,6 @@ export async function setupGateway(opts: {
   statsStore?: StatsStore;
   events: SchedulerEventBus;
   telemetry?: any;
-  mkLogger: typeof createLogger | typeof createFileOnlyLogger;
   statusTracker?: StatusTracker;
   webUI?: boolean;
   expose?: boolean;
@@ -54,7 +52,7 @@ export async function setupGateway(opts: {
   const {
     projectPath, globalConfig, state, agentConfigs,
     webhookRegistry, webhookSecrets, webhookConfigs, stateStore, statsStore, events, telemetry,
-    mkLogger, statusTracker, webUI, expose, logger,
+    statusTracker, webUI, expose, logger,
   } = opts;
 
   // Ensure gateway API key exists (fallback generation if doctor wasn't run)
@@ -86,7 +84,7 @@ export async function setupGateway(opts: {
   const gateway = await startGateway({
     port: gatewayPort,
     hostname: expose ? "0.0.0.0" : "127.0.0.1",
-    logger: mkLogger(projectPath, "gateway"),
+    logger,
     killContainer: undefined,
     webhookRegistry,
     webhookSecrets,

--- a/packages/action-llama/src/scheduler/index.ts
+++ b/packages/action-llama/src/scheduler/index.ts
@@ -83,7 +83,7 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
   const { gateway, gatewayPort, registerContainer, unregisterContainer, setChatRuntime } = await setupGateway({
     projectPath, globalConfig, state, agentConfigs,
     webhookRegistry, webhookSecrets, webhookConfigs: webhookSources, stateStore, statsStore, events, telemetry,
-    mkLogger, statusTracker, webUI, expose, logger,
+    statusTracker, webUI, expose, logger,
   });
 
   // Register webhook bindings early (before Docker builds) so incoming webhooks are queued

--- a/packages/frontend/src/components/ActivityTable.tsx
+++ b/packages/frontend/src/components/ActivityTable.tsx
@@ -78,6 +78,7 @@ const ActivityTableRow = memo(function ActivityTableRow({
   // Per-row state — only this row re-renders when its summary changes
   const [isLoading, setIsLoading] = useState(false);
   const [localSummary, setLocalSummary] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const [collapsed, setCollapsed] = useState(false);
   const [mobileExpanded, setMobileExpanded] = useState(false);
 
@@ -97,13 +98,15 @@ const ActivityTableRow = memo(function ActivityTableRow({
   const handleGenerate = async () => {
     if (!row.agentName || !instanceId) return;
     setIsLoading(true);
+    setError(null);
     try {
       const result = await summarizeLogs(row.agentName, instanceId);
       if (result.summary) {
         setLocalSummary(result.summary);
       }
-    } catch {
-      // silently ignore errors
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to generate summary";
+      setError(message);
     } finally {
       setIsLoading(false);
     }
@@ -173,6 +176,10 @@ const ActivityTableRow = memo(function ActivityTableRow({
       {isLoading ? (
         <span className="text-xs text-slate-400 dark:text-slate-500 animate-pulse">
           Generating…
+        </span>
+      ) : error ? (
+        <span className="text-xs text-red-500 dark:text-red-400" title={error}>
+          Failed to generate — {error}
         </span>
       ) : effectiveSummary ? (
         <div className="flex items-start gap-1.5">
@@ -253,6 +260,10 @@ const ActivityTableRow = memo(function ActivityTableRow({
                 <span className="text-xs text-slate-400 dark:text-slate-500 animate-pulse">
                   Generating…
                 </span>
+              ) : error ? (
+                <span className="text-xs text-red-500 dark:text-red-400" title={error}>
+                  Failed to generate
+                </span>
               ) : effectiveSummary ? (
                 <div>
                   <button
@@ -315,6 +326,7 @@ const ActivityRowItem = memo(function ActivityRowItem({ row, agentNames }: Activ
   // Per-row UI state
   const [isLoading, setIsLoading] = useState(false);
   const [localSummary, setLocalSummary] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [isMobileExpanded, setIsMobileExpanded] = useState(false);
 
@@ -328,11 +340,13 @@ const ActivityRowItem = memo(function ActivityRowItem({ row, agentNames }: Activ
   const handleGenerate = useCallback(async () => {
     if (!row.agentName || !instanceId) return;
     setIsLoading(true);
+    setError(null);
     try {
       const result = await summarizeLogs(row.agentName, instanceId);
       if (result.summary) setLocalSummary(result.summary);
-    } catch {
-      // silently ignore
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to generate summary";
+      setError(message);
     } finally {
       setIsLoading(false);
     }
@@ -431,6 +445,10 @@ const ActivityRowItem = memo(function ActivityRowItem({ row, agentNames }: Activ
                 <span className="text-xs text-slate-400 dark:text-slate-500 animate-pulse">
                   Generating…
                 </span>
+              ) : error ? (
+                <span className="text-xs text-red-500 dark:text-red-400" title={error}>
+                  Failed to generate
+                </span>
               ) : effectiveSummary ? (
                 <div>
                   <button
@@ -475,6 +493,10 @@ const ActivityRowItem = memo(function ActivityRowItem({ row, agentNames }: Activ
         {isLoading ? (
           <span className="text-xs text-slate-400 dark:text-slate-500 animate-pulse">
             Generating…
+          </span>
+        ) : error ? (
+          <span className="text-xs text-red-500 dark:text-red-400" title={error}>
+            Failed to generate — {error}
           </span>
         ) : effectiveSummary ? (
           <div className="flex items-start gap-1.5">


### PR DESCRIPTION
Closes #533

## Changes

1. **Merged gateway and scheduler logs** - The gateway now uses the same logger as the scheduler, so both systems write to the same log file. This means `al logs` will show all system messages without needing to check `al logs gateway` separately.

2. **Show error feedback in dashboard** - When summary generation fails on the "Generate" button, the error message is now displayed to the user in red text instead of being silently ignored.

## Implementation Details

- **gateway-setup.ts**: Removed separate `mkLogger` call for gateway; now uses the scheduler's logger directly
- **index.ts**: Removed `mkLogger` parameter from `setupGateway` call  
- **ActivityTable.tsx**: Added error state tracking and UI feedback for both desktop and mobile views

## Testing

All existing tests pass. The changes maintain backward compatibility while improving the user experience when summarization fails.