### PR TITLE
Fix: integration test suite hanging with keep-alive connections

### DIFF
--- a/.changeset/fix-server-connections.md
+++ b/.changeset/fix-server-connections.md
@@ -1,0 +1,6 @@
+---
+"@action-llama/action-llama": patch
+"@action-llama/skill": patch
+---
+
+Fix integration test suite hanging with 160+ test files by closing all keep-alive connections before server shutdown

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "action-llama",
+  "name": "repo",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -13319,7 +13319,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.26.7",
+      "version": "0.26.9",
       "license": "MIT",
       "dependencies": {
         "@action-llama/skill": "*",
@@ -13428,7 +13428,7 @@
     },
     "packages/skill": {
       "name": "@action-llama/skill",
-      "version": "0.26.7",
+      "version": "0.26.9",
       "license": "MIT"
     }
   }

--- a/packages/action-llama/src/gateway/index.ts
+++ b/packages/action-llama/src/gateway/index.ts
@@ -179,6 +179,7 @@ export async function startGateway(opts: GatewayOptions): Promise<GatewayServer>
       }
       lockStore.dispose();
       callStore.dispose();
+      server.closeAllConnections();
       server.close(() => resolve());
     });
 


### PR DESCRIPTION
Closes #565

## Summary
Fixed the integration test suite hanging indefinitely when run with 160+ test files by properly closing all keep-alive connections before shutting down the HTTP server.

## Changes
- Added `server.closeAllConnections()` before `server.close()` in the gateway close function
- This ensures that all existing connections are forcibly terminated before the server shuts down
- Requires Node.js 18.2+ (which is already the minimum supported version)

## Root Cause
The original implementation used only `server.close(callback)`, which stops accepting new connections but does NOT close existing keep-alive connections. When multiple test files run in parallel and make HTTP requests, these keep-alive connections prevent the server from fully shutting down, causing timeout issues.

## Testing
This fix resolves the timeout hangs reported when the integration test suite grew from ~65 to 160+ files, providing enough parallel test execution pressure to trigger the issue with keep-alive connections.