### PR TITLE
Fix: Document defensive error handlers in scheduler and execution paths

### DIFF
--- a/.changeset/document-defensive-handlers.md
+++ b/.changeset/document-defensive-handlers.md
@@ -1,0 +1,5 @@
+---
+"@action-llama/action-llama": patch
+---
+
+Document defensive error handlers in scheduler webhook dispatch and execution paths. The `.catch()` handlers are unlikely to trigger since `executeRun()` and `drainQueues()` wrap all errors internally, but they remain for defensive programming and safety if those functions are modified to propagate errors in the future. Closes #574

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "action-llama",
+  "name": "repo",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -13319,7 +13319,7 @@
     },
     "packages/action-llama": {
       "name": "@action-llama/action-llama",
-      "version": "0.26.7",
+      "version": "0.26.9",
       "license": "MIT",
       "dependencies": {
         "@action-llama/skill": "*",
@@ -13428,7 +13428,7 @@
     },
     "packages/skill": {
       "name": "@action-llama/skill",
-      "version": "0.26.7",
+      "version": "0.26.9",
       "license": "MIT"
     }
   }

--- a/packages/action-llama/src/execution/execution.ts
+++ b/packages/action-llama/src/execution/execution.ts
@@ -247,6 +247,8 @@ export function dispatchTriggers(
         }
         return drainQueues(ctx);
       })
+      // Defensive: executeRun() wraps all errors, and drainQueues() doesn't throw.
+      // This catch is unlikely to trigger, but remains for safety if those functions change.
       .catch((err) => {
         if (callEdgeId != null && ctx.statsStore) {
           try {
@@ -297,6 +299,8 @@ function fireQueuedItem(
     const prompt = makeWebhookPrompt(agentConfig, work.context, ctx);
     executeRun(runner, prompt, { type: 'webhook', source: work.context.source, receiptId: work.context.receiptId }, agentConfig.name, 0, ctx, instanceLifecycle)
       .then(() => drainQueues(ctx))
+      // Defensive: executeRun() wraps all errors, and drainQueues() doesn't throw.
+      // This catch is unlikely to trigger, but remains for safety if those functions change.
       .catch((err) => ctx.logger.error({ err, agent: agentConfig.name }, "queued webhook failed"));
 
   } else if (work.type === 'agent-trigger') {
@@ -318,6 +322,8 @@ function fireQueuedItem(
         }
         return drainQueues(ctx);
       })
+      // Defensive: executeRun() wraps all errors, and drainQueues() doesn't throw.
+      // This catch is unlikely to trigger, but remains for safety if those functions change.
       .catch((err) => {
         if (work.callId) ctx.callStore?.fail(work.callId, err?.message || "unknown error");
         ctx.logger.error({ err, agent: agentConfig.name }, "queued trigger failed");
@@ -327,11 +333,15 @@ function fireQueuedItem(
     ctx.logger.info({ agent: agentConfig.name, ageMs }, "draining queued scheduled run");
     // runWithReruns already calls drainQueues on completion and handles instance lifecycle
     runWithReruns(runner, agentConfig, 0, ctx, 'schedule')
+      // Defensive: runWithReruns() doesn't throw. This catch is unlikely to trigger,
+      // but remains for safety if the function is modified to propagate errors.
       .catch((err) => ctx.logger.error({ err, agent: agentConfig.name }, "queued scheduled run failed"));
 
   } else if (work.type === 'manual') {
     ctx.logger.info({ agent: agentConfig.name, ageMs }, "draining queued manual trigger");
     runWithReruns(runner, agentConfig, 0, ctx, 'manual', work.prompt)
+      // Defensive: runWithReruns() doesn't throw. This catch is unlikely to trigger,
+      // but remains for safety if the function is modified to propagate errors.
       .catch((err) => ctx.logger.error({ err, agent: agentConfig.name }, "queued manual trigger failed"));
   }
 }

--- a/packages/action-llama/src/scheduler/index.ts
+++ b/packages/action-llama/src/scheduler/index.ts
@@ -116,6 +116,9 @@ export async function startScheduler(projectPath: string, globalConfigOverride?:
             const prompt = makeWebhookPrompt(config, context, state.schedulerCtx);
             executeRun(result.runner, prompt, { type: 'webhook', source: context.source, receiptId: context.receiptId }, config.name, 0, state.schedulerCtx)
               .then(() => drainQueues(state.schedulerCtx!))
+              // Defensive: executeRun() wraps all runner errors in try/catch, so rejection is unlikely.
+              // However, we keep this catch for safety in case drainQueues() or internal handler code
+              // propagates errors in the future.
               .catch((err) => logger.error({ err, agent: config.name }, "webhook run failed"));
             return true;
           }


### PR DESCRIPTION
Closes #574

## Summary
Added documentation comments to all defensive `.catch()` error handlers in the scheduler and execution paths to clarify that they handle unlikely scenarios where the underlying functions propagate errors in the future.

## Changes
- Added comments to 6 defensive catch handlers explaining they are unlikely to trigger but remain for safety
- Handlers document that executeRun() and drainQueues() currently wrap all errors internally
- Comments guide future maintainers that if those functions are modified to propagate errors, the handlers will become active

## Context
The issue highlighted that a `.catch()` handler in the webhook dispatch code showed 0 coverage despite tests exercising the dispatch path. This is because executeRun() wraps all errors in its own try/catch and never rejects. Rather than remove these defensive handlers, I've documented them to preserve the error handling contract and make the code intent clear.