### PR TITLE
Fix webhook and cron setup when agent is re-enabled

### DIFF
--- a/.changeset/tidy-roses-judge.md
+++ b/.changeset/tidy-roses-judge.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fix webhook and cron setup when agent is re-enabled (scale 0→N transition). Previously, when an agent config had scale=0 and was later changed to scale>0, webhooks and cron jobs were not created. Now handleChangedAgent() properly detects the 0→N and N→0 transitions and sets up or tears down resources accordingly.

--- a/packages/action-llama/src/scheduler/watcher.ts
+++ b/packages/action-llama/src/scheduler/watcher.ts
@@ -364,6 +364,73 @@ export function watchAgents(ctx: HotReloadContext): WatcherHandle {
     }
     ctx.agentImages[agentName] = image;
 
+    // Handle scale 0 → N transition: need to create pool, runners, cron, webhooks
+    // (similar to handleNewAgent but for an existing config entry)
+    if (oldScale === 0 && newScale > 0) {
+      const runners: PoolRunner[] = [];
+      for (let i = 0; i < newScale; i++) {
+        runners.push(ctx.createRunner(newConfig, image));
+      }
+      const pool = new RunnerPool(runners);
+      ctx.runnerPools[agentName] = pool;
+
+      ctx.statusTracker?.updateAgentScale(agentName, newScale);
+
+      // Set up cron
+      if (newConfig.schedule) {
+        const job = new Cron(newConfig.schedule, { timezone: ctx.timezone }, async () => {
+          if (ctx.statusTracker && !ctx.statusTracker.isAgentEnabled(agentName)) return;
+          const runner = pool.getAvailableRunner();
+          if (!runner) {
+            const { dropped } = ctx.schedulerCtx.workQueue.enqueue(agentName, { type: 'schedule' });
+            ctx.logger.info({ agent: agentName }, "all runners busy, scheduled run queued");
+            if (dropped) ctx.logger.warn({ agent: agentName }, "queue full, oldest event dropped");
+            return;
+          }
+          await runWithReruns(runner, newConfig, 0, ctx.schedulerCtx);
+        });
+        ctx.cronJobs.push(job);
+        const nextRun = job.nextRun();
+        if (nextRun) ctx.statusTracker?.setNextRunAt(agentName, nextRun);
+      }
+
+      // Set up webhooks
+      if (ctx.webhookRegistry) {
+        registerWebhookBindings({
+          agentConfig: newConfig,
+          webhookRegistry: ctx.webhookRegistry,
+          webhookSources: ctx.webhookSources,
+          onTrigger: buildWebhookTrigger(pool, ctx),
+          logger: ctx.logger,
+        });
+      }
+
+      ctx.statusTracker?.setAgentState(agentName, "idle");
+      ctx.statusTracker?.addLogLine(agentName, "hot-reloaded (activated from scale=0)");
+      ctx.logger.info({ agent: agentName, scale: newScale }, "hot reload: agent activated from scale=0");
+      return;
+    }
+
+    // Handle scale N → 0 transition: tear down pool, cron, webhooks
+    if (oldScale > 0 && newScale === 0) {
+      const pool = ctx.runnerPools[agentName];
+      if (pool) {
+        pool.killAll();
+        delete ctx.runnerPools[agentName];
+      }
+
+      rebuildCronJobs(agentName);
+      ctx.statusTracker?.setNextRunAt(agentName, null);
+
+      ctx.webhookRegistry?.removeBindingsForAgent(agentName);
+
+      ctx.statusTracker?.updateAgentScale(agentName, 0);
+      ctx.statusTracker?.setAgentState(agentName, "idle");
+      ctx.statusTracker?.addLogLine(agentName, "hot-reloaded (deactivated to scale=0)");
+      ctx.logger.info({ agent: agentName }, "hot reload: agent deactivated (scale=0)");
+      return;
+    }
+
     // Update existing runners with new image, config, and runtime (if changed)
     const pool = ctx.runnerPools[agentName];
     if (pool) {

--- a/packages/action-llama/test/scheduler/watcher.test.ts
+++ b/packages/action-llama/test/scheduler/watcher.test.ts
@@ -1390,4 +1390,176 @@ describe("watchAgents handler (via _handleAgentChange)", () => {
       "hot reload: reverted to container runtime"
     );
   });
+
+  // ── handleChangedAgent: scale 0→N transition ─────────────────────────────
+
+  it("handles changed agent: scale 0→N creates pool, runners, cron, and webhooks", async () => {
+    // Start with an agent config at scale=0 with no pool
+    const disabledConfig = makeAgentConfig("agent-a", { scale: 0, schedule: "0 * * * *" });
+    const ctx = makeContext({
+      agentConfigs: [disabledConfig],
+      runnerPools: {}, // No pool for agent-a since scale=0
+    });
+
+    // Re-enable agent to scale=3
+    const enabledConfig = makeAgentConfig("agent-a", { scale: 3, schedule: "0 * * * *" });
+    mockedDiscoverAgents.mockReturnValue(["agent-a"]);
+    mockedLoadAgentConfig.mockReturnValue(enabledConfig);
+    mockedBuildSingleAgentImage.mockResolvedValue("agent-a:v1");
+
+    const handle = watchAgents(ctx);
+    await handle._handleAgentChange("agent-a");
+
+    // Pool should now exist with 3 runners
+    expect(ctx.runnerPools["agent-a"]).toBeInstanceOf(RunnerPool);
+    expect(ctx.runnerPools["agent-a"]!.size).toBe(3);
+    expect(ctx.createRunner).toHaveBeenCalledTimes(3);
+
+    // Cron job should be created since schedule exists
+    expect(ctx.cronJobs.length).toBeGreaterThan(0);
+    expect(ctx.statusTracker!.setNextRunAt).toHaveBeenCalled();
+
+    // Webhooks should be registered
+    expect(mockedRegisterWebhookBindings).toHaveBeenCalled();
+
+    // Status should be updated
+    expect(ctx.statusTracker!.updateAgentScale).toHaveBeenCalledWith("agent-a", 3);
+    expect(ctx.statusTracker!.setAgentState).toHaveBeenCalledWith("agent-a", "idle");
+    expect(ctx.statusTracker!.addLogLine).toHaveBeenCalledWith(
+      "agent-a",
+      "hot-reloaded (activated from scale=0)"
+    );
+    expect(ctx.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: "agent-a", scale: 3 }),
+      "hot reload: agent activated from scale=0"
+    );
+  });
+
+  it("handles changed agent: scale 0→N without schedule (no cron)", async () => {
+    const disabledConfig = makeAgentConfig("agent-a", { scale: 0, schedule: undefined });
+    const ctx = makeContext({
+      agentConfigs: [disabledConfig],
+      runnerPools: {},
+    });
+
+    const enabledConfig = makeAgentConfig("agent-a", { scale: 2, schedule: undefined });
+    mockedDiscoverAgents.mockReturnValue(["agent-a"]);
+    mockedLoadAgentConfig.mockReturnValue(enabledConfig);
+    mockedBuildSingleAgentImage.mockResolvedValue("agent-a:v1");
+
+    const handle = watchAgents(ctx);
+    await handle._handleAgentChange("agent-a");
+
+    // Pool should exist with 2 runners
+    expect(ctx.runnerPools["agent-a"]!.size).toBe(2);
+
+    // No cron job should be created since schedule is undefined
+    expect(ctx.statusTracker!.setNextRunAt).not.toHaveBeenCalled();
+
+    // Webhooks should still be registered if webhookRegistry exists
+    expect(mockedRegisterWebhookBindings).toHaveBeenCalled();
+  });
+
+  it("handles changed agent: scale 0→N with webhooks registers bindings", async () => {
+    const disabledConfig = makeAgentConfig("agent-a", { scale: 0, webhooks: [{ source: "github", trigger: { event: "push" } }] });
+    const ctx = makeContext({
+      agentConfigs: [disabledConfig],
+      runnerPools: {},
+    });
+
+    const enabledConfig = makeAgentConfig("agent-a", { scale: 1, webhooks: [{ source: "github", trigger: { event: "push" } }] });
+    mockedDiscoverAgents.mockReturnValue(["agent-a"]);
+    mockedLoadAgentConfig.mockReturnValue(enabledConfig);
+    mockedBuildSingleAgentImage.mockResolvedValue("agent-a:v1");
+
+    const handle = watchAgents(ctx);
+    await handle._handleAgentChange("agent-a");
+
+    // Pool should exist
+    expect(ctx.runnerPools["agent-a"]).toBeInstanceOf(RunnerPool);
+
+    // registerWebhookBindings should have been called with the enabled agent
+    expect(mockedRegisterWebhookBindings).toHaveBeenCalled();
+  });
+
+  // ── handleChangedAgent: scale N→0 transition ─────────────────────────────
+
+  it("handles changed agent: scale N→0 tears down pool, cron, and webhooks", async () => {
+    // Start with an enabled agent at scale=2
+    const enabledConfig = makeAgentConfig("agent-a", { scale: 2, schedule: "0 * * * *" });
+    const runner1 = makeMockRunner("agent-a-1");
+    const runner2 = makeMockRunner("agent-a-2");
+    // Mark runners as running so killAll() will call abort()
+    runner1.isRunning = true;
+    runner2.isRunning = true;
+    const pool = new RunnerPool([runner1, runner2]);
+
+    const ctx = makeContext({
+      agentConfigs: [enabledConfig],
+      runnerPools: { "agent-a": pool },
+    });
+
+    // Add a cron job for this agent (simulate existing schedule)
+    const mockCronJob: any = { stop: vi.fn() };
+    ctx.cronJobs.push(mockCronJob);
+
+    // Disable the agent (scale to 0)
+    const disabledConfig = makeAgentConfig("agent-a", { scale: 0, schedule: "0 * * * *" });
+    mockedDiscoverAgents.mockReturnValue(["agent-a"]);
+    mockedLoadAgentConfig.mockReturnValue(disabledConfig);
+
+    const handle = watchAgents(ctx);
+    await handle._handleAgentChange("agent-a");
+
+    // Pool should be killed and removed
+    expect(runner1.abort).toHaveBeenCalled();
+    expect(runner2.abort).toHaveBeenCalled();
+    expect(ctx.runnerPools["agent-a"]).toBeUndefined();
+
+    // Webhook bindings should be removed
+    expect(ctx.webhookRegistry!.removeBindingsForAgent).toHaveBeenCalledWith("agent-a");
+
+    // Cron job should be rebuilt (stopped)
+    expect(mockCronJob.stop).toHaveBeenCalled();
+
+    // Status should be updated
+    expect(ctx.statusTracker!.updateAgentScale).toHaveBeenCalledWith("agent-a", 0);
+    expect(ctx.statusTracker!.setAgentState).toHaveBeenCalledWith("agent-a", "idle");
+    expect(ctx.statusTracker!.setNextRunAt).toHaveBeenCalledWith("agent-a", null);
+    expect(ctx.statusTracker!.addLogLine).toHaveBeenCalledWith(
+      "agent-a",
+      "hot-reloaded (deactivated to scale=0)"
+    );
+    expect(ctx.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: "agent-a" }),
+      "hot reload: agent deactivated (scale=0)"
+    );
+  });
+
+  it("handles changed agent: scale N→0 without pool (gracefully ignores)", async () => {
+    // Start with config that claims scale=2 but pool is missing (edge case)
+    const enabledConfig = makeAgentConfig("agent-a", { scale: 2 });
+    const ctx = makeContext({
+      agentConfigs: [enabledConfig],
+      runnerPools: {}, // Pool missing
+    });
+
+    const disabledConfig = makeAgentConfig("agent-a", { scale: 0 });
+    mockedDiscoverAgents.mockReturnValue(["agent-a"]);
+    mockedLoadAgentConfig.mockReturnValue(disabledConfig);
+
+    const handle = watchAgents(ctx);
+    // Should not throw
+    await handle._handleAgentChange("agent-a");
+
+    // Pool should still be missing (none to kill)
+    expect(ctx.runnerPools["agent-a"]).toBeUndefined();
+
+    // Status should still be updated
+    expect(ctx.statusTracker!.updateAgentScale).toHaveBeenCalledWith("agent-a", 0);
+    expect(ctx.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: "agent-a" }),
+      "hot reload: agent deactivated (scale=0)"
+    );
+  });
 });


### PR DESCRIPTION
Closes #551

## Problem
When an agent config had scale=0 and was later changed to scale>0, webhooks and cron jobs were never created. This happened because `handleChangedAgent()` assumed a runner pool already existed.

## Solution
- Added handling for the 0→N transition: creates runner pool, cron jobs, and webhook bindings when an agent is re-enabled
- Added handling for the N→0 transition: properly tears down pool, cron jobs, and webhook bindings when an agent is disabled
- Added comprehensive tests for both transitions

## Testing
All tests pass (5010 tests in action-llama + 24 tests in skill)
- New tests verify 0→N and N→0 transitions with and without schedules/webhooks
- Tests confirm proper resource cleanup and status tracker updates