### PR TITLE
Fix: integration test suite hangs with 160+ files due to server.close() not closing keep-alive connections

### DIFF
--- a/.changeset/tall-stars-wait.md
+++ b/.changeset/tall-stars-wait.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Fix: Call server.closeAllConnections() before server.close() to force-close keep-alive connections, preventing integration test suite hangs with 160+ test files

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "action-llama",
+  "name": "repo",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -13319,7 +13319,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.26.7",
+      "version": "0.26.9",
       "license": "MIT",
       "dependencies": {
         "@action-llama/skill": "*",
@@ -13428,7 +13428,7 @@
     },
     "packages/skill": {
       "name": "@action-llama/skill",
-      "version": "0.26.7",
+      "version": "0.26.9",
       "license": "MIT"
     }
   }

--- a/packages/action-llama/src/gateway/index.ts
+++ b/packages/action-llama/src/gateway/index.ts
@@ -179,6 +179,7 @@ export async function startGateway(opts: GatewayOptions): Promise<GatewayServer>
       }
       lockStore.dispose();
       callStore.dispose();
+      server.closeAllConnections();
       server.close(() => resolve());
     });
 


### PR DESCRIPTION
Closes #566

## Problem
Integration test suite hangs when run with 160+ test files because `server.close()` in Node.js does NOT close existing keep-alive HTTP connections. The callback passed to `server.close()` never fires if connections remain open, causing vitest fork workers to timeout.

## Solution
Call `server.closeAllConnections()` (available in Node.js 18.2+) before `server.close()` to force-close all connections, ensuring the server closes properly.

## Changes
- Modified `packages/action-llama/src/gateway/index.ts` close() function to call `server.closeAllConnections()` before `server.close()`
- Added changeset for the fix